### PR TITLE
Application Service tweaks

### DIFF
--- a/event-schemas/core
+++ b/event-schemas/core
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "event": {
+      "type": "object",
+      "properties": {
+        "event_id": {
+          "type": "string"
+        },
+        "user_id": {
+          "type": "string"
+        },
+        "content": {
+          "type": "object"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["event_id", "user_id", "content", "type"]
+    },
+    "room_event": {
+        "type": "object",
+        "allOf":[{
+            "$ref": "#/definitions/event"
+        }],
+        "properties": {
+            "room_id": {
+                "type": "string"
+            }
+        },
+        "required": ["room_id"]
+    }
+  }
+}

--- a/event-schemas/m.room.message
+++ b/event-schemas/m.room.message
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "allOf": [{
+        "$ref": "core#/definitions/room_event"
+    }],
+    "properties": {
+        "content": {
+            "type": "object",
+            "properties": {
+                "msgtype": {
+                    "type": "string"
+                },
+                "body": {
+                    "type": "string"
+                }
+            },
+            "required": ["msgtype", "body"]
+        }
+    }
+}

--- a/specification/40_application_service_api.rst
+++ b/specification/40_application_service_api.rst
@@ -80,6 +80,7 @@ Notes:
  {
    url: "https://my.application.service.com/matrix/",
    as_token: "some_AS_token",
+   filter_id: "some filter id",
    namespaces: {
      users: [
        {

--- a/specification/40_application_service_api.rst
+++ b/specification/40_application_service_api.rst
@@ -419,7 +419,7 @@ user IDs in whatever way they desire.
 
 ::
 
-  GET /_matrix/appservice/v1/user?uri=$url_encoded_uri
+  GET /_matrix/appservice/v1/uris/user?uri=$url_encoded_uri
   
   Returns 200 OK:
   {
@@ -445,7 +445,7 @@ expose room aliases.
 
 ::
 
-  GET /_matrix/appservice/v1/alias?uri=$url_encoded_uri
+  GET /_matrix/appservice/v1/uris/alias?uri=$url_encoded_uri
   
   Returns 200 OK:
   {

--- a/specification/40_application_service_api.rst
+++ b/specification/40_application_service_api.rst
@@ -41,6 +41,7 @@ Inputs:
  - Namespace[users]
  - Namespace[room aliases]
  - URL base to receive inbound comms
+ - Filter ID to apply when receiving inbound comms (optional)
 Output:
  - The credentials the HS will use to query the AS with in return. (e.g. some 
    kind of string token)
@@ -66,6 +67,9 @@ Notes:
          "regex": "@irc\.freenode\.net/.*"
        }
      ]
+ - The filter ID in this request will be applied to push-based inbound
+   communications, in a similar way to how filter IDs are applied to the
+   client-server pull-based sync API.
 
 ::
 
@@ -386,7 +390,7 @@ but only if the application service has defined the namespace as ``exclusive``.
 
 ID conventions
 ~~~~~~~~~~~~~~
-.. NOTE::
+.. NOTE
   - Giving HSes the freedom to namespace still feels like the Right Thing here.
   - Exposing a public API provides the consistency which was the main complaint
     against namespacing.
@@ -408,18 +412,10 @@ types, including:
 - XMPP (xep-0032)
 - SIP URIs (RFC 3261)
 
-As a result, virtual user IDs SHOULD relate to their URI counterpart. This
-mapping from URI to user ID can be expressed in a number of ways:
-
-- Expose a C-S API on the HS which takes URIs and responds with user IDs.
-- Munge the URI with the user ID.
-
-Exposing an API would allow HSes to internally map user IDs however they like,
-at the cost of an extra round trip (of which the response can be cached).
-Munging the URI would allow clients to apply the mapping locally, but would force
-user X on service Y to always map to the same munged user ID. Considering the
-exposed API could just be applying this munging, there is more flexibility if
-an API is exposed. 
+As a result, virtual user IDs SHOULD relate to their URI counterpart. The
+mapping from URI to user ID is expressed as a C-S API on the HS which takes
+URIs and responds with user IDs. Home servers can internally map URIs to 
+user IDs in whatever way they desire.
 
 ::
 

--- a/specification/40_application_service_api.rst
+++ b/specification/40_application_service_api.rst
@@ -40,6 +40,7 @@ Inputs:
  - Credentials (e.g. some kind of string token)
  - Namespace[users]
  - Namespace[room aliases]
+ - Namespace[room IDs]
  - URL base to receive inbound comms
  - Filter ID to apply when receiving inbound comms (optional)
 Output:


### PR DESCRIPTION
Tweaks wording in the spec, and adds in a ``filter id`` for ``/register`` to avoid ASes from being flooded with a hosepipe of everything in their namespace.