### PR TITLE
Add version 2 of the server key distribution API

### DIFF
--- a/specification/30_server_server_api.rst
+++ b/specification/30_server_server_api.rst
@@ -81,6 +81,13 @@ directly or by querying an intermediate perspective server using a
 response with their own key. A server may query multiple perspective servers
 to ensure that they all report the same public keys.
 
+This approach is borrowed from the Perspectives Project
+(http://perspectives-project.org/), but modified to include the NACL keys and to
+use JSON instead of XML. It has the advantage of avoiding a single trust-root
+since each server is free to pick which perspective servers they trust and can
+corroborate the keys returned by a given perspective server by querying other
+servers.
+
 Publishing Keys
 _______________
 
@@ -116,6 +123,10 @@ Intermediate perspective servers should cache a response for half of its
 remaining life time to avoid serving a stale response. Servers should avoid
 querying for certificates more frequently than once an hour to avoid flooding
 a server with requests.
+
+If a server goes offline intermediate perspective servers should continue to
+return the last response they received from that server so that the signatures
+of old events sent by that server can still be checked.
 
 ==================== =================== ======================================
     Key                    Type                         Description

--- a/specification/30_server_server_api.rst
+++ b/specification/30_server_server_api.rst
@@ -109,7 +109,8 @@ it should request that ``key_id`` for the originating server to check whether
 the key has expired.
 
 The ``old_verify_keys`` can be used to sign events with an ``origin_server_ts``
-before the ``expired_ts``.
+before the ``expired_ts``. The ``expired_ts`` is a millisecond POSIX timestamp
+of when the originating server stopped using that key.
 
 Intermediate perspective servers should cache a response for half of its
 remaining life time to avoid serving a stale response. Servers should avoid

--- a/specification/30_server_server_api.rst
+++ b/specification/30_server_server_api.rst
@@ -73,6 +73,14 @@ Retrieving Server Keys
 Version 2
 +++++++++
 
+Each home server publishes its public keys under ``/_matrix/key/v2/server/``.
+Home servers query for keys by either getting ``/_matrix/key/v2/server/``
+directly or by querying an intermediate perspective server using a
+``/_matrix/key/v2/query`` API. Intermediate perspective servers query the
+``/_matrix/key/v2/server/`` API on behalf of another server and sign the
+response with their own key. A server may query multiple perspective servers
+to ensure that they all report the same public keys.
+
 Publishing Keys
 _______________
 
@@ -103,10 +111,10 @@ the key has expired.
 The ``old_verify_keys`` can be used to sign events with an ``origin_server_ts``
 before the ``expired_ts``.
 
-Intermediate servers should cache a response for half of its remaining life
-time to avoid serving a stale response. Servers should avoid querying for
-certificates more frequently than once an hour to avoid flooding a server
-with requests.
+Intermediate perspective servers should cache a response for half of its
+remaining life time to avoid serving a stale response. Servers should avoid
+querying for certificates more frequently than once an hour to avoid flooding
+a server with requests.
 
 ==================== =================== ======================================
     Key                    Type                         Description


### PR DESCRIPTION
Improves on v1 by allowing responses to be cached, using the fingerprint hash of the TLS certificate rather than the entire certificate and allowing expired keys to be listed in the response.

In addition v2 adds a query API so that a server can obtain keys by querying trusted perspective servers.