### PR TITLE
Add minimum_valid_until_ts to key/v2 API

### DIFF
--- a/specification/30_server_server_api.rst
+++ b/specification/30_server_server_api.rst
@@ -199,7 +199,7 @@ Requests:
 
 .. code::
 
-    GET /_matrix/key/v2/query/${server_name}/${key_id}/${minimum_valid_until_ts} HTTP/1.1
+    GET /_matrix/key/v2/query/${server_name}/${key_id}/?minimum_valid_until_ts={minimum_valid_until_ts} HTTP/1.1
 
     POST /_matrix/key/v2/query HTTP/1.1
     Content-Type: application/json

--- a/specification/30_server_server_api.rst
+++ b/specification/30_server_server_api.rst
@@ -199,7 +199,7 @@ Requests:
 
 .. code::
 
-    GET /_matrix/key/v2/query/${server_name}/${key_id}/?minimum_valid_until_ts={minimum_valid_until_ts} HTTP/1.1
+    GET /_matrix/key/v2/query/${server_name}/${key_id}/?minimum_valid_until_ts=${minimum_valid_until_ts} HTTP/1.1
 
     POST /_matrix/key/v2/query HTTP/1.1
     Content-Type: application/json


### PR DESCRIPTION
Otherwise an intermediate server has no way to promptly respond to request for a key for a server that is offline.