### PR TITLE
Bugfix to embedded sign_json() python code

### DIFF
--- a/specification/31_event_signing.rst
+++ b/specification/31_event_signing.rst
@@ -124,7 +124,7 @@ and additional signatures.
       signature_base64 = encode_base64(signed.signature)
 
       key_id = "%s:%s" % (signing_key.alg, signing_key.version)
-      signatures.setdefault(sigature_name, {})[key_id] = signature_base64
+      signatures.setdefault(signing_name, {})[key_id] = signature_base64
 
       json_object["signatures"] = signatures
       if unsigned is not None:


### PR DESCRIPTION
Name of local variable used inside the function probably ought to match parameter name given.