### PR TITLE
Set the current directory in gendoc.py to the scripts directory

### DIFF
--- a/scripts/gendoc.py
+++ b/scripts/gendoc.py
@@ -8,6 +8,8 @@ import shutil
 import subprocess
 import sys
 
+os.chdir(os.path.dirname(__file__))
+
 stylesheets = {
     "stylesheet_path": ["basic.css", "nature.css"]
 }


### PR DESCRIPTION
The script has a number of paths that are hard coded relative to the scripts directory.