### PR TITLE
Continuserv: Log port being listened on

### DIFF
--- a/scripts/continuserv/main.go
+++ b/scripts/continuserv/main.go
@@ -56,7 +56,7 @@ func main() {
 	go doPopulate(ch, dir)
 
 	go watchFS(ch, w)
-
+    fmt.Printf("Listening on port %d\n", *port)
 	http.HandleFunc("/", serve)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 

--- a/scripts/continuserv/main.go
+++ b/scripts/continuserv/main.go
@@ -56,7 +56,7 @@ func main() {
 	go doPopulate(ch, dir)
 
 	go watchFS(ch, w)
-    fmt.Printf("Listening on port %d\n", *port)
+	fmt.Printf("Listening on port %d\n", *port)
 	http.HandleFunc("/", serve)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 


### PR DESCRIPTION
Not having this was annoying me because I just ran `go run main.go` and then had no idea which port to be going to.