### PR TITLE
Receipts module

### DIFF
--- a/api/client-server/v2_alpha/receipts.yaml
+++ b/api/client-server/v2_alpha/receipts.yaml
@@ -1,0 +1,68 @@
+swagger: '2.0'
+info:
+  title: "Matrix Client-Server v2 Receipts API"
+  version: "1.0.0"
+host: localhost:8008
+schemes:
+  - https
+  - http
+basePath: /_matrix/client/v2_alpha
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  accessToken:
+    type: apiKey
+    description: The user_id or application service access_token
+    name: access_token
+    in: query
+paths:
+  "/rooms/{roomId}/receipt/{receiptType}/{eventId}":
+    post:
+      summary: Send a receipt for the given event ID.
+      description: |-
+        This API updates the marker for the given receipt type to the event ID
+        specified.
+      security:
+        - accessToken: []
+      parameters:
+        - in: path
+          type: string
+          name: roomId
+          description: The room in which to send the event.
+          required: true
+          x-example: "!wefuh21ffskfuh345:example.com"
+        - in: path
+          type: string
+          name: receiptType
+          description: The type of receipt to send.
+          required: true
+          x-example: "m.read"
+          enum: ["m.read"]
+        - in: path
+          type: string
+          name: eventId
+          description: The event ID to acknowledge up to.
+          required: true
+          x-example: "$1924376522eioj:example.com"
+        - in: body
+          description: |-
+            Extra receipt information to attach to ``content`` if any. The
+            server will automatically set the ``ts`` field.
+          schema:
+            type: object
+            example: |-
+              {}
+      responses:
+        200:
+          description: The receipt was sent.
+          examples:
+            application/json: |-
+              {}
+          schema:
+            type: object  # empty json object
+        429:
+          description: This request was rate-limited.
+          schema:
+            "$ref": "definitions/error.yaml"

--- a/event-schemas/examples/v1/m.receipt
+++ b/event-schemas/examples/v1/m.receipt
@@ -3,7 +3,7 @@
     "room_id": "!KpjVgQyZpzBwvMBsnT:matrix.org",
     "content": {
         "$1435641916114394fHBLK:matrix.org": {
-            "read": {
+            "m.read": {
                 "@rikj:jki.re": {
                     "ts": 1436451550453
                 }

--- a/event-schemas/schema/v1/m.receipt
+++ b/event-schemas/schema/v1/m.receipt
@@ -5,17 +5,20 @@
     "properties": {
         "content": {
             "type": "object",
-            "description": "The event ids which the receipts relate to.",
             "patternProperties": {
                 "^\\$": {
                     "type": "object",
-                    "description": "The types of the receipts.",
+                    "x-pattern": "$EVENT_ID",
+                    "description": "The mapping of event ID to receipt type. The event ID is the ID which the receipts relate to and *not* an ID for the receipt itself. The key in the object is an enum which must be ``read``.",
                     "additionalProperties": {
                         "type": "object",
-                        "description": "User ids of the receipts",
+                        "title": "Users",
                         "patternProperties": {
                             "^@": {
                                 "type": "object",
+                                "title": "Receipt",
+                                "description": "The mapping of user ID to receipt. The user ID is the entity who sent this receipt.",
+                                "x-pattern": "$USER_ID",
                                 "properties": {
                                     "ts": {
                                         "type": "number",

--- a/event-schemas/schema/v1/m.receipt
+++ b/event-schemas/schema/v1/m.receipt
@@ -9,25 +9,28 @@
                 "^\\$": {
                     "type": "object",
                     "x-pattern": "$EVENT_ID",
-                    "description": "The mapping of event ID to receipt type. The event ID is the ID which the receipts relate to and *not* an ID for the receipt itself. The key in the object is an enum which must be ``read``.",
-                    "additionalProperties": {
-                        "type": "object",
-                        "title": "Users",
-                        "patternProperties": {
-                            "^@": {
-                                "type": "object",
-                                "title": "Receipt",
-                                "description": "The mapping of user ID to receipt. The user ID is the entity who sent this receipt.",
-                                "x-pattern": "$USER_ID",
-                                "properties": {
-                                    "ts": {
-                                        "type": "number",
-                                        "description": "The timestamp the receipt was sent at"
+                    "title": "Receipts",
+                    "description": "The mapping of event ID to a collection of receipts for this event ID. The event ID is the ID of the event being acknowledged and *not* an ID for the receipt itself.",
+                    "properties": {
+                        "m.read": {
+                            "type": "object",
+                            "title": "Users",
+                            "description": "A collection of users who have sent ``m.read`` receipts for this event.",
+                            "patternProperties": {
+                                "^@": {
+                                    "type": "object",
+                                    "title": "Receipt",
+                                    "description": "The mapping of user ID to receipt. The user ID is the entity who sent this receipt.",
+                                    "x-pattern": "$USER_ID",
+                                    "properties": {
+                                        "ts": {
+                                            "type": "number",
+                                            "description": "The timestamp the receipt was sent at."
+                                        }
                                     }
                                 }
                             }
-                        },
-                        "additionalProperties": false
+                        }
                     }
                 }
             },

--- a/specification/modules/receipts.rst
+++ b/specification/modules/receipts.rst
@@ -6,8 +6,16 @@ have interacted with. For example, which events the user has read. For
 efficiency this is done as "up to" markers, i.e. marking a particular event
 as, say, ``read`` indicates the user has read all events *up to* that event.
 
-Client-Server API
-~~~~~~~~~~~~~~~~~
+Events
+------
+
+{{m_receipt_event}}
+
+Client behaviour
+----------------
+
+ - When clients should send receipts
+ - What clients should do when they receive these receipts
 
 Clients will receive receipts in the following format::
 
@@ -18,22 +26,6 @@ Clients will receive receipts in the following format::
             <event_id>: {
                 <receipt_type>: {
                     <user_id>: { "ts": <ts>, ... },
-                    ...
-                }
-            },
-            ...
-        }
-    }
-
-For example::
-
-    {
-        "type": "m.receipt",
-        "room_id": "!KpjVgQyZpzBwvMBsnT:matrix.org",
-        "content": {
-            "$1435641916114394fHBLK:matrix.org": {
-                "read": {
-                    "@erikj:jki.re": { "ts": 1436451550453 },
                     ...
                 }
             },
@@ -56,9 +48,8 @@ A client can update the markers for its user by issuing a request::
 Where the contents of the ``POST`` will be included in the content sent to
 other users. The server will automatically set the ``ts`` field.
 
-
-Server-Server API
-~~~~~~~~~~~~~~~~~
+Server behaviour
+----------------
 
 Receipts are sent across federation as EDUs with type ``m.receipt``. The
 format of the EDUs are::
@@ -74,4 +65,8 @@ format of the EDUs are::
     }
 
 These are always sent as deltas to previously sent receipts.
+
+Security considerations
+-----------------------
+
 

--- a/specification/modules/receipts.rst
+++ b/specification/modules/receipts.rst
@@ -1,55 +1,62 @@
 Receipts
---------
+========
 
-Receipts are used to publish which events in a room the user or their devices
-have interacted with. For example, which events the user has read. For
-efficiency this is done as "up to" markers, i.e. marking a particular event
-as, say, ``read`` indicates the user has read all events *up to* that event.
+This module adds in support for receipts. These receipts are a form of
+acknowledgement of an event. This module defines a single acknowledgement:
+``m.read`` which indicates that the user has read up to a given event.
+
+Sending a receipt for each event can result in sending large amounts of traffic
+to a homeserver. To prevent this from becoming a problem, receipts are implemented
+using "up to" markers. This marker indicates that the acknowledgement applies
+to all events "up to and including" the event specified. For example, marking
+an event as "read" would indicate that the user had read all events *up to* the
+referenced event.
 
 Events
 ------
+Each ``user_id``, ``receipt_type`` pair must be associated with only a
+single ``event_id``.
 
 {{m_receipt_event}}
 
 Client behaviour
 ----------------
 
- - When clients should send receipts
- - What clients should do when they receive these receipts
+In v1 ``/initialSync``, receipts are listed in a separate top level ``receipts``
+key. In v2 ``/sync``, receipts are contained in the ``ephemeral`` block for a
+room. New receipts that come down the event streams are deltas which update
+existing mappings. Clients should replace older receipt acknowledgements based
+on ``user_id`` and ``receipt_type`` pairs. For example::
 
-Clients will receive receipts in the following format::
+  Client receives m.receipt:
+    user = @alice:example.com
+    receipt_type = m.read
+    event_id = $aaa:example.com
 
-     {
-        "type": "m.receipt",
-        "room_id": <room_id>,
-        "content": {
-            <event_id>: {
-                <receipt_type>: {
-                    <user_id>: { "ts": <ts>, ... },
-                    ...
-                }
-            },
-            ...
-        }
-    }
+  Client receives another m.receipt:
+    user = @alice:example.com
+    receipt_type = m.read
+    event_id = $bbb:example.com
 
-For efficiency, receipts are batched into one event per room. In the initialSync
-and v2 sync APIs the receipts are listed in a separate top level ``receipts``
-key. Each ``user_id``, ``receipt_type`` pair must be associated with only a
-single ``event_id``. New receipts that come down the event streams are deltas.
-Deltas update existing mappings, clobbering based on ``user_id``,
-``receipt_type`` pairs.
+  The client should replace the older acknowledgement for $aaa:example.com with
+  this one for $bbb:example.com
 
+Clients should send read receipts when there is some certainty that the event in
+question has been **displayed** to the user. Simply receiving an event does not
+provide enough certainty that the user has seen the event. The user SHOULD need
+to *take some action* such as viewing the room that the event was sent to or
+dismissing a notification in order for the event to count as "read".
 
-A client can update the markers for its user by issuing a request::
+A client can update the markers for its user by interacting with the following
+HTTP APIs.
 
-    POST /_matrix/client/v2_alpha/rooms/<room_id>/receipt/read/<event_id>
-
-Where the contents of the ``POST`` will be included in the content sent to
-other users. The server will automatically set the ``ts`` field.
+{{v2_receipts_http_api}}
 
 Server behaviour
 ----------------
+
+For efficiency, receipts SHOULD be batched into one event per room before
+delivering them to clients.
 
 Receipts are sent across federation as EDUs with type ``m.receipt``. The
 format of the EDUs are::
@@ -64,9 +71,12 @@ format of the EDUs are::
         ...
     }
 
-These are always sent as deltas to previously sent receipts.
+These are always sent as deltas to previously sent receipts. Currently only a
+single ``<receipt_type>`` should be used: ``m.read``.
 
 Security considerations
 -----------------------
 
+As receipts are sent outside the context of the event graph, there are no
+integrity checks performed on the contents of ``m.receipt`` events.
 

--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -344,7 +344,7 @@ class MatrixUnits(Units):
         for path in paths:
             is_v2 = (path == V2_CLIENT_API)
             if not os.path.exists(V2_CLIENT_API):
-                self.log("Skipping v2 apis: %s does not exist.", V2_CLIENT_API)
+                self.log("Skipping v2 apis: %s does not exist." % V2_CLIENT_API)
                 continue
             for filename in os.listdir(path):
                 if not filename.endswith(".yaml"):

--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -19,6 +19,7 @@ import yaml
 V1_CLIENT_API = "../api/client-server/v1"
 V1_EVENT_EXAMPLES = "../event-schemas/examples/v1"
 V1_EVENT_SCHEMA = "../event-schemas/schema/v1"
+V2_CLIENT_API = "../api/client-server/v2_alpha"
 CORE_EVENT_SCHEMA = "../event-schemas/schema/v1/core-event-schema"
 CHANGELOG = "../CHANGELOG.rst"
 TARGETS = "../specification/targets.yaml"
@@ -336,18 +337,27 @@ class MatrixUnits(Units):
         }
 
     def load_swagger_apis(self):
-        path = V1_CLIENT_API
+        paths = [
+            V1_CLIENT_API, V2_CLIENT_API
+        ]
         apis = {}
-        for filename in os.listdir(path):
-            if not filename.endswith(".yaml"):
+        for path in paths:
+            is_v2 = (path == V2_CLIENT_API)
+            if not os.path.exists(V2_CLIENT_API):
+                self.log("Skipping v2 apis: %s does not exist.", V2_CLIENT_API)
                 continue
-            self.log("Reading swagger API: %s" % filename)
-            with open(os.path.join(path, filename), "r") as f:
-                # strip .yaml
-                group_name = filename[:-5]
-                api = yaml.load(f.read())
-                api["__meta"] = self._load_swagger_meta(api, group_name)
-                apis[group_name] = api
+            for filename in os.listdir(path):
+                if not filename.endswith(".yaml"):
+                    continue
+                self.log("Reading swagger API: %s" % filename)
+                with open(os.path.join(path, filename), "r") as f:
+                    # strip .yaml
+                    group_name = filename[:-5]
+                    if is_v2:
+                        group_name = "v2_" + group_name
+                    api = yaml.load(f.read())
+                    api["__meta"] = self._load_swagger_meta(api, group_name)
+                    apis[group_name] = api
         return apis
 
     def load_common_event_fields(self):


### PR DESCRIPTION
This PR makes the receipt module conform to the sections in the module template and adjusts the wording/descriptions of some JSON Schema keys. It also adds Swagger for the new receipts HTTP endpoint.

Finally, it adds templating support for `x-pattern` which is a "pretty-printed" pattern which is used when generating tables over the raw pattern regex if supplied.