### PR TITLE
Add flag to initial sync to say we want rooms that the user has left

### DIFF
--- a/api/client-server/v1/sync.yaml
+++ b/api/client-server/v1/sync.yaml
@@ -39,6 +39,16 @@ paths:
           description: The maximum time in milliseconds to wait for an event.
           required: false
           x-example: "35000"
+        - in: query
+          type: string
+          name: archived
+          description: |-
+            Whether to include rooms that the user has left. If absent then
+            only rooms that the user has been invited to or has joined are
+            included. If set to "1" then rooms that the user has left are
+            included as well.
+          required: false
+          x-example: "1"
       responses:
         200:
           description: "The events received, which may be none."

--- a/api/client-server/v1/sync.yaml
+++ b/api/client-server/v1/sync.yaml
@@ -45,10 +45,10 @@ paths:
           description: |-
             Whether to include rooms that the user has left. If absent then
             only rooms that the user has been invited to or has joined are
-            included. If set to "1" then rooms that the user has left are
+            included. If set to "true" then rooms that the user has left are
             included as well.
           required: false
-          x-example: "1"
+          x-example: "true"
       responses:
         200:
           description: "The events received, which may be none."


### PR DESCRIPTION
Some of the existing clients don't seem to cope well with getting rooms down that they have left down their initial sync. So we should probably only include that information if the client explicitly asks for it.