### PR TITLE
Put swagger for the directory API in the spec.

### DIFF
--- a/api/client-server/v1/directory.yaml
+++ b/api/client-server/v1/directory.yaml
@@ -29,12 +29,17 @@ paths:
           name: roomAlias
           description: The room alias to set.
           required: true
+          x-example: "#coffee:example.com"
         - in: body
           name: roomInfo
           description: Information about this room alias.
           required: true
           schema:
             type: object
+            example: |-
+              {
+                "room_id": "!AfafhafwefwiugefSD:example.com"
+              }
             properties:
               room_id:
                 type: string
@@ -42,6 +47,9 @@ paths:
       responses:
         200:
           description: The mapping was created.
+          examples:
+            application/json: |-
+              {}
           schema:
             type: object  # empty json object
     get:
@@ -52,9 +60,16 @@ paths:
           name: roomAlias
           description: The room alias.
           required: true
+          x-example: "#coffee:example.com"
       responses:
         200:
           description: The room ID and other information for this alias.
+          examples:
+            application/json: |-
+              {
+                "room_id": "!AfafhafwefwiugefSD:example.com",
+                "servers": ["example.com", "testing.com"]
+              }
           schema:
             type: object
             properties:
@@ -79,9 +94,13 @@ paths:
           name: roomAlias
           description: The room alias to remove.
           required: true
+          x-example: "#coffee:example.com"
       responses:
         200:
           description: The mapping was removed.
+          examples:
+            application/json: |-
+              {}
           schema:
             type: object  # empty json object
 

--- a/specification/1-client_server_api.rst
+++ b/specification/1-client_server_api.rst
@@ -875,6 +875,7 @@ homeservers to send update requests to other servers. Home servers can respond t
 resolve requests for aliases on other domains than their own by using the
 federation API to ask other domain name home servers.
 
+NB: Aliases contain a hash ('#') which MUST be URL-encoded where appropriate.
 The directory API consists of:
 
 {{directory_http_api}}

--- a/specification/1-client_server_api.rst
+++ b/specification/1-client_server_api.rst
@@ -854,46 +854,30 @@ See `Room Events`_ for more information on these events.
 
 Room aliases
 ~~~~~~~~~~~~
-.. NOTE::
-  This section is a work in progress.
 
-Room aliases can be created by sending a ``PUT /directory/room/<room alias>``::
-
-  {
-    "room_id": <room id>
-  }
-
-They can be deleted by sending a ``DELETE /directory/room/<room alias>`` with
-no content. Only some privileged users may be able to delete room aliases, e.g.
-server admins, the creator of the room alias, etc. This specification does not
-outline the privilege level required for deleting room aliases.
-
-As room aliases are scoped to a particular home server domain name, it is
-likely that a home server will reject attempts to maintain aliases on other
-domain names. This specification does not provide a way for home servers to
-send update requests to other servers.
-
-Rooms store a *partial* list of room aliases via the ``m.room.aliases`` state
+Room aliases are pointers to room IDs. They exist outside the context of a room.
+Rooms can store a *partial* list of room aliases via the ``m.room.aliases`` state
 event. This alias list is partial because it cannot guarantee that the alias
 list is in any way accurate or up-to-date, as room aliases can point to
 different room IDs over time. Crucially, the aliases in this event are
 **purely informational** and SHOULD NOT be treated as accurate. They SHOULD
 be checked before they are used or shared with another user. If a room
 appears to have a room alias of ``#alias:example.com``, this SHOULD be checked
-to make sure that the room's ID matches the ``room_id`` returned from the
+to make sure that the room's ID matches the ``room_id`` returned from the directory
 request.
 
-Room aliases can be checked in the same way they are resolved; by sending a
-``GET /directory/room/<room alias>``::
 
-  {
-    "room_id": <room id>,
-    "servers": [ <domain>, <domain2>, <domain3> ]
-  }
+As room aliases are scoped to a particular homeserver domain it is likely that a
+homeserver will reject attempts to maintain aliases on other domain names. This
+means that the aliases used in the following APIs should belong to the same
+domain as the homeserver. This specification does not provide a way for
+homeservers to send update requests to other servers. Home servers can respond to
+resolve requests for aliases on other domains than their own by using the
+federation API to ask other domain name home servers.
 
-Home servers can respond to resolve requests for aliases on other domains than
-their own by using the federation API to ask other domain name home servers.
+The directory API consists of:
 
+{{directory_http_api}}
 
 Permissions
 ~~~~~~~~~~~


### PR DESCRIPTION
This resolves SPEC-168 "Spell out that # should be escaped as %23 in URIs that take room aliases"