### PR TITLE
Add in size limits as per SPEC-222

### DIFF
--- a/event-schemas/schema/v1/core-event-schema/state_event.json
+++ b/event-schemas/schema/v1/core-event-schema/state_event.json
@@ -8,7 +8,7 @@
   "properties": {
     "state_key": {
       "type": "string",
-      "description": "A unique key which defines the overwriting semantics for this piece of room state. This value is often a zero-length string. The presence of this key makes this event a State Event."
+      "description": "A unique key which defines the overwriting semantics for this piece of room state. This value is often a zero-length string. The presence of this key makes this event a State Event. The key MUST NOT start with '_'."
     },
     "prev_content": {
       "type": "object",

--- a/event-schemas/schema/v1/m.room.name
+++ b/event-schemas/schema/v1/m.room.name
@@ -11,7 +11,7 @@
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "The name of the room."
+                    "description": "The name of the room. This MUST NOT exceed 255 bytes."
                 }
             },
             "required": ["name"]

--- a/specification/0-events.rst
+++ b/specification/0-events.rst
@@ -12,6 +12,23 @@ server-server and application-service APIs, and are described below.
 {{common_state_event_fields}}
 
 
+Size limits
+-----------
+
+The total size of any event MUST NOT exceed 65 KB. There are additional
+restrictions on sizes per key:
+
+ - ``user_id`` MUST NOT exceed 255 bytes (including domain).
+ - ``room_id`` MUST NOT exceed 255 bytes.
+ - ``state_key`` MUST NOT exceed 255 bytes.
+ - ``type`` MUST NOT exceed 255 bytes.
+ - ``event_id`` MUST NOT exceed 255 bytes.
+ - ``user_id`` MUST NOT exceed 255 bytes.
+
+Some event types have additional sizes restrictions which are specified in
+the description of the event. Additional keys have no limit other than that
+implied by the total 65 KB limit on events.
+
 Room Events
 -----------
 .. NOTE::

--- a/specification/0-events.rst
+++ b/specification/0-events.rst
@@ -23,9 +23,8 @@ restrictions on sizes per key:
  - ``state_key`` MUST NOT exceed 255 bytes.
  - ``type`` MUST NOT exceed 255 bytes.
  - ``event_id`` MUST NOT exceed 255 bytes.
- - ``user_id`` MUST NOT exceed 255 bytes.
 
-Some event types have additional sizes restrictions which are specified in
+Some event types have additional size restrictions which are specified in
 the description of the event. Additional keys have no limit other than that
 implied by the total 65 KB limit on events.
 

--- a/specification/0-intro.rst
+++ b/specification/0-intro.rst
@@ -296,7 +296,7 @@ be obtained by visiting the domain specified. They are case-insensitive. Note
 that the mapping from a room alias to a room ID is not fixed, and may change
 over time to point to a different room ID. For this reason, Clients SHOULD
 resolve the room alias to a room ID once and then use that ID on subsequent
-requests.
+requests. Room aliases MUST NOT exceed 255 bytes.
 
 When resolving a room alias the server will also respond with a list of servers
 that are in the room that can be used to join via.

--- a/specification/0-intro.rst
+++ b/specification/0-intro.rst
@@ -296,7 +296,7 @@ be obtained by visiting the domain specified. They are case-insensitive. Note
 that the mapping from a room alias to a room ID is not fixed, and may change
 over time to point to a different room ID. For this reason, Clients SHOULD
 resolve the room alias to a room ID once and then use that ID on subsequent
-requests. Room aliases MUST NOT exceed 255 bytes.
+requests. Room aliases MUST NOT exceed 255 bytes (including the domain).
 
 When resolving a room alias the server will also respond with a list of servers
 that are in the room that can be used to join via.


### PR DESCRIPTION
The bug in question just says things like (255) which I assume are bytes and not \*gulp\* characters :)