### PR TITLE
Update 3pid invite section to reflect signed property

### DIFF
--- a/event-schemas/examples/v1/m.room.member
+++ b/event-schemas/examples/v1/m.room.member
@@ -8,7 +8,15 @@
         "token": "pc98",
         "public_key": "abc123",
         "key_validity_url": "https://magic.forest/verifykey",
-        "signature": "q1w2e3",
+        "signed": {
+          "mxid": "@alice:localhost",
+          "token": "pc98",
+          "signatures": {
+            "magic.forest": {
+              "ed25519:0": "poi098"
+            }
+          }
+        },
         "sender": "@zun:zun.soft"
     }
   },

--- a/event-schemas/schema/v1/m.room.member
+++ b/event-schemas/schema/v1/m.room.member
@@ -40,7 +40,7 @@
                         },
                         "signed": {
                             "type": "object",
-                            "title": "signed_third_party_invite",
+                            "title": "signed",
                             "properties": {
                                 "mxid": {
                                     "type": "string",
@@ -48,11 +48,12 @@
                                 },
                                 "token": {
                                     "type": "string",
-                                    "description": "The token property of the containing third_party_invite object.",
+                                    "description": "The token property of the containing third_party_invite object."
                                 },
                                 "signatures": {
                                     "type": "object",
-                                    "description": "A single signature from the verifying server, in the format specified by the Signing Events section."
+                                    "description": "A single signature from the verifying server, in the format specified by the Signing Events section.",
+                                    "title": "Signatures"
                                 }
                             },
                             "required": ["mxid", "signatures", "token"]

--- a/event-schemas/schema/v1/m.room.member
+++ b/event-schemas/schema/v1/m.room.member
@@ -54,14 +54,15 @@
                                     "type": "object",
                                     "description": "A single signature from the verifying server, in the format specified by the Signing Events section."
                                 }
-                            }
+                            },
+                            "required": ["mxid", "signatures", "token"]
                         },
                         "sender": {
                             "type": "string",
                             "description": "The matrix user ID of the user who send the invite which is being used."
                         }
                     },
-                    "required": ["token", "key_validity_url", "public_key", "signature", "sender"]
+                    "required": ["token", "key_validity_url", "public_key", "sender", "signed"]
                 }
             },
             "required": ["membership"]

--- a/event-schemas/schema/v1/m.room.member
+++ b/event-schemas/schema/v1/m.room.member
@@ -38,9 +38,23 @@
                             "type": "string",
                             "description": "A base64-encoded ed25519 key with which token must be signed."
                         },
-                        "signature": {
-                            "type": "string",
-                            "description": "A base64-encoded signature of token with public_key."
+                        "signed": {
+                            "type": "object",
+                            "title": "signed_third_party_invite",
+                            "properties": {
+                                "mxid": {
+                                    "type": "string",
+                                    "description": "The invited matrix user ID. Must be equal to the user_id property of the event."
+                                },
+                                "token": {
+                                    "type": "string",
+                                    "description": "The token property of the containing third_party_invite object.",
+                                },
+                                "signatures": {
+                                    "type": "object",
+                                    "description": "A single signature from the verifying server, in the format specified by the Signing Events section."
+                                }
+                            }
                         },
                         "sender": {
                             "type": "string",

--- a/specification/modules/third_party_invites.rst
+++ b/specification/modules/third_party_invites.rst
@@ -36,8 +36,8 @@ A client asks a server to invite a user by their third party identifier.
 Server behaviour
 ----------------
 
-All homeservers MUST verify the signature in the ``signed`` property of the
-``third_party_invite`` property in the ``content`` the event.
+All homeservers MUST verify the signature in the event's
+``content.third_party_invite.signed`` object.
 
 If a client of the current homeserver is joining by an
 ``m.room.third_party_invite``, that homesever MUST validate that the public
@@ -94,9 +94,8 @@ For example:
     When the third party user validates their identity, they are told about the
     invite, and ask their homeserver, H3, to join the room.
 
-    H3 validates that signature in the ``signed`` property of the
-    ``third_party_invite`` property of the ``content`` property of the  event,
-    and may check ``key_validity_url``.
+    H3 validates the signature in the event's
+    ``content.third_party_invite.signed`` object.
 
     H3 then asks H1 to join it to the room. H1 *must* validate the ``signed``
     property *and* check ``key_validity_url``.

--- a/specification/modules/third_party_invites.rst
+++ b/specification/modules/third_party_invites.rst
@@ -36,7 +36,8 @@ A client asks a server to invite a user by their third party identifier.
 Server behaviour
 ----------------
 
-All homeservers MUST verify that sig(``token``, ``public_key``) = ``signature``.
+All homeservers MUST verify the signature in the ``signed`` property of the
+``third_party_invite`` property in the ``content`` the event.
 
 If a client of the current homeserver is joining by an
 ``m.room.third_party_invite``, that homesever MUST validate that the public
@@ -93,11 +94,12 @@ For example:
     When the third party user validates their identity, they are told about the
     invite, and ask their homeserver, H3, to join the room.
 
-    H3 validates that sign(``token``, ``public_key``) = ``signature``, and may check
-    ``key_validity_url``.
+    H3 validates that signature in the ``signed`` property of the
+    ``third_party_invite`` property of the ``content`` property of the  event,
+    and may check ``key_validity_url``.
 
-    H3 then asks H1 to join it to the room. H1 *must* validate that
-    sign(``token``, ``public_key``) = ``signature`` *and* check ``key_validity_url``.
+    H3 then asks H1 to join it to the room. H1 *must* validate the ``signed``
+    property *and* check ``key_validity_url``.
 
     Having validated these things, H1 writes the join event to the room, and H3
     begins participating in the room. H2 *must* accept this event.


### PR DESCRIPTION
This makes it more consistent with other places where we do signature verification; it means that we are duplicating some data within the event (small storage cost, and an additional consistency check required) with the benefits that:

1) The identity server can just produce signed json like it already knows how to
2) The homeserver can just verify signed json like it already knows how to
3) It is incredibly explicit about what has been signed and needs to be verified (originally I was playing word games with "Construct an object which consists of these keys which you've pulled from the event in these places" kind of descriptions)
4) If the identity server wants to provide additional signed information, it may do so, and the HS will verify the signature but can safely ignore the extra content.