### PR TITLE
Capture cryptographic test vectors for JSON or event signing from source

### DIFF
--- a/specification/appendices.rst
+++ b/specification/appendices.rst
@@ -133,7 +133,7 @@ Cryptographic Test Vectors
 --------------------------
 
 To assist in the development of compatible implementations, the following test
-values may be useful for verifying the cryptograph event signing code.
+values may be useful for verifying the cryptographic event signing code.
 
 Signing Key
 ~~~~~~~~~~~

--- a/specification/appendices.rst
+++ b/specification/appendices.rst
@@ -128,3 +128,160 @@ Threat: Disclosure to Servers Within Chatroom
 An attacker could take control of a server within a chatroom to expose message
 contents or metadata for messages in that room.
 
+
+Cryptographic Test Vectors
+--------------------------
+
+To assist in the development of compatible implementations, the following test
+values may be useful for verifying the cryptograph event signing code.
+
+Signing Key
+~~~~~~~~~~~
+
+The following test vectors all use the 32-byte value given by the following
+Base64-encoded string as the seed for generating the ``ed25519`` signing key:
+
+.. code::
+
+    SIGNING_KEY_SEED = decode_base64(
+        "YJDBA9Xnr2sVqXD9Vj7XVUnmFZcZrlw8Md7kMW+3XA1"
+    )
+
+In each case, the server name and key ID are as follows:
+
+.. code::
+
+    SERVER_NAME = "domain"
+
+    KEY_ID = "ed25519:1"
+
+JSON Signing
+~~~~~~~~~~~~
+
+Given an empty JSON object:
+
+.. code:: json
+
+    {}
+
+The JSON signing algorithm should emit the following signed data:
+
+.. code:: json
+
+    {
+        "signatures": {
+            "domain": {
+                "ed25519:1": "K8280/U9SSy9IVtjBuVeLr+HpOB4BQFWbg+UZaADMtTdGYI7Geitb76LTrr5QV/7Xg4ahLwYGYZzuHGZKM5ZAQ"
+            }
+        }
+    }
+
+Given the following JSON object with data values in it:
+
+.. code:: json
+
+    {
+        "one": 1,
+        "two": "Two"
+    }
+
+The JSON signing algorithm should emit the following signed JSON:
+
+.. code:: json
+
+    {
+        "one": 1,
+        "signatures": {
+            "domain": {
+                "ed25519:1": "KqmLSbO39/Bzb0QIYE82zqLwsA+PDzYIpIRA2sRQ4sL53+sN6/fpNSoqE7BP7vBZhG6kYdD13EIMJpvhJI+6Bw"
+            }
+        },
+        "two": "Two"
+    }
+
+Event Signing
+~~~~~~~~~~~~~
+
+Given the following minimally-sized event:
+
+.. code:: json
+
+    {
+        "event_id": "$0:domain",
+        "origin": "domain",
+        "origin_server_ts": 1000000,
+        "signatures": {},
+        "type": "X",
+        "unsigned": {
+            "age_ts": 1000000
+        }
+    }
+
+The event signing algorithm should emit the following signed event:
+
+.. code:: json
+
+    {
+        "event_id": "$0:domain",
+        "hashes": {
+            "sha256": "6tJjLpXtggfke8UxFhAKg82QVkJzvKOVOOSjUDK4ZSI"
+        },
+        "origin": "domain",
+        "origin_server_ts": 1000000,
+        "signatures": {
+            "domain": {
+                "ed25519:1": "2Wptgo4CwmLo/Y8B8qinxApKaCkBG2fjTWB7AbP5Uy+aIbygsSdLOFzvdDjww8zUVKCmI02eP9xtyJxc/cLiBA"
+            }
+        },
+        "type": "X",
+        "unsigned": {
+            "age_ts": 1000000
+        }
+    }
+
+Given the following event containing redactable content:
+
+.. code:: json
+
+    {
+        "content": {
+            "body": "Here is the message content",
+        },
+        "event_id": "$0:domain",
+        "origin": "domain",
+        "origin_server_ts": 1000000,
+        "type": "m.room.message",
+        "room_id": "!r:domain",
+        "sender": "@u:domain",
+        "signatures": {},
+        "unsigned": {
+            "age_ts": 1000000
+        }
+    }
+
+The event signing algorithm should emit the following signed event:
+
+.. code:: json
+
+    {
+        "content": {
+            "body": "Here is the message content",
+        },
+        "event_id": "$0:domain",
+        "hashes": {
+            "sha256": "onLKD1bGljeBWQhWZ1kaP9SorVmRQNdN5aM2JYU2n/g"
+        },
+        "origin": "domain",
+        "origin_server_ts": 1000000,
+        "type": "m.room.message",
+        "room_id": "!r:domain",
+        "sender": "@u:domain",
+        "signatures": {
+            "domain": {
+                "ed25519:1": "Wm+VzmOUOz08Ds+0NTWb1d4CZrVsJSikkeRxh6aCcUwu6pNC78FunoD7KNWzqFn241eYHYMGCA5McEiVPdhzBA"
+            }
+        },
+        "unsigned": {
+            "age_ts": 1000000
+        }
+    }


### PR DESCRIPTION
These values all obtained from various unit tests; namely:

    https://github.com/matrix-org/python-signedjson/blob/master/tests/test_known_key.py
    https://github.com/matrix-org/synapse/blob/develop/tests/crypto/test_event_signing.py

When this is merged into the spec, I'll add comments to the unit test files to point them at the spec, in case of later edits. It would be useful to keep them all in sync.