### PR TITLE
Update the spec to talk about v2 sync

### DIFF
--- a/api/client-server/v2_alpha/sync.yaml
+++ b/api/client-server/v2_alpha/sync.yaml
@@ -135,7 +135,7 @@ paths:
                           type: object
                           description: |-
                             The state of a room that the user has been invited
-                            to. These state events may only have the `sender``,
+                            to. These state events may only have the ``sender``,
                             ``type``, ``state_key`` and ``content`` keys
                             present. These events do not replace any state that
                             the client already has for the room, for example if

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -625,7 +625,7 @@ Now, to receive future events in real-time on the event stream, you GET
 $V2PREFIX/sync with a ``since`` parameter of 'a-b-c': in other words passing in
 the ``next_batch`` token returned by the initial sync. The request blocks until
 new events are available or until your specified timeout elapses, and then
-returns a new paginatable chunk of events alongside new start and end
+returns a new list of events alongside new ``prev_batch`` and ``next_batch``
 parameters::
 
   [E0]->[E1]->[E2]->[E3]->[E4]->[E5]->[E6]->[E7]->[E8]->[E9]->[E10]


### PR DESCRIPTION
Some updates to the 'events' section of the spec to talk about the v2 spec API
instead of the old initialSync/events stuff.

---

Should we get rid of the initialSync and events api docs? is there a way to link to an old version?