### PR TITLE
Cache spec output

### DIFF
--- a/scripts/speculator/README
+++ b/scripts/speculator/README
@@ -6,9 +6,13 @@ It serves the following HTTP endpoints:
  - /diff/rst/123 which gives a diff of the spec's rst at pull request 123.
  - /diff/html/123 which gives a diff of the spec's HTML at pull request 123.
 
-To run it, you must install the `go` tool, and run:
+The build or run, you need a working `go` installation.
+Then fetch dependencies:
+ ` go get github.com/hashicorp/golang-lru`
+
+To run it, then run:
  `go run main.go`
 
 To build the binary (which is necessary for deployment to the matrix.org
-servers), you must again install `go`, and then run:
+servers), you must again install `go` and dependencies, and then run:
  `go build`

--- a/scripts/speculator/main.go
+++ b/scripts/speculator/main.go
@@ -401,7 +401,7 @@ func serveText(s string) func(http.ResponseWriter, *http.Request) {
 }
 
 func initCache() error {
-	c, err := lru.New(50)
+	c, err := lru.New(50) // Evict after 50 entries (i.e. 50 sha1s)
 	specCache = c
 	return err
 }


### PR DESCRIPTION
Does not cache inability to generate spec. Does not cache diffs or
anything fancy. Just the raw spec generation.