### PR TITLE
Enable syntax highlighting for example http requests

### DIFF
--- a/scripts/css/codehighlight.css
+++ b/scripts/css/codehighlight.css
@@ -1,6 +1,16 @@
 pre.code .comment, code .comment { color: green }
 pre.code .keyword, code .keyword { color: darkred; font-weight: bold }
 pre.code .name.builtin, code .name.builtin { color: darkred; font-weight: bold }
-pre.code .literal.number, code .literal.number { color: blue }
 pre.code .name.tag, code .name.tag { color: darkgreen }
-pre.code .literal.string, code .literal.string { color: darkblue }
+pre.code .literal, code .literal { color: darkblue }
+pre.code .literal.number, code .literal.number { color: blue }
+
+
+/* HTTP Methods have class "name function" */
+pre.code.http .name.function,  code.http .name.function { color: black; font-weight: bold }
+/* HTTP Paths have class "name namespace" */
+pre.code.http .name.namespace, code.http .name.namespace { color: darkgreen }
+/* HTTP "HTTP" strings have class "keyword reserved" */
+pre.code.http .keyword.reserved, code.http .keyword.reserved { color: black; font-weight: bold }
+/* HTTP Header names have class "name attribute" */
+pre.code.http .name.attribute, code.http .name.attribute { color: black; font-weight: bold }

--- a/templating/matrix_templates/templates/http-api.tmpl
+++ b/templating/matrix_templates/templates/http-api.tmpl
@@ -47,7 +47,9 @@ Response format:
 {% endfor %}
 {% endif -%}
 
-Example request::
+Example request:
+
+.. code:: http
 
   {{endpoint.example.req | indent_block(2)}}
 

--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -336,9 +336,15 @@ class MatrixUnits(Units):
                         elif param["in"] == "query":
                             qps[param["name"]] = param["x-example"]
                     query_string = "" if len(qps) == 0 else "?"+urllib.urlencode(qps)
-                    endpoint["example"]["req"] = "%s %s%s\n%s" % (
-                        method.upper(), path_template, query_string, body
-                    )
+                    if body:
+                        endpoint["example"]["req"] = "%s %s%s HTTP/1.1\nContent-Type: application/json\n\n%s" % (
+                            method.upper(), path_template, query_string, body
+                        )
+                    else:
+                        endpoint["example"]["req"] = "%s %s%s HTTP/1.1\n\n" % (
+                            method.upper(), path_template, query_string
+                        )
+
                 else:
                     self.log(
                         "The following parameters are missing examples :( \n %s" %


### PR DESCRIPTION
Adds some CSS to highlight the HTTP method, path and version.
Adds a Content-Type header so that the syntax highlighter knows that the content is JSON.
