### PR TITLE
speculator: Send Content-Type: text/html header

### DIFF
--- a/scripts/speculator/main.go
+++ b/scripts/speculator/main.go
@@ -388,7 +388,7 @@ func main() {
 	http.HandleFunc("/diff/rst/", forceHTML(s.serveRSTDiff))
 	http.HandleFunc("/diff/html/", forceHTML(s.serveHTMLDiff))
 	http.HandleFunc("/healthz", serveText("ok"))
-	http.HandleFunc("/", listPulls)
+	http.HandleFunc("/", forceHTML(listPulls))
 
 	fmt.Printf("Listening on port %d\n", *port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))

--- a/scripts/speculator/main.go
+++ b/scripts/speculator/main.go
@@ -384,14 +384,21 @@ func main() {
 		log.Fatal(err)
 	}
 	s := server{masterCloneDir}
-	http.HandleFunc("/spec/", s.serveSpec)
-	http.HandleFunc("/diff/rst/", s.serveRSTDiff)
-	http.HandleFunc("/diff/html/", s.serveHTMLDiff)
+	http.HandleFunc("/spec/", forceHTML(s.serveSpec))
+	http.HandleFunc("/diff/rst/", forceHTML(s.serveRSTDiff))
+	http.HandleFunc("/diff/html/", forceHTML(s.serveHTMLDiff))
 	http.HandleFunc("/healthz", serveText("ok"))
 	http.HandleFunc("/", listPulls)
 
 	fmt.Printf("Listening on port %d\n", *port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
+}
+
+func forceHTML(h func(w http.ResponseWriter, req *http.Request)) func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		h(w, req)
+	}
 }
 
 func serveText(s string) func(http.ResponseWriter, *http.Request) {


### PR DESCRIPTION
Go is auto-detecting that this is XML (because for some reason we
generate XHTML), and serving it with a Content-Type header text/xml.

This causes the browser to render it as XHTML, which gives interesting
quirks like extra newlines.

This change forces the browser to interpret it as HTML.

What we should probably do instead of stop generating XHTML and start
generating HTML. But in the mean time, this will fix the rendering
issues.