### PR TITLE
Document macaroon type=login

### DIFF
--- a/drafts/macaroons_caveats.rst
+++ b/drafts/macaroons_caveats.rst
@@ -25,10 +25,13 @@ Specified caveats:
 | gen         | Generation of the macaroon caveat spec.          | 1                                                                                              |
 | user_id     | ID of the user for which this macaroon is valid. | Pure equality check. Operator must be =.                                                       |
 | type        | The purpose of this macaroon.                    | access - used to authorize any action except token refresh                                     |
-|                                                                   refresh - only used to authorize a token refresh                                              |
+|             |                                                  | refresh - only used to authorize a token refresh                                               |
+|             |                                                  | login - issued as a very short-lived token by third party login flows; proves that             |
+|             |                                                  | authentication has happened but doesn't grant any privileges other than being able to be       |
+|             |                                                  | exchanged for other tokens.                                                                    |
 | time        | Time before/after which this macaroon is valid.  | A POSIX timestamp in milliseconds (in UTC).                                                    |
-|                                                                  Operator < means the macaroon is valid before the timestamp, as interpreted by the server.     |
-|                                                                  Operator > means the macaroon is valid after the timestamp, as interpreted by the server.      |
-|                                                                  Operator == means the macaroon is valid at exactly the timestamp, as interpreted by the server.|
-|                                                                  Note that exact equality of time is largely meaningless.                                       |
+|             |                                                  | Operator < means the macaroon is valid before the timestamp, as interpreted by the server.     |
+|             |                                                  | Operator > means the macaroon is valid after the timestamp, as interpreted by the server.      |
+|             |                                                  | Operator == means the macaroon is valid at exactly the timestamp, as interpreted by the server.|
+|             |                                                  | Note that exact equality of time is largely meaningless.                                       |
 +-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+

--- a/drafts/macaroons_caveats.rst
+++ b/drafts/macaroons_caveats.rst
@@ -9,12 +9,15 @@ Caveats can only be used for reducing the scope of a token, never for increasing
 
 Some caveats are specified in this specification, and must be understood by all servers. The use of non-standard caveats is allowed.
 
-All caveats must take the form:
+All caveats must take the form::
 
-`key` `operator` `value`
-where `key` is a non-empty string drawn from the character set [A-Za-z0-9_]
-`operator` is a non-empty string which does not contain whitespace
-`value` is a non-empty string
+  key operator value
+
+where:
+ - ``key`` is a non-empty string drawn from the character set [A-Za-z0-9_]
+ - ``operator`` is a non-empty string which does not contain whitespace
+ - ``value`` is a non-empty string
+ 
 And these are joined by single space characters.
 
 Specified caveats:

--- a/drafts/macaroons_caveats.rst
+++ b/drafts/macaroons_caveats.rst
@@ -21,14 +21,17 @@ Specified caveats:
 
 +-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
 | Caveat name | Description                                      | Legal Values                                                                                   |
-+-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
++=============+==================================================+================================================================================================+
 | gen         | Generation of the macaroon caveat spec.          | 1                                                                                              |
++-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
 | user_id     | ID of the user for which this macaroon is valid. | Pure equality check. Operator must be =.                                                       |
++-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
 | type        | The purpose of this macaroon.                    | access - used to authorize any action except token refresh                                     |
 |             |                                                  | refresh - only used to authorize a token refresh                                               |
 |             |                                                  | login - issued as a very short-lived token by third party login flows; proves that             |
 |             |                                                  | authentication has happened but doesn't grant any privileges other than being able to be       |
 |             |                                                  | exchanged for other tokens.                                                                    |
++-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
 | time        | Time before/after which this macaroon is valid.  | A POSIX timestamp in milliseconds (in UTC).                                                    |
 |             |                                                  | Operator < means the macaroon is valid before the timestamp, as interpreted by the server.     |
 |             |                                                  | Operator > means the macaroon is valid after the timestamp, as interpreted by the server.      |

--- a/drafts/macaroons_caveats.rst
+++ b/drafts/macaroons_caveats.rst
@@ -29,11 +29,11 @@ Specified caveats:
 +-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
 | user_id     | ID of the user for which this macaroon is valid. | Pure equality check. Operator must be =.                                                       |
 +-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
-| type        | The purpose of this macaroon.                    | access - used to authorize any action except token refresh                                     |
-|             |                                                  | refresh - only used to authorize a token refresh                                               |
-|             |                                                  | login - issued as a very short-lived token by third party login flows; proves that             |
-|             |                                                  | authentication has happened but doesn't grant any privileges other than being able to be       |
-|             |                                                  | exchanged for other tokens.                                                                    |
+| type        | The purpose of this macaroon.                    | - ``access``: used to authorize any action except token refresh                                |
+|             |                                                  | -  ``refresh``: only used to authorize a token refresh                                         |
+|             |                                                  | - ``login``: issued as a very short-lived token by third party login flows; proves that        |
+|             |                                                  |   authentication has happened but doesn't grant any privileges other than being able to be     |
+|             |                                                  |   exchanged for other tokens.                                                                  |
 +-------------+--------------------------------------------------+------------------------------------------------------------------------------------------------+
 | time        | Time before/after which this macaroon is valid.  | A POSIX timestamp in milliseconds (in UTC).                                                    |
 |             |                                                  | Operator < means the macaroon is valid before the timestamp, as interpreted by the server.     |


### PR DESCRIPTION
This is very close to a refresh token, and I'm a little tempted to just use refresh tokens for this, but they're also different enough to feel worth separating.

@stevenhammerton FYI

As implemented in https://github.com/matrix-org/synapse/pull/349