### PR TITLE
Make the speculator serve up errors as plain text

### DIFF
--- a/scripts/speculator/main.go
+++ b/scripts/speculator/main.go
@@ -135,6 +135,7 @@ func generate(dir string) error {
 }
 
 func writeError(w http.ResponseWriter, code int, err error) {
+	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(code)
 	io.WriteString(w, fmt.Sprintf("%v\n", err))
 }


### PR DESCRIPTION
... so that they are legible.