### PR TITLE
Embed release labels in spec

### DIFF
--- a/scripts/gendoc.py
+++ b/scripts/gendoc.py
@@ -250,7 +250,7 @@ def addAnchors(path):
             f.write(line + "\n")
 
 
-def run_through_template(input, set_verbose):
+def run_through_template(input, set_verbose, release_label):
     tmpfile = './tmp/output'
     try:
         with open(tmpfile, 'w') as out:
@@ -258,6 +258,7 @@ def run_through_template(input, set_verbose):
                 'python', 'build.py',
                 "-i", "matrix_templates",
                 "-o", "../scripts/tmp",
+                "--release_label", release_label,
                 "../scripts/"+input
             ]
             if set_verbose:
@@ -392,7 +393,7 @@ def cleanup_env():
     shutil.rmtree("./tmp")
 
 
-def main(requested_target_name, keep_intermediates):
+def main(requested_target_name, keep_intermediates, release_label):
     prepare_env()
     log("Building spec [target=%s]" % requested_target_name)
 
@@ -407,7 +408,7 @@ def main(requested_target_name, keep_intermediates):
 
         target = get_build_target("../specification/targets.yaml", target_name)
         build_spec(target=target, out_filename=templated_file)
-        run_through_template(templated_file, VERBOSE)
+        run_through_template(templated_file, VERBOSE, release_label)
         fix_relative_titles(
             target=target, filename=templated_file,
             out_filename=rst_file,
@@ -417,7 +418,7 @@ def main(requested_target_name, keep_intermediates):
 
     if requested_target_name == "all":
         shutil.copy("../supporting-docs/howtos/client-server.rst", "tmp/howto.rst")
-        run_through_template("tmp/howto.rst", False)  # too spammy to mark -v on this
+        run_through_template("tmp/howto.rst", False, release_label)  # too spammy to mark -v on this
         rst2html("tmp/howto.rst", "gen/howtos.html")
 
     if not keep_intermediates:
@@ -441,9 +442,13 @@ if __name__ == '__main__':
         "--verbose", "-v", action="store_true",
         help="Turn on verbose mode."
     )
+    parser.add_argument(
+        "--release", "-r", action="store", default="unstable",
+        help="The release tag to generate, e.g. r1.2"
+    )
     args = parser.parse_args()
     if not args.target:
         parser.print_help()
         sys.exit(1)
     VERBOSE = args.verbose
-    main(args.target, args.nodelete)
+    main(args.target, args.nodelete, args.release)

--- a/scripts/generate-http-docs.sh
+++ b/scripts/generate-http-docs.sh
@@ -4,6 +4,15 @@
 # It takes all of the swagger YAML files for the client-server API, and turns
 # them into API docs, with none of the narrative found in the rst files which
 # normally wrap these API docs.
+#
+# Optionally takes one positional argument, the label of the release, e.g. r1.2.
+# This falls back to "unstable" if unspecified.
+
+if [[ $# == 1 ]]; then
+  RELEASE=$1
+else
+  RELEASE="unstable"
+fi
 
 cd "$(dirname $0)"
 
@@ -23,5 +32,5 @@ for f in ../api/client-server/*.yaml; do
   echo "{{${f/-/_}}}" >> tmp/http_apis
 done
 
-(cd ../templating ; python build.py -i matrix_templates -o ../scripts/gen ../scripts/tmp/http_apis)
+(cd ../templating ; python build.py -i matrix_templates -o ../scripts/gen ../scripts/tmp/http_apis --release="${RELEASE}")
 rst2html.py --stylesheet-path=$(echo css/*.css | tr ' ' ',') gen/http_apis > gen/http_apis.html

--- a/templating/build.py
+++ b/templating/build.py
@@ -44,6 +44,7 @@ import importlib
 import json
 import logging
 import os
+import re
 import sys
 from textwrap import TextWrapper
 
@@ -56,7 +57,7 @@ def check_unaccessed(name, store):
         log("Found %s unused %s keys." % (len(unaccessed_keys), name))
         log(unaccessed_keys)
 
-def main(input_module, file_stream=None, out_dir=None, verbose=False):
+def main(input_module, file_stream=None, out_dir=None, verbose=False, substitutions={}):
     if out_dir and not os.path.exists(out_dir):
         os.makedirs(out_dir)
 
@@ -167,6 +168,12 @@ def main(input_module, file_stream=None, out_dir=None, verbose=False):
     temp = Template(temp_str)
     log("Creating output for: %s" % file_stream.name)
     output = create_from_template(temp, sections)
+
+    # Do these substitutions outside of the ordinary templating system because
+    # we want them to apply to things like the underlying swagger used to
+    # generate the templates, not just the top-level sections.
+    for old, new in substitutions.items():
+        output = output.replace(old, new)
     with open(
             os.path.join(out_dir, os.path.basename(file_stream.name)), "w"
             ) as f:
@@ -209,6 +216,11 @@ if __name__ == '__main__':
         "--verbose", "-v", action="store_true",
         help="Turn on verbose mode."
     )
+    parser.add_argument(
+        "--release_label", action="store",
+        help="Release label of API, used in URL endpoints, e.g. r1.2, or unstable." +
+             " Note that some places may derive a major version number from this."
+    )
     args = parser.parse_args()
 
     if args.verbose:
@@ -221,12 +233,25 @@ if __name__ == '__main__':
         main(args.input, verbose=args.verbose)
         sys.exit(0)
 
+    if not args.release_label:
+        raise Exception("Missing release label.")
+
     if not args.file:
         log("No file supplied.")
         parser.print_help()
         sys.exit(1)
 
+    major_version = args.release_label
+    match = re.match("^(r\d)+(\.\d+)?$", major_version)
+    if match:
+        major_version = match.group(1)
+
+    substitutions = {
+        "%RELEASE_LABEL%": args.release_label,
+        "%MAJOR_VERSION%": major_version,
+    }
+
     main(
         args.input, file_stream=args.file, out_dir=args.out_directory,
-        verbose=args.verbose
+        substitutions=substitutions, verbose=args.verbose
     )


### PR DESCRIPTION
Note that nothing actually pulls in these labels yet, but this adds the infrastructure to do so.

I will go through putting them in place when https://github.com/matrix-org/matrix-doc/pull/185 lands