### PR TITLE
Add tables of contents to individual specs

### DIFF
--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -12,6 +12,9 @@ irrespective of the underlying homeserver implementation.
   Add in Client-Server services? Overview of bots? Seems weird to be in the spec
   given it is VERY implementation specific.
 
+.. contents:: Table of Contents
+.. sectnum::
+
 Application Services
 --------------------
 Application services are passive and can only observe events from a given

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -17,6 +17,9 @@ shortly.
 Documentation for the old `V1 authentication
 <../attic/v1_registration_login.rst>`_ is still available separately.
 
+.. contents:: Table of Contents
+.. sectnum::
+
 API Standards
 -------------
 

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -41,6 +41,9 @@ EDUs and PDUs are further wrapped in an envelope called a Transaction, which is
 transferred from the origin to the destination home server using an HTTPS PUT
 request.
 
+.. contents:: Table of Contents
+.. sectnum::
+
 Server Discovery
 ----------------
 


### PR DESCRIPTION
I don't know why some of the pages count their title as section 1 and some don't.

I would love to know why.