### PR TITLE
Move event signing to server-server spec

### DIFF
--- a/event-schemas/schema/core-event-schema/room_event.json
+++ b/event-schemas/schema/core-event-schema/room_event.json
@@ -21,6 +21,7 @@
     "unsigned": {
       "type": "object",
       "description": "Contains optional extra information about the event.",
+      "title": "UnsignedData",
       "properties": {
         "age": {
           "type": "integer",

--- a/event-schemas/schema/m.room.member
+++ b/event-schemas/schema/m.room.member
@@ -30,6 +30,7 @@
                         "signed": {
                             "type": "object",
                             "title": "signed",
+                            "description": "A block of content which has been signed, which servers can use to verify the event. Clients should ignore this.",
                             "properties": {
                                 "mxid": {
                                     "type": "string",
@@ -41,7 +42,7 @@
                                 },
                                 "signatures": {
                                     "type": "object",
-                                    "description": "A single signature from the verifying server, in the format specified by the Signing Events section.",
+                                    "description": "A single signature from the verifying server, in the format specified by the Signing Events section of the server-server API.",
                                     "title": "Signatures"
                                 }
                             },

--- a/specification/targets.yaml
+++ b/specification/targets.yaml
@@ -6,7 +6,6 @@ targets:
     files:
       - client_server_api.rst
       - { 1: events.rst }
-      - { 1: event_signing.rst }
       - { 1: modules.rst }
       - { 2: feature_profiles.rst }
       - { 2: "group:modules" }  # reference a group of files
@@ -16,6 +15,7 @@ targets:
   server_server:
     files:
       - server_server_api.rst
+      - { 1: event_signing.rst }
   appendices:
     files:
       - appendices.rst


### PR DESCRIPTION
It's *definitely* not a client concern.

It isn't really in the right place at the moment, but s-s is very much a
work in progress whereas c-s is nearly stable.