### PR TITLE
Resolve references by default

### DIFF
--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -559,6 +559,7 @@ class MatrixUnits(Units):
                     # strip .yaml
                     group_name = filename[:-5].replace("-", "_")
                     api = yaml.load(f.read())
+                    api = resolve_references(filepath, api)
                     api["__meta"] = self._load_swagger_meta(
                         filepath, api, group_name
                     )


### PR DESCRIPTION
This means I can re-use this function for the swagger-UI generation

I can't see why you would want un-resolved references as a consumer.