### PR TITLE
Take object, not bool, as param

### DIFF
--- a/api/client-server/pushrules.yaml
+++ b/api/client-server/pushrules.yaml
@@ -470,14 +470,21 @@ paths:
           description: |
             The identifier for the rule.
         - in: body
-          name: <body>
+          name: body
           description: |
             Whether the push rule is enabled or not.
           required: true
           schema:
-            type: boolean
+            type: object
+            properties:
+              enabled:
+                type: boolean
+                description: Whether the push rule is enabled or not.
+            required: ["enabled"]
             example: |-
-              true
+              {
+                "enabled": true
+              }
       responses:
         200:
           description: The push rule was enabled or disabled.


### PR DESCRIPTION
Throughout our API we take objects. And swagger is unhappy with not
doing so.