### PR TITLE
Add a host and scheme to Location headers in redirects

### DIFF
--- a/scripts/speculator/main.go
+++ b/scripts/speculator/main.go
@@ -387,8 +387,12 @@ func (s *server) serveSpec(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte("Not found"))
 }
 
-func (s *server) redirectTo(w http.ResponseWriter, _ *http.Request, path string) {
-	w.Header().Set("Location", path)
+func (s *server) redirectTo(w http.ResponseWriter, req *http.Request, path string) {
+	u := *req.URL
+	u.Scheme = "http"
+	u.Host = req.Host
+	u.Path = path
+	w.Header().Set("Location", u.String())
 	w.WriteHeader(302)
 }
 


### PR DESCRIPTION
Our apache reverse-proxy can't correctly rewrite relative Location headers, so
add the Host from the request into the Location.