### PR TITLE
Don't need to document /pdu/ any more

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -485,15 +485,6 @@ The destination name will be set to that of the receiving server itself. Each
 embedded PDU in the transaction body will be processed.
 
 
-To fetch a particular PDU::
-
-  GET .../pdu/<origin>/<pdu_id>/
-    Response: JSON encoding of a single Transaction containing one PDU
-
-Retrieves a given PDU from the server. The response will contain a single new
-Transaction, inside which will be the requested PDU.
-
-
 To fetch all the state of a given room::
 
   GET .../state/<room_id>/


### PR DESCRIPTION
The `/pdu/` endpoint was renamed to `/event/`. Since the latter is now actually documented, the former can be deleted.

https://github.com/matrix-org/synapse/commit/ad6eacb3#diff-86a3316d6c59552744a794090e2c78ecR375