### PR TITLE
Filters don't support wildcards for senders or room ids

### DIFF
--- a/api/client-server/definitions/event_filter.yaml
+++ b/api/client-server/definitions/event_filter.yaml
@@ -5,7 +5,7 @@ properties:
   not_senders:
     description: A list of sender IDs to exclude. If this list is absent then no senders
       are excluded. A matching sender will be excluded even if it is listed in the
-      'senders' filter. A '*' can be used as a wildcard to match any sequence of characters.
+      'senders' filter.
     items:
       type: string
     type: array
@@ -19,8 +19,7 @@ properties:
     type: array
   senders:
     description: A list of senders IDs to include. If this list is absent then all
-      senders are included. A '*' can be used as a wildcard to match any sequence
-      of characters.
+      senders are included.
     items:
       type: string
     type: array

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -4,13 +4,13 @@ properties:
   not_rooms:
     description: A list of room IDs to exclude. If this list is absent then no rooms
       are excluded. A matching room will be excluded even if it is listed in the 'rooms'
-      filter. A '*' can be used as a wildcard to match any sequence of characters.
+      filter.
     items:
       type: string
     type: array
   rooms:
     description: A list of room IDs to include. If this list is absent then all rooms
-      are included. A '*' can be used as a wildcard to match any sequence of characters.
+      are included.
     items:
       type: string
     type: array


### PR DESCRIPTION
This isn't implemented, and I doubt it will be useful given that room ids are random, and sender ids aren't necessarily human readable.