### PR TITLE
Display POST body parameters as tables

### DIFF
--- a/templating/build.py
+++ b/templating/build.py
@@ -224,6 +224,8 @@ if __name__ == '__main__':
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
 
     if not args.input:
         raise Exception("Missing [i]nput python module.")

--- a/templating/matrix_templates/templates/http-api.tmpl
+++ b/templating/matrix_templates/templates/http-api.tmpl
@@ -28,7 +28,6 @@ Request format:
 {{ tables.paramtable(table.rows) }}
 {% endfor -%}
 {% endif -%}
-
 {% else %}
 `No parameters`
 {% endif %}

--- a/templating/matrix_templates/templates/http-api.tmpl
+++ b/templating/matrix_templates/templates/http-api.tmpl
@@ -21,13 +21,13 @@
 Request format:
 {% if (endpoint.req_param_by_loc | length) %}
 {{ tables.split_paramtable(endpoint.req_param_by_loc) }}
-
-{% if (endpoint.req_body_tables) -%}
+{% if (endpoint.req_body_tables) %}
 {% for table in endpoint.req_body_tables -%}
 {{"``"+table.title+"``" if table.title else "" }}
 {{ tables.paramtable(table.rows) }}
 {% endfor -%}
 {% endif -%}
+
 {% else %}
 `No parameters`
 {% endif %}

--- a/templating/matrix_templates/templates/http-api.tmpl
+++ b/templating/matrix_templates/templates/http-api.tmpl
@@ -21,6 +21,14 @@
 Request format:
 {% if (endpoint.req_param_by_loc | length) %}
 {{ tables.split_paramtable(endpoint.req_param_by_loc) }}
+
+{% if (endpoint.req_body_tables) -%}
+{% for table in endpoint.req_body_tables -%}
+{{"``"+table.title+"``" if table.title else "" }}
+{{ tables.paramtable(table.rows) }}
+{% endfor -%}
+{% endif -%}
+
 {% else %}
 `No parameters`
 {% endif %}

--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -470,7 +470,7 @@ class MatrixUnits(Units):
 
         # put the top-level parameters into 'req_param_by_loc', and the others
         # into 'req_body_tables'
-        body_params = endpoint_data['req_param_by_loc'].setdefault("body",[])
+        body_params = endpoint_data['req_param_by_loc'].setdefault("JSON body",[])
         body_params.extend(req_body_tables[0]["rows"])
 
         body_tables = req_body_tables[1:]


### PR DESCRIPTION
Replace a whole bunch of special-casing for POST body parameters with the same
logic as is used for response objects: represent all but the top-level as
tables.

Once this, #255, *and* #254 all land, we'll have documentation of the params to POST /filter.