### PR TITLE
Don't sort the properties in object schemas

### DIFF
--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -151,7 +151,7 @@ def get_json_schema_object_fields(obj, enforce_title=False, include_parents=Fals
 
     tables = [fields]
 
-    for key_name in sorted(props):
+    for key_name in props:
         logger.debug("Processing property %s.%s", obj.get('title'), key_name)
         value_type = None
         required = key_name in required_keys


### PR DESCRIPTION
It makes more sense for us to order the properties manually in the yaml file,
rather than forcing their alphabeticising.