### PR TITLE
Remove references to device specific push rules

### DIFF
--- a/api/client-server/definitions/push_condition.yaml
+++ b/api/client-server/definitions/push_condition.yaml
@@ -2,7 +2,6 @@ properties:
   kind:
     enum:
     - event_match
-    - profile_tag
     - contains_display_name
     - room_member_count
     type: string

--- a/api/client-server/pusher.yaml
+++ b/api/client-server/pusher.yaml
@@ -41,7 +41,6 @@ paths:
                 "app_display_name": "Mat Rix",
                 "device_display_name": "iPhone 9",
                 "app_id": "com.example.app.ios",
-                "profile_tag": "4bea66906d0111e59d70feff819cdc9f",
                 "pushkey": "APA91bHPRgkF3JUikC4ENAHEeMrd41Zxv3hVZjC9KtT8OvPVGJ-hQMRKRrZuJAEcl7B338qju59zJMjw2DELjzEvxwYv7hH5Ynpc1ODQ0aT4U4OFEeco8ohsN5PjL1iC2dNtk2BAokeMCg2ZXKqpc8FXKmhX94kIxQ",
                 "data": {
                   "url": "https://push-gateway.location.here"
@@ -63,17 +62,6 @@ paths:
                 description: |-
                   The kind of pusher to configure. ``"http"`` makes a pusher that
                   sends HTTP pokes. ``null`` deletes the pusher.
-              profile_tag:
-                type: string
-                description: |-
-                  This is a string that determines what set of device rules will
-                  be matched when evaluating push rules for this pusher. It is
-                  an arbitrary string. Multiple devices may use the same
-                  ``profile_tag``. It is advised that when an app's data is
-                  copied or restored to a different device, this value remain
-                  the same. Client apps should offer ways to change the
-                  ``profile_tag``, optionally copying rules from the old
-                  profile tag. Max length, 32 bytes.
               app_id:
                 type: string
                 description: |-
@@ -116,7 +104,7 @@ paths:
                   different user IDs. Otherwise, the homeserver must remove any
                   other pushers with the same App ID and pushkey for different
                   users. The default is ``false``.
-            required: ['profile_tag', 'kind', 'app_id', 'app_display_name',
+            required: ['kind', 'app_id', 'app_display_name',
                 'device_display_name', 'pushkey', 'lang', 'data']
       responses:
         200:

--- a/api/client-server/pushrules.yaml
+++ b/api/client-server/pushrules.yaml
@@ -33,20 +33,8 @@ paths:
           description: All the push rulesets for this user.
           schema:
             type: object
-            required: ["device", "global"]
+            required: ["global"]
             properties:
-              device:
-                type: object
-                title: Devices
-                description: A dictionary of profile tags to rulesets.
-                additionalProperties:
-                    x-pattern: "$PROFILE_TAG"
-                    type: object
-                    description: The ruleset for this profile tag.
-                    title: Ruleset
-                    allOf: [
-                      "$ref": "definitions/push_ruleset.yaml"
-                    ]
               global:
                 type: object
                 description: The global ruleset.
@@ -57,7 +45,6 @@ paths:
           examples:
             application/json: |-
               {
-                "device": {},
                 "global": {
                     "content": [
                         {
@@ -261,8 +248,7 @@ paths:
           required: true
           x-example: "global"
           description: |-
-            Either ``global`` or ``device/<profile_tag>`` to specify global
-            rules or device rules for the given ``profile_tag``.
+            ``global`` to specify global rules.
         - in: path
           type: string
           name: kind
@@ -314,8 +300,7 @@ paths:
           required: true
           x-example: "global"
           description: |-
-            Either ``global`` or ``device/<profile_tag>`` to specify global
-            rules or device rules for the given ``profile_tag``.
+            ``global`` to specify global rules.
         - in: path
           type: string
           name: kind
@@ -356,8 +341,7 @@ paths:
           required: true
           x-example: "global"
           description: |-
-            Either ``global`` or ``device/<profile_tag>`` to specify global
-            rules or device rules for the given ``profile_tag``.
+            ``global`` to specify global rules.
         - in: path
           type: string
           name: kind
@@ -460,8 +444,7 @@ paths:
           required: true
           x-example: "global"
           description: |-
-            Either ``global`` or ``device/<profile_tag>`` to specify global
-            rules or device rules for the given ``profile_tag``.
+            ``global`` to specify global rules.
         - in: path
           type: string
           name: kind

--- a/specification/modules/push.rst
+++ b/specification/modules/push.rst
@@ -122,16 +122,9 @@ Underride rules ``underride``
   These are identical to ``override`` rules, but have a lower priority than
   ``content``, ``room`` and ``sender`` rules.
 
-Push rules may be either global or device-specific. Device specific rules only
-affect delivery of notifications via pushers with a matching ``profile_tag``.
-All device-specific rules have a higher priority than global rules. This means
-that the full list of rule kinds, in descending priority order, is as follows:
+This means that the full list of rule kinds, in descending priority order, is
+as follows:
 
-* Device-specific Override
-* Device-specific Content
-* Device-specific Room
-* Device-specific Sender
-* Device-specific Underride
 * Global Override
 * Global Content
 * Global Room
@@ -320,12 +313,6 @@ rule determines its behaviour. The following conditions are defined:
   * ``pattern``: The glob-style pattern to match against. Patterns with no
     special glob characters should be treated as having asterisks
     prepended and appended when testing the condition.
-
-``profile_tag``
-  Matches the ``profile_tag`` of the device that the notification would be
-  delivered to. Parameters:
-
-  * ``profile_tag``: The profile_tag to match with.
 
 ``contains_display_name``
   This matches unencrypted messages where ``content.body`` contains the owner's


### PR DESCRIPTION
Since they weren't implemented on the servers and weren't
used by the clients.