### PR TITLE
Include newline before table headings

### DIFF
--- a/templating/matrix_templates/templates/events.tmpl
+++ b/templating/matrix_templates/templates/events.tmpl
@@ -6,7 +6,7 @@
     {{event.typeof_info}}
 
 {{event.desc | wrap(80)}}
-{% for table in event.content_fields -%}
+{% for table in event.content_fields %}
 {{"``"+table.title+"``" if table.title else "" }}
 
 {{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"]) }}


### PR DESCRIPTION
Currently sometimes the title of the first table is on the same line as the general prose introduction; this fixes that.