### PR TITLE
Move the 'old versions' links into the client-server API spec

### DIFF
--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -16,7 +16,7 @@ Changelog
 .. topic:: Version: %CLIENT_RELEASE_LABEL%
 {{client_server_changelog}}
 
-The documents in this version of the specification are generated from
+This version of the specification is generated from
 `matrix-doc <https://github.com/matrix-org/matrix-doc>`_ as of Git commit
 `{{git_version}} <https://github.com/matrix-org/matrix-doc/tree/{{git_rev}}>`_.
 

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -16,11 +16,26 @@ Changelog
 .. topic:: Version: %CLIENT_RELEASE_LABEL%
 {{client_server_changelog}}
 
+The documents in this version of the specification are generated from
+`matrix-doc <https://github.com/matrix-org/matrix-doc>`_ as of Git commit
+`{{git_version}} <https://github.com/matrix-org/matrix-doc/tree/{{git_rev}}>`_.
+
 For the full historical changelog, see
 https://github.com/matrix-org/matrix-doc/blob/master/changelogs/client_server.rst
 
 If this is an unstable snapshot, any changes since the last release may be
 viewed using ``git log``.
+
+Other versions of this specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following other versions are also available, in reverse chronological order:
+
+- `HEAD <https://matrix.org/speculator/spec/head/client_server.html>`_: Includes all changes since the latest versioned release.
+- `r0.0.1 <https://matrix.org/docs/spec/r0.0.1/client_server.html>`_
+- `r0.0.0 <https://matrix.org/docs/spec/r0.0.0/client_server.html>`_
+- `Legacy <https://matrix.org/docs/spec/legacy/#client-server-api>`_: The last draft before the spec was formally released in version r0.0.0.
+
 
 API Standards
 -------------

--- a/specification/index.rst
+++ b/specification/index.rst
@@ -28,19 +28,6 @@ one of the above APIs are also available.
 Specification Versions
 ----------------------
 
-The documents in this version of the specification are generated from
-`matrix-doc <https://github.com/matrix-org/matrix-doc>`_ as of Git commit
-`{{git_version}} <https://github.com/matrix-org/matrix-doc/tree/{{git_rev}}>`_.
-
-The following other versions of the specification are also available,
-in reverse chronological order:
-
-- `HEAD <https://matrix.org/speculator/spec/head/>`_: Includes all changes since the latest versioned release.
-- `r0.0.1 <https://matrix.org/docs/spec/r0.0.1>`_
-- `r0.0.0 <https://matrix.org/docs/spec/r0.0.0>`_
-- `Legacy <https://matrix.org/docs/spec/legacy/>`_: The last draft before the spec was formally released in version r0.0.0.
-
-
 The specification for each API is versioned in the form ``rX.Y.Z``.
  * A change to ``X`` reflects a breaking change: a client implemented against
    ``r1.0.0`` may need changes to work with a server which supports (only)


### PR DESCRIPTION
Since the spec index is supposedly unversioned, it makes little sense to keep
the historical links there.