### PR TITLE
Put each bit of spec in its own directory

### DIFF
--- a/specification/targets.yaml
+++ b/specification/targets.yaml
@@ -12,19 +12,24 @@ targets:
       - { 1: modules.rst }
       - { 2: feature_profiles.rst }
       - { 2: "group:modules" }  # reference a group of files
+    version_label: "%CLIENT_RELEASE_LABEL%"
   application_service:
     files:
       - application_service_api.rst
+    version_label: unstable
   server_server:
     files:
       - server_server_api.rst
       - { 1: event_signing.rst }
+    version_label: "%SERVER_RELEASE_LABEL%"
   identity_service:
     files:
       - identity_service_api.rst
+    version_label: unstable
   push_gateway:
     files:
       - push_gateway.rst
+    version_label: unstable
   appendices:
     files:
       - appendices.rst

--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -541,25 +541,27 @@ class MatrixUnits(Units):
         return event_types
 
     def load_apis(self, substitutions):
+        cs_ver = substitutions.get("%CLIENT_RELEASE_LABEL%", "unstable")
+        fed_ver = substitutions.get("%SERVER_RELEASE_LABEL%", "unstable")
         return {
             "rows": [{
-                "key": "`Client-Server API <client_server.html>`_",
-                "type": substitutions.get("%CLIENT_RELEASE_LABEL%", "unstable"),
+                "key": "`Client-Server API <client_server/"+cs_ver+".html>`_",
+                "type": cs_ver,
                 "desc": "Interaction between clients and servers",
             }, {
-                "key": "`Server-Server API <server_server.html>`_",
-                "type": substitutions.get("%SERVER_RELEASE_LABEL%", "unstable"),
+                "key": "`Server-Server API <server_server/"+fed_ver+".html>`_",
+                "type": fed_ver,
                 "desc": "Federation between servers",
             }, {
-                "key": "`Application Service API <application_service.html>`_",
-                "type": substitutions.get("%CLIENT_RELEASE_LABEL%", "unstable"),
+                "key": "`Application Service API <application_service/unstable.html>`_",
+                "type": "unstable",
                 "desc": "Privileged server plugins",
             }, {
-                "key": "`Identity Service API <identity_service.html>`_",
+                "key": "`Identity Service API <identity_service/unstable.html>`_",
                 "type": "unstable",
                 "desc": "Mapping of third party IDs with Matrix ID",
             }, {
-                "key": "`Push Gateway API <push_gateway.html>`_",
+                "key": "`Push Gateway API <push_gateway/unstable.html>`_",
                 "type": "unstable",
                 "desc": "Push notifications for Matrix events",
             }]


### PR DESCRIPTION
I want to change the URLs for the spec sections on the website from
`<version>/<section>.html` to `<section>/<version>.html`, to better reflect how we
do the versioning.

This puts each bit of spec in its own directory, updates the index to point to
the right place, and fixes continuserv to deal with directories as well as
files.