### PR TITLE
Improve API examples in the spec

### DIFF
--- a/templating/matrix_templates/templates/http-api.tmpl
+++ b/templating/matrix_templates/templates/http-api.tmpl
@@ -44,16 +44,18 @@ Example request:
 
   {{endpoint.example.req | indent_block(2)}}
 
-{% if endpoint.example.responses|length > 0 -%}
-Response{{"s" if endpoint.example.responses|length > 1 else "" }}:
+{% if endpoint.responses|length > 0 -%}
+Response{{"s" if endpoint.responses|length > 1 else "" }}:
 
 {% endif -%}
 
-{% for res in endpoint.example.responses -%}
+{% for res in endpoint.responses -%}
 
 **Status code {{res["code"]}}:**
 
 {{res["description"]}}
+
+{% if res["example"] -%}
 
 Example
 
@@ -61,5 +63,6 @@ Example
 
   {{res["example"] | indent_block(2)}}
 
-{% endfor %}
+{% endif -%}
 
+{% endfor %}


### PR DESCRIPTION
* Show response codes even if we don't have examples for them
 * Walk the objects to build param examples if none are given at the top level