### PR TITLE
Add PyYAML to scripts/README.md

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,7 @@ Generating the HTML for the specification
 Requirements:
  - docutils (for converting RST to HTML)
  - Jinja2 (for templating)
+ - PyYAML (for reading YAML files)
 
 To generate the complete specification along with supporting documentation, run:
     python gendoc.py


### PR DESCRIPTION
PyYAML is a 3rd-party package used by `gendoc.py`.