### PR TITLE
Supply prev_batch unconditionally in timelines

### DIFF
--- a/api/client-server/definitions/timeline_batch.yaml
+++ b/api/client-server/definitions/timeline_batch.yaml
@@ -6,7 +6,7 @@ properties:
       on the filter
     type: boolean
   prev_batch:
-    description: If the batch was limited then this is a token that can be supplied
-      to the server to retrieve earlier events
+    description: A token that can be supplied to to the ``from`` parameter of the
+      rooms/{roomId}/messages endpoint
     type: string
 type: object


### PR DESCRIPTION
I would have liked to make the endpoint reference a hyperlink, but it's not clear to me if there's any way to do that from a yaml file. It's also not clear to me if there are other intended uses of from_batch, as the original wording was vague, but this at least calls out the one necessary for efficient infinite scrollback.

Note that this change merely documents what appears to be synapse's current behavior.