### PR TITLE
Don't line wrap the API descriptions

### DIFF
--- a/templating/matrix_templates/templates/http-api.tmpl
+++ b/templating/matrix_templates/templates/http-api.tmpl
@@ -8,7 +8,7 @@
 
 {% endif -%}
 
-{{endpoint.desc | wrap(80)}}
+{{endpoint.desc}}
 
 {{":Rate-limited: Yes." if endpoint.rate_limited else "" }}
 {{":Requires auth: Yes." if endpoint.requires_auth else "" }}


### PR DESCRIPTION
They are in RST format which is whitespace sensitive and threfore can't be line wrapped without breaking the syntax.

There is more wrapping in other places but some of it is into tables where it does need to be fixed width in order for the RST table to parse correctly.