### PR TITLE
Add missing "to" parameter to /messages

### DIFF
--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -34,9 +34,20 @@ paths:
           name: from
           description: |-
             The token to start returning events from. This token can be obtained
-            from the initial sync API.
+            from a ``prev_batch`` token returned for each room by the sync API,
+            or from a ``start`` or ``end`` token returned by a previous request
+            to this endpoint.
           required: true
           x-example: "s345_678_333"
+        - in: query
+          type: string
+          name: to
+          description: |-
+            The token to stop returning events at. This token can be obtained from
+            a ``prev_batch`` token returned for each room by the sync endpoint,
+            or from a ``start`` or ``end`` token returned by a previous request to
+            this endpoint.
+          required: false
         - in: query
           type: string
           enum: ["b", "f"]
@@ -61,7 +72,7 @@ paths:
               start:
                 type: string
                 description: |-
-                  The token to start paginating from. If ``dir=b`` this will be
+                  The token the pagination starts from. If ``dir=b`` this will be
                   the token supplied in ``from``.
               end:
                 type: string


### PR DESCRIPTION
The current synapse implementation accepts this token (see https://github.com/matrix-org/synapse/blob/master/synapse/rest/client/v1/room.py#L326 and https://github.com/matrix-org/synapse/blob/master/synapse/streams/config.py#L58), and its presence makes it much easier to link up forward pagination with a timeline obtained from /sync. Therefore, I'd like to make its support explicitly required.

I also made an effort to clarify the documentation concerning how the various tokens can be obtained and what their semantics are. The new wording should be checked for accuracy before these changes are merged.