### PR TITLE
Fix name of prev_content to preserve on redactions

### DIFF
--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -878,7 +878,7 @@ the following list:
 - ``room_id``
 - ``user_id``
 - ``state_key``
-- ``prev_state``
+- ``prev_content``
 - ``content``
 
 The content object should also be stripped of all keys, unless it is one of


### PR DESCRIPTION
The field is called prev_content, not prev_state.