### PR TITLE
Clarifications to authentication mechanisms

### DIFF
--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -29,7 +29,7 @@ paths:
     post:
       summary: Register for an account on this homeserver.
       description: |-
-        This API endpoint uses the `User-Interactive Authentication API`.
+        This API endpoint uses the `User-Interactive Authentication API`_.
 
         Register for an account on this homeserver.
 
@@ -57,7 +57,13 @@ paths:
             properties:
               auth:
                 description: |-
-                  Additional authentication information for the user-interactive authentication API.
+                    Additional authentication information for the
+                    user-interactive authentication API. Note that this
+                    information is *not* used to define how the registered user
+                    should be authenticated, but is instead used to
+                    authenticate the ``register`` call itself. It should be
+                    left empty, or omitted, unless an earlier call returned an
+                    response with status code 401.
                 "$ref": "definitions/auth_data.yaml"
               bind_email:
                 type: boolean


### PR DESCRIPTION
* Make the purpose of the `auth` key in /register requests explicit, and say
  that it should be empty at first.

* Restructure the UA-auth section a bit.

* In the UA-auth section, say that clients should submit no `auth` to start
  with, and add 'Stage 0' representing  this to the example.

* s/{stage,login} type/authentication type/ in the UA-auth section. Seems
   clearer to me.

* Try to distinguish the example responses from the example requests by giving
  an HTTP header.

Fixes https://matrix.org/jira/browse/SPEC-441.