### PR TITLE
Fix some obsolete uses of user_id key in events

### DIFF
--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -107,7 +107,7 @@ paths:
                 "chunk": [
                   {
                     "origin_server_ts": 1444812213737,
-                    "user_id": "@alice:example.com",
+                    "sender": "@alice:example.com",
                     "event_id": "$1444812213350496Caaaa:example.com",
                     "content": {
                       "body": "hello world",
@@ -119,7 +119,7 @@ paths:
                   },
                   {
                     "origin_server_ts": 1444812194656 ,
-                    "user_id": "@bob:example.com",
+                    "sender": "@bob:example.com",
                     "event_id": "$1444812213350496Cbbbb:example.com",
                     "content": {
                       "body": "the world is big",
@@ -131,7 +131,7 @@ paths:
                   },
                   {
                     "origin_server_ts": 1444812163990,
-                    "user_id": "@bob:example.com",
+                    "sender": "@bob:example.com",
                     "event_id": "$1444812213350496Ccccc:example.com",
                     "content": {
                       "name": "New room name"

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -19,6 +19,8 @@
     (`#365 <https://github.com/matrix-org/matrix-doc/pull/365>`_).
   - A number of clarifications to authentication
     (`#371 <https://github.com/matrix-org/matrix-doc/pull/371>`_).
+  - Correct references to ``user_id`` which should have been ``sender``
+    (`#376 <https://github.com/matrix-org/matrix-doc/pull/376>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -955,7 +955,7 @@ the following list:
 - ``event_id``
 - ``type``
 - ``room_id``
-- ``user_id``
+- ``sender``
 - ``state_key``
 - ``prev_content``
 - ``content``


### PR DESCRIPTION
This should account for most of the incorrect users in the client-server API docs. I made no attempt to review the server-server API for similar errors.