### PR TITLE
Add a nix-shell environment suitable for building

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,10 @@ Requirements:
  - Jinja2 (for templating)
  - PyYAML (for reading YAML files)
 
+Nix[2] users can enter an environment with the appropriate tools and
+dependencies available by invoking `nix-shell contrib/shell.nix` in this
+directory.
+
 To generate the complete specification along with supporting documentation, run:
     python gendoc.py
 
@@ -38,3 +42,4 @@ To make use of the generated file, there are a number of options:
    * View the UI via your browser at http://\<hostname>?url=api-docs.json
 
 [1] http://swagger.io/
+[2] https://nixos.org/nix/

--- a/scripts/contrib/shell.nix
+++ b/scripts/contrib/shell.nix
@@ -1,0 +1,6 @@
+with import <nixpkgs> {};
+
+(python.buildEnv.override {
+  extraLibs = with pythonPackages;
+    [ docutils pyyaml jinja2 pygments ];
+}).env


### PR DESCRIPTION
This enables easy execution of scripts/*.py by Nix users.

I have no idea if this sort of thing is desired in the repository, but I needed to write it for my personal use and it might be useful to others, and it is very small.