### PR TITLE
s/vector/riot/

### DIFF
--- a/supporting-docs/guides/2015-08-19-faq.md
+++ b/supporting-docs/guides/2015-08-19-faq.md
@@ -368,7 +368,7 @@ letting the user interact with users and rooms anywhere within the
 Matrix federation.  Text and image messages are supported, and basic
 voice-only VoIP calling via WebRTC is supported in one-to-one rooms.
 (As of October 2015, experimental multi-way calling is also available
-on Vector.im).
+on Riot.im).
 
 ##### How do I connect my homeserver to the public Matrix network?
 
@@ -563,28 +563,28 @@ Data is only shared between servers of participating users of a room. If all use
 
 ##### Where can I find a mobile app?
 
-Vector is available for Android and iOS.
+Riot is available for Android and iOS.
 
 The iOS version can be downloaded from the [Apple store](https://itunes.apple.com/us/app/vector.im/id1083446067).
 
-The Android version can be downloaded from the [Google Play store](https://play.google.com/store/apps/details?id=im.vector.alpha) or [F-Droid](https://f-droid.org/repository/browse/?fdid=im.vector.alpha). If you are not sure which one to choose, install Vector from the [Google Play store](https://play.google.com/store/apps/details?id=im.vector.alpha).
+The Android version can be downloaded from the [Google Play store](https://play.google.com/store/apps/details?id=im.vector.alpha) or [F-Droid](https://f-droid.org/repository/browse/?fdid=im.vector.alpha). If you are not sure which one to choose, install Riot from the [Google Play store](https://play.google.com/store/apps/details?id=im.vector.alpha).
 
 For the Android app, you can also install the latest development version
 built by [Jenkins](http://matrix.org/jenkins/job/VectorAndroidDevelop). Use it at your own risk and only if you know what you are doing.
 
-##### I installed Vector via F-Droid, why is it draining my battery?
+##### I installed Riot via F-Droid, why is it draining my battery?
 
-The F-Droid release of Vector does not use [Google Cloud Messaging](https://developers.google.com/cloud-messaging/). This allows users that do not have or want Google Services installed to use Vector.
+The F-Droid release of Riot does not use [Google Cloud Messaging](https://developers.google.com/cloud-messaging/). This allows users that do not have or want Google Services installed to use Riot.
 
-The drawback is that Vector has to pull for new messages, which can drain your battery. To counter this, you can change the delay between polls in the settings. Higher delay means better battery life (but may delay receiving messages). You can also disable the background sync entirely (which means that you won't get any notifications at all).
+The drawback is that Riot has to pull for new messages, which can drain your battery. To counter this, you can change the delay between polls in the settings. Higher delay means better battery life (but may delay receiving messages). You can also disable the background sync entirely (which means that you won't get any notifications at all).
 
 If you don't mind using Google Services, you might be better off installing the [Google Play store](https://play.google.com/store/apps/details?id=im.vector.alpha) version.
 
 ##### Where can I find a web app?
 
-You can use [Vector.im](https://vector.im) - a glossy web client written on top of [matrix-react-sdk](https://github.com/matrix-org/matrix-react-sdk).
+You can use [Riot.im](https://Riot.im) - a glossy web client written on top of [matrix-react-sdk](https://github.com/matrix-org/matrix-react-sdk).
 
-You can also run Vector on your own server. It's a static web application, just download the [last release](https://github.com/vector-im/vector-web/) and unpack it.
+You can also run Vector, the code that Riot.im uses, on your own server. It's a static web application, just download the [last release](https://github.com/vector-im/vector-web/) and unpack it.
 
 ##### Where can I find a desktop client?
 


### PR DESCRIPTION
Replace references to Vector with Riot (when appropriate).