### PR TITLE
Various spec templating fixes

### DIFF
--- a/templating/matrix_templates/templates/events.tmpl
+++ b/templating/matrix_templates/templates/events.tmpl
@@ -2,8 +2,12 @@
 
 ``{{event.type}}``
 {{(4 + event.type | length) * title_kind}}
+
+{% if (event.typeof | length) %}
 *{{event.typeof}}*
     {{event.typeof_info}}
+
+{% endif -%}
 
 {{event.desc | wrap(80)}}
 {% for table in event.content_fields %}

--- a/templating/matrix_templates/templates/http-api.tmpl
+++ b/templating/matrix_templates/templates/http-api.tmpl
@@ -27,6 +27,12 @@ Request format:
 `No parameters`
 {% endif %}
 
+{% if endpoint.res_headers|length > 0 -%}
+Response headers:
+
+{{ tables.paramtable(endpoint.res_headers) }}
+{% endif -%}
+
 {% if endpoint.res_tables|length > 0 -%}
 Response format:
 

--- a/templating/matrix_templates/units.py
+++ b/templating/matrix_templates/units.py
@@ -680,7 +680,7 @@ class MatrixUnits(Units):
             json_schema = yaml.load(f)
 
         schema = {
-            "typeof": None,
+            "typeof": "",
             "typeof_info": "",
             "type": None,
             "title": None,
@@ -703,11 +703,9 @@ class MatrixUnits(Units):
             STATE_EVENT: "State Event"
         }
         if type(json_schema.get("allOf")) == list:
-            schema["typeof"] = base_defs.get(
-                json_schema["allOf"][0].get("$ref")
-            )
-        elif json_schema.get("title"):
-            schema["typeof"] = json_schema["title"]
+            firstRef = json_schema["allOf"][0]["$ref"]
+            if firstRef in base_defs:
+                schema["typeof"] = base_defs[firstRef]
 
         json_schema = resolve_references(filepath, json_schema)
 


### PR DESCRIPTION
The most important change here is that we render the bodies of responses which return an object whose properties are defined by reference to an external schema file (`/user/{userId}/filter/{filterId}` for example).
