### PR TITLE
E2E impl guide: check ids in device query

### DIFF
--- a/supporting-docs/guides/2016-10-18-e2e_implementation.rst
+++ b/supporting-docs/guides/2016-10-18-e2e_implementation.rst
@@ -399,12 +399,18 @@ and the corresponding signature for the ``signature`` parameter. If the
 signature check fails, no further processing should be done on the
 device.
 
-The client should check if the ``user_id``/``device_ie`` correspond to a device
+The client must also check that the ``user_id`` and ``device_id`` fields in the
+object match those in the top-level map [#]_.
+
+The client should check if the ``user_id``/``device_id`` correspond to a device
 it had seen previously. If it did, the client **must** check that the Ed25519
 key hasn't changed. Again, if it has changed, no further processing should be
 done on the device.
 
 Otherwise the client stores the information about this device.
+
+.. [#] This prevents a malicious or compromised homeserver replacing the keys
+       for the device with those of another.
 
 Sending an encrypted event
 --------------------------


### PR DESCRIPTION
Update the E2E impl guide to note that the user_id and device_id returned from
a device query need to be checked.