### PR TITLE
Move m.* thumbnail_url to be inside info to match m.video

### DIFF
--- a/event-schemas/examples/m.room.message#m.location
+++ b/event-schemas/examples/m.room.message#m.location
@@ -3,12 +3,14 @@
   "content": {
     "body": "Big Ben, London, UK",
     "geo_uri": "geo:51.5008,0.1247",
-    "thumbnail_url": "mxc://localhost/FHyPlCeYUSFFxlgbQYZmoEoe",
-    "thumbnail_info": {
-      "mimetype": "image/jpeg",
-      "size": 46144,
-      "w": 300,
-      "h": 300
+    "info": {
+      "thumbnail_url": "mxc://localhost/FHyPlCeYUSFFxlgbQYZmoEoe",
+      "thumbnail_info": {
+        "mimetype": "image/jpeg",
+        "size": 46144,
+        "w": 300,
+        "h": 300
+      }
     },
     "msgtype": "m.location"
   },

--- a/event-schemas/examples/m.room.message#m.location
+++ b/event-schemas/examples/m.room.message#m.location
@@ -19,4 +19,4 @@
   "room_id": "!jEsUZKDJdhlrceRyVU:localhost",
   "type": "m.room.message",
   "sender": "@example:localhost"
-} 
+}

--- a/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
@@ -18,7 +18,7 @@ properties:
     type: string
   thumbnail_info:
     allOf:
-      - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
+      - $ref: thumbnail_info.yaml
     description: Metadata about the image referred to in ``thumbnail_url``.
     title: ThumbnailInfo
     type: object

--- a/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
@@ -4,14 +4,14 @@ properties:
   h:
     description: The height of the image in pixels.
     type: integer
+  w:
+    description: The width of the image in pixels.
+    type: integer
   mimetype:
     description: The mimetype of the image, e.g. ``image/jpeg``.
     type: string
   size:
     description: Size of the image in bytes.
-    type: integer
-  w:
-    description: The width of the image in pixels.
     type: integer
   thumbnail_url:
     description: The URL to a thumbnail of the image.
@@ -20,6 +20,5 @@ properties:
     allOf:
       - $ref: thumbnail_info.yaml
     description: Metadata about the image referred to in ``thumbnail_url``.
-    title: ThumbnailInfo
-    type: object
 title: ImageInfo
+type: object

--- a/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/image_info.yaml
@@ -14,7 +14,7 @@ properties:
     description: The width of the image in pixels.
     type: integer
   thumbnail_url:
-    desciption: The URL to a thumbnail of the image.
+    description: The URL to a thumbnail of the image.
     type: string
   thumbnail_info:
     allOf:

--- a/event-schemas/schema/core-event-schema/msgtype_infos/thumbnail_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/thumbnail_info.yaml
@@ -4,14 +4,14 @@ properties:
   h:
     description: The height of the image in pixels.
     type: integer
+  w:
+    description: The width of the image in pixels.
+    type: integer
   mimetype:
     description: The mimetype of the image, e.g. ``image/jpeg``.
     type: string
   size:
     description: Size of the image in bytes.
-    type: integer
-  w:
-    description: The width of the image in pixels.
     type: integer
 title: ThumbnailInfo
 type: object

--- a/event-schemas/schema/core-event-schema/msgtype_infos/thumbnail_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/thumbnail_info.yaml
@@ -1,5 +1,5 @@
 $schema: http://json-schema.org/draft-04/schema#
-description: Metadata about an image.
+description: Metadata about a thumbnail image.
 properties:
   h:
     description: The height of the image in pixels.
@@ -13,13 +13,4 @@ properties:
   w:
     description: The width of the image in pixels.
     type: integer
-  thumbnail_url:
-    desciption: The URL to a thumbnail of the image.
-    type: string
-  thumbnail_info:
-    allOf:
-      - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
-    description: Metadata about the image referred to in ``thumbnail_url``.
-    title: ThumbnailInfo
-    type: object
-title: ImageInfo
+title: ThumbnailInfo

--- a/event-schemas/schema/core-event-schema/msgtype_infos/thumbnail_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/thumbnail_info.yaml
@@ -14,3 +14,4 @@ properties:
     description: The width of the image in pixels.
     type: integer
 title: ThumbnailInfo
+type: object

--- a/event-schemas/schema/m.room.avatar
+++ b/event-schemas/schema/m.room.avatar
@@ -11,15 +11,6 @@ properties:
         description: Metadata about the image referred to in ``url``.
         title: ImageInfo
         type: object
-      thumbnail_info:
-        allOf:
-          - $ref: core-event-schema/msgtype_infos/image_info.yaml
-        description: Metadata about the image referred to in ``thumbnail_url``.
-        title: ImageInfo
-        type: object
-      thumbnail_url:
-        description: The URL to the thumbnail of the image.
-        type: string
       url:
         description: The URL to the image.
         type: string

--- a/event-schemas/schema/m.room.avatar
+++ b/event-schemas/schema/m.room.avatar
@@ -9,8 +9,6 @@ properties:
         allOf:
           - $ref: core-event-schema/msgtype_infos/image_info.yaml
         description: Metadata about the image referred to in ``url``.
-        title: ImageInfo
-        type: object
       url:
         description: The URL to the image.
         type: string

--- a/event-schemas/schema/m.room.message#m.file
+++ b/event-schemas/schema/m.room.message#m.file
@@ -20,15 +20,15 @@ properties:
           size:
             description: The size of the file in bytes.
             type: integer
+          thumbnail_url:
+            description: The URL to the thumbnail of the file.
+            type: string
           thumbnail_info:
             allOf:
               - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
             description: Metadata about the image referred to in ``thumbnail_url``.
             title: ThumbnailInfo
             type: object
-          thumbnail_url:
-            description: The URL to the thumbnail of the file.
-            type: string
         title: FileInfo
         type: object
       msgtype:

--- a/event-schemas/schema/m.room.message#m.file
+++ b/event-schemas/schema/m.room.message#m.file
@@ -20,20 +20,20 @@ properties:
           size:
             description: The size of the file in bytes.
             type: integer
+          thumbnail_info:
+            allOf:
+              - $ref: core-event-schema/msgtype_infos/image_info.yaml
+            description: Metadata about the image referred to in ``thumbnail_url``.
+            title: ImageInfo
+            type: object
+          thumbnail_url:
+            description: The URL to the thumbnail of the file.
+            type: string
         title: FileInfo
         type: object
       msgtype:
         enum:
           - m.file
-        type: string
-      thumbnail_info:
-        allOf:
-          - $ref: core-event-schema/msgtype_infos/image_info.yaml
-        description: Metadata about the image referred to in ``thumbnail_url``.
-        title: ImageInfo
-        type: object
-      thumbnail_url:
-        description: The URL to the thumbnail of the file.
         type: string
       url:
         description: The URL to the file.

--- a/event-schemas/schema/m.room.message#m.file
+++ b/event-schemas/schema/m.room.message#m.file
@@ -27,8 +27,6 @@ properties:
             allOf:
               - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
             description: Metadata about the image referred to in ``thumbnail_url``.
-            title: ThumbnailInfo
-            type: object
         title: FileInfo
         type: object
       msgtype:

--- a/event-schemas/schema/m.room.message#m.file
+++ b/event-schemas/schema/m.room.message#m.file
@@ -22,9 +22,9 @@ properties:
             type: integer
           thumbnail_info:
             allOf:
-              - $ref: core-event-schema/msgtype_infos/image_info.yaml
+              - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
             description: Metadata about the image referred to in ``thumbnail_url``.
-            title: ImageInfo
+            title: ThumbnailInfo
             type: object
           thumbnail_url:
             description: The URL to the thumbnail of the file.

--- a/event-schemas/schema/m.room.message#m.image
+++ b/event-schemas/schema/m.room.message#m.image
@@ -23,20 +23,20 @@ properties:
           w:
             description: The width of the image in pixels.
             type: integer
+          thumbnail_info:
+            allOf:
+              - $ref: core-event-schema/msgtype_infos/image_info.yaml
+            description: Metadata about the image referred to in ``thumbnail_url``.
+            title: ImageInfo
+            type: object
+          thumbnail_url:
+            description: The URL to the thumbnail of the image.
+            type: string
         title: ImageInfo
         type: object
       msgtype:
         enum:
           - m.image
-        type: string
-      thumbnail_info:
-        allOf:
-          - $ref: core-event-schema/msgtype_infos/image_info.yaml
-        description: Metadata about the image referred to in ``thumbnail_url``.
-        title: ImageInfo
-        type: object
-      thumbnail_url:
-        description: The URL to the thumbnail of the image.
         type: string
       url:
         description: The URL to the image.

--- a/event-schemas/schema/m.room.message#m.image
+++ b/event-schemas/schema/m.room.message#m.image
@@ -9,29 +9,9 @@ properties:
         description: "A textual representation of the image. This could be the alt text of the image, the filename of the image, or some kind of content description for accessibility e.g. 'image attachment'."
         type: string
       info:
+        allOf:
+          - $ref: core-event-schema/msgtype_infos/image_info.yaml
         description: Metadata about the image referred to in ``url``.
-        properties:
-          h:
-            description: The height of the image in pixels.
-            type: integer
-          mimetype:
-            description: 'The mimetype of the image, e.g. ``image/jpeg``.'
-            type: string
-          size:
-            description: Size of the image in bytes.
-            type: integer
-          w:
-            description: The width of the image in pixels.
-            type: integer
-          thumbnail_info:
-            allOf:
-              - $ref: core-event-schema/msgtype_infos/image_info.yaml
-            description: Metadata about the image referred to in ``thumbnail_url``.
-            title: ImageInfo
-            type: object
-          thumbnail_url:
-            description: The URL to the thumbnail of the image.
-            type: string
         title: ImageInfo
         type: object
       msgtype:

--- a/event-schemas/schema/m.room.message#m.image
+++ b/event-schemas/schema/m.room.message#m.image
@@ -12,8 +12,6 @@ properties:
         allOf:
           - $ref: core-event-schema/msgtype_infos/image_info.yaml
         description: Metadata about the image referred to in ``url``.
-        title: ImageInfo
-        type: object
       msgtype:
         enum:
           - m.image

--- a/event-schemas/schema/m.room.message#m.location
+++ b/event-schemas/schema/m.room.message#m.location
@@ -20,8 +20,8 @@ properties:
         properties:
           thumbnail_info:
             allOf:
-              - $ref: core-event-schema/msgtype_infos/image_info.yaml
-            title: ImageInfo
+              - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
+            title: ThumbnailInfo
             type: object
           thumbnail_url:
             description: The URL to a thumbnail of the location being represented.

--- a/event-schemas/schema/m.room.message#m.location
+++ b/event-schemas/schema/m.room.message#m.location
@@ -15,14 +15,18 @@ properties:
         enum:
           - m.location
         type: string
-      thumbnail_info:
-        allOf:
-          - $ref: core-event-schema/msgtype_infos/image_info.yaml
-        title: ImageInfo
+      info:
         type: object
-      thumbnail_url:
-        description: The URL to a thumbnail of the location being represented.
-        type: string
+        properties:
+          thumbnail_info:
+            allOf:
+              - $ref: core-event-schema/msgtype_infos/image_info.yaml
+            title: ImageInfo
+            type: object
+          thumbnail_url:
+            description: The URL to a thumbnail of the location being represented.
+            type: string
+        title: LocationInfo
     required:
       - msgtype
       - body

--- a/event-schemas/schema/m.room.message#m.location
+++ b/event-schemas/schema/m.room.message#m.location
@@ -18,14 +18,13 @@ properties:
       info:
         type: object
         properties:
-          thumbnail_info:
-            allOf:
-              - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
-            title: ThumbnailInfo
-            type: object
           thumbnail_url:
             description: The URL to a thumbnail of the location being represented.
             type: string
+          thumbnail_info:
+            allOf:
+              - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
+            description:  Metadata about the image referred to in ``thumbnail_url``.
         title: LocationInfo
     required:
       - msgtype

--- a/event-schemas/schema/m.room.message#m.video
+++ b/event-schemas/schema/m.room.message#m.video
@@ -25,8 +25,8 @@ properties:
             type: integer
           thumbnail_info:
             allOf:
-              - $ref: core-event-schema/msgtype_infos/image_info.yaml
-            title: ImageInfo
+              - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
+            title: ThumbnailInfo
             type: object
           thumbnail_url:
             description: The URL to a thumbnail of the video clip.

--- a/event-schemas/schema/m.room.message#m.video
+++ b/event-schemas/schema/m.room.message#m.video
@@ -17,23 +17,22 @@ properties:
           h:
             description: The height of the video in pixels.
             type: integer
+          w:
+            description: The width of the video in pixels.
+            type: integer
           mimetype:
             description: The mimetype of the video e.g. ``video/mp4``.
             type: string
           size:
             description: The size of the video in bytes.
             type: integer
+          thumbnail_url:
+            description: The URL to an image thumbnail of the video clip.
+            type: string
           thumbnail_info:
             allOf:
               - $ref: core-event-schema/msgtype_infos/thumbnail_info.yaml
-            title: ThumbnailInfo
-            type: object
-          thumbnail_url:
-            description: The URL to a thumbnail of the video clip.
-            type: string
-          w:
-            description: The width of the video in pixels.
-            type: integer
+            description: Metadata about the image referred to in ``thumbnail_url``.
         title: VideoInfo
         type: object
       msgtype:

--- a/specification/modules/instant_messaging.rst
+++ b/specification/modules/instant_messaging.rst
@@ -71,6 +71,12 @@ Events which have attachments (e.g. ``m.image``, ``m.file``) SHOULD be
 uploaded using the `content repository module`_ where available. The
 resulting ``mxc://`` URI can then be used in the ``url`` key.
 
+Clients MAY include a client generated thumbnail image for an attachment under
+a ``info.thumbnail_url`` key. The thumbnail SHOULD also be a ``mxc://`` URI.
+Clients displaying events with attachments can either use the client generated
+thumbnail or ask its homeserver to generate a thumbnail from the original
+attachment using the `content repository module`_.
+
 .. _`content repository module`: `module:content`_
 
 Recommendations when sending messages


### PR DESCRIPTION
I've moved the thumbnail_{url,info} inside an "info" key for all types to be consistent with m.room.message#m.video.
I've added the thumbnail_{url,info} keys to the ImageInfo shared between m.room.mesage#image and m.room.avatar.
I've created a new ThumbnailInfo schema to avoid recursion within the ImageInfo schema.