### PR TITLE
update FAQ to mention Riot desktop version

### DIFF
--- a/supporting-docs/guides/2015-08-19-faq.md
+++ b/supporting-docs/guides/2015-08-19-faq.md
@@ -592,7 +592,7 @@ You can also run Vector, the code that Riot.im uses, on your own server. It's a 
 
 ##### Where can I find a desktop client?
 
-There are several, but they don't have all the features that synapse has. Check the list of clients on [matrix.org](http://matrix.org/docs/projects/try-matrix-now.html#clients).
+[Riot.im](https://Riot.im) has desktop versions (via electron) for Windows, macOS, and Linux.  There are several other clients, but they don't have all the features that Riot has. Check the list of clients on [matrix.org](http://matrix.org/docs/projects/try-matrix-now.html#clients).
 
 ##### Why can't end-to-end encryption be turned off?
 


### PR DESCRIPTION
The FAQ entry regarding desktop clients should be updated now that Riot has a desktop version.  (Also, that FAQ entry mistakenly refers to Synapse instead of Riot.)