### PR TITLE
Added status field to m.notice.

### DIFF
--- a/event-schemas/examples/m.room.message#m.notice
+++ b/event-schemas/examples/m.room.message#m.notice
@@ -1,7 +1,8 @@
 {
   "age": 242352,
   "content": {
-    "body": "This is an example notice",
+    "body": "Your coffee has brewed.",
+    "status": "info",
     "msgtype": "m.notice"
   },
   "origin_server_ts": 1431961217939,

--- a/event-schemas/schema/m.room.message#m.notice
+++ b/event-schemas/schema/m.room.message#m.notice
@@ -1,12 +1,20 @@
 ---
 allOf:
   - $ref: core-event-schema/room_event.yaml
-description: 'The ``m.notice`` type is primarily intended for responses from automated clients. An ``m.notice`` message must be treated the same way as a regular ``m.text`` message with two exceptions. Firstly, clients should present ``m.notice`` messages to users in a distinct manner, and secondly, ``m.notice`` messages must never be automatically responded to. This helps to prevent infinite-loop situations where two automated clients continuously exchange messages.'
+description: 'The ``m.notice`` type is primarily intended for responses from automated clients. An ``m.notice`` message must be treated the same way as a regular ``m.text`` message with two exceptions. Firstly, clients should present ``m.notice`` messages to users in a distinct manner, and secondly, ``m.notice`` messages must never be automatically responded to. This helps to prevent infinite-loop situations where two automated clients continuously exchange messages. The ``status`` field should be used by the client to display the state of a operation or the bot itself in a simple, elegant way such as an colour or icon.'
 properties:
   content:
     properties:
       body:
         description: The notice text to send.
+        type: string
+      status:
+        description: A status hint to the client that represents the result of an operation or the priority of a message.
+        enum:
+          - info
+          - warning
+          - error
+          - critical
         type: string
       msgtype:
         enum:

--- a/event-schemas/schema/m.room.message#m.notice
+++ b/event-schemas/schema/m.room.message#m.notice
@@ -15,6 +15,7 @@ properties:
           - warning
           - error
           - critical
+          - success
         type: string
       msgtype:
         enum:


### PR DESCRIPTION
Most of the time, notices are used by bots to respond to a user with either a failure or a success. "This is the gif we found" or "we couldn't find a gif called 'dog with a jetpack'". Right now bots all have their own phrasing for this whereas it could be part of the metadata of an event to include the status of an operation. Representing this on the client could be as simple as adding a warning triangle next to a message, or highlighting it in a sensible colour that works with the theme.

Problems:
* I came up with a few status options, but I'm not sure if that covers all of them, or too many.
* Should they start with ``m.`` or kept as is. That depends if custom statuses are a thing. I'd prefer them not to be, because that defeats the point of having statuses at all.

Example of how I expect it to look, in a messy CSS way.
![errornotice](https://cloud.githubusercontent.com/assets/2072976/23660171/77ba83c8-0340-11e7-91f6-0fd204e7e0f1.png)
