### PR TITLE
Fix device keys query

### DIFF
--- a/supporting-docs/guides/2016-10-18-e2e_implementation.rst
+++ b/supporting-docs/guides/2016-10-18-e2e_implementation.rst
@@ -432,8 +432,10 @@ The client should build a JSON query object as follows:
 .. code:: json
 
   {
-    "<user_id>": {},
-    ...
+    "device_keys": {
+      "<user_id>": {},
+      [...]
+    }
   }
 
 Each member in the room should be included in the query. This is then


### PR DESCRIPTION
Omitting the "device_keys" wrap results in an empty response.