### PR TITLE
Update AS spec username registration request body to match synapse expectation

### DIFF
--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -255,7 +255,7 @@ including the AS token on a ``/register`` request, along with a login type of
   Content:
   {
     type: "m.login.application_service",
-    username: "<desired user localpart in AS namespace>"
+    user: "<desired user localpart in AS namespace>"
   }
 
 Application services which attempt to create users or aliases *outside* of


### PR DESCRIPTION
While putting together matrix-org/matrix-python-sdk#108 I noticed that synapse expects `user: localpart` rather than `username: localpart`. If this is something that should be changed in synapse rather than the spec, I can prepare a PR there, too.