### PR TITLE
Update morpheus doc to point to correct location

### DIFF
--- a/supporting-docs/projects/2016-02-07-morpheus.md
+++ b/supporting-docs/projects/2016-02-07-morpheus.md
@@ -8,4 +8,4 @@ maturity: Alpha
 ---
 
 # {{ page.title }}
-A Matrix client written in Haskell ([github](https://github.com/Xe/morpheus))
+A Matrix client written in Haskell ([github](https://github.com/Xe/code/tree/master/other/morpheus))


### PR DESCRIPTION
Haven't reached out to @Xe, but it looks like development has ceased. Is the policy to keep clients in the list even after they've been shelved?