### PR TITLE
Be explicit about python2

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,7 @@ dependencies available by invoking `nix-shell contrib/shell.nix` in this
 directory.
 
 To generate the complete specification along with supporting documentation, run:
-    python gendoc.py
+    python2 gendoc.py
 
 The output of this will be inside the "scripts/gen" folder.
 

--- a/scripts/continuserv/main.go
+++ b/scripts/continuserv/main.go
@@ -164,7 +164,7 @@ func serve(w http.ResponseWriter, req *http.Request) {
 }
 
 func generate(dir string) (map[string][]byte, error) {
-	cmd := exec.Command("python", "gendoc.py")
+	cmd := exec.Command("python2", "gendoc.py")
 	cmd.Dir = path.Join(dir, "scripts")
 	var b bytes.Buffer
 	cmd.Stderr = &b
@@ -175,7 +175,7 @@ func generate(dir string) (map[string][]byte, error) {
 
 	// cheekily dump the swagger docs into the gen directory so that it is
 	// easy to serve
-	cmd = exec.Command("python", "dump-swagger.py", "gen/api-docs.json")
+	cmd = exec.Command("python2", "dump-swagger.py", "gen/api-docs.json")
 	cmd.Dir = path.Join(dir, "scripts")
 	cmd.Stderr = &b
 	if err := cmd.Run(); err != nil {

--- a/scripts/gendoc.py
+++ b/scripts/gendoc.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # Copyright 2016 OpenMarket Ltd
 #
@@ -272,7 +272,7 @@ def addAnchors(path):
 
 def run_through_template(input_files, set_verbose, substitutions):
     args = [
-        'python', 'build.py',
+        'python2', 'build.py',
         "-o", "../scripts/tmp",
         "-i", "matrix_templates",
     ]

--- a/scripts/speculator/main.go
+++ b/scripts/speculator/main.go
@@ -149,7 +149,7 @@ func (s *server) lookupBranch(branch string) (string, error) {
 }
 
 func generate(dir string) error {
-	cmd := exec.Command("python", "gendoc.py", "--nodelete")
+	cmd := exec.Command("python2", "gendoc.py", "--nodelete")
 	cmd.Dir = path.Join(dir, "scripts")
 	var b bytes.Buffer
 	cmd.Stderr = &b
@@ -159,7 +159,7 @@ func generate(dir string) error {
 
 	// cheekily dump the swagger docs into the gen directory so they can be
 	// served by serveSpec
-	cmd = exec.Command("python", "dump-swagger.py", "gen/api-docs.json")
+	cmd = exec.Command("python2", "dump-swagger.py", "gen/api-docs.json")
 	cmd.Dir = path.Join(dir, "scripts")
 	cmd.Stderr = &b
 	if err := cmd.Run(); err != nil {

--- a/scripts/swagger-http-server.py
+++ b/scripts/swagger-http-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Runs an HTTP server on localhost:8000 which will serve the generated swagger
 # JSON so that it can be viewed in an online swagger UI.


### PR DESCRIPTION
I tried to build the docs in Arch Linux (which symlinks /usr/bin/python to /usr/bin/python3) and noticed that the scripts expect "python" to be "python2".  The commit makes the python version in the scripts explicit to avoid this confusion.