### PR TITLE
Update Quaternion and libqmatrixclient records

### DIFF
--- a/supporting-docs/projects/2015-06-27-quaternion.md
+++ b/supporting-docs/projects/2015-06-27-quaternion.md
@@ -2,13 +2,13 @@
 layout: project
 title: Quaternion
 categories: projects client
-thumbnail: https://raw.githubusercontent.com/Fxrh/Quaternion/master/quaternion.png
-author: Fxrh
+thumbnail: https://raw.githubusercontent.com/QMatrixClient/Quaternion/master/quaternion.png
+author: Felix Rohrbach, Kitsune Ral
 description: Quaternion is an IM client for the Matrix protocol
-maturity: Alpha
+maturity: Late alpha
 ---
 
-![screenshot](https://raw.githubusercontent.com/Fxrh/Quaternion/master/quaternion.png "{{ page.title }}")
+![screenshot](https://raw.githubusercontent.com/QMatrixClient/Quaternion/master/quaternion.png "{{ page.title }}")
 
 # {{ page.title }}
-Quaternion is an IM client for the Matrix protocol in development. ([github](https://github.com/Fxrh/Quaternion))
+Quaternion is a Qt/QML-based IM client for the Matrix protocol in development. ([github](https://github.com/QMatrixClient/Quaternion))

--- a/supporting-docs/projects/2016-04-05-libqmatrixclient.md
+++ b/supporting-docs/projects/2016-04-05-libqmatrixclient.md
@@ -2,11 +2,11 @@
 layout: project
 title: libqmatrixclient
 categories: projects sdk
-author: Felix Rohrbach
-maturity: Alpha
+authors: Kitsune Ral, Felix Rohrbach
+maturity: Late alpha
 ---
 
 # {{ page.title }}
-libqmatrixclient is a Qt-based library to make IM clients for the Matrix protocol. It is used by the [Quaternion client](https://matrix.org/docs/projects/client/quaternion.html) and is a part of the Quaternion project. 
+libqmatrixclient is a Qt-based library to make IM clients for the Matrix protocol. It is used by the [Quaternion client](https://matrix.org/docs/projects/client/quaternion.html) and is a part of the Quaternion project. Recent builds of [Tensor](https://matrix.org/docs/projects/client/tensor.html) are also made on top of libqmatrixclient.
 
-The project lives in Felix Rohrbach's [github space](https://github.com/Fxrh/libqmatrixclient).
+The project lives in QMatrixClient [github space](https://github.com/QMatrixClient/libqmatrixclient).


### PR DESCRIPTION
Prominent changes:
- Both repos are now taken care of @QMatrixClient organisation (that consists of me and @fxrh)
- Added myself as a coauthor of both projects
- Status of both projects is now considered "late alpha":
  - Quaternion's functionality is still quite limited but the application is stable and can be used on daily basis;
  - libqmatrixclient API is still subject to sweeping changes, though this becomes more of an exception than a rule.