### PR TITLE
Tox.im -> Tox.chat

### DIFF
--- a/supporting-docs/guides/2015-08-19-faq.md
+++ b/supporting-docs/guides/2015-08-19-faq.md
@@ -289,11 +289,11 @@ PSYC's views on Matrix.
 
 ##### What is the difference between Matrix and Tox?
 
-Tox.im looks to be a very cool clone of Skype - a fully decentralised
+Tox.chat looks to be a very cool clone of Skype - a fully decentralised
 peer-to-peer network.  Matrix is deliberately not a 'pure' peer-to-peer
 system; instead each user has a well-defined homeserver which stores
 his data and that he can depend upon.  Matrix provides HTTP APIs;
-Tox.im provides C APIs.  As of October 2015 Tox doesn't seem to have an
+Tox.chat provides C APIs.  As of October 2015 Tox doesn't seem to have an
 answer yet for decentralised conversation history storage.
 
 ##### How does Matrix compare with something like Trillian or Pidgin?


### PR DESCRIPTION
https://tox.chat is the Tox project's official homepage, while Tox.im is their old page, that seems to have been taken over by a squatter linking to an old blog post.

Don't want to mislead people :)