### PR TITLE
Room member

### DIFF
--- a/api/client-server/room_state.yaml
+++ b/api/client-server/room_state.yaml
@@ -56,20 +56,22 @@ paths:
           name: eventType
           description: The type of event to send.
           required: true
-          x-example: "m.room.name"
+          x-example: "m.room.member"
         - in: path
           type: string
           name: stateKey
           description: The state_key for the state to send. Defaults to the empty string.
           required: true
-          x-example: ""
+          x-example: "@alice:example.com"
         - in: body
           name: body
           schema:
             type: object
             example: |-
               {
-                  "name": "New name for the room"
+                "membership": "join",
+                "avatar_url": "mxc://localhost/SEsfnsuifSDFSSEF#auto",
+                "displayname": "Alice Margatroid"
               }
       responses:
         200:

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -52,7 +52,7 @@
 - Spec clarifications:
 
   - Fixed an example of ``m.room.member`` event and added a clarification
-    on the membership event sent upon profile uppdate
+    on the membership event sent upon profile update
     (`#950 <https://github.com/matrix-org/matrix-doc/pull/950>`_).
   - Spell out the way that state is handled by ``POST /createRoom``
     (`#362 <https://github.com/matrix-org/matrix-doc/pull/362>`_).

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -51,8 +51,8 @@
 
 - Spec clarifications:
 
-  - Fixed an example of ``m.room.member`` event and added a clarification
-    on the membership event sent upon profile update
+  - Fixed examples of ``m.room.member`` event and room state change,
+    and added a clarification on the membership event sent upon profile update
     (`#950 <https://github.com/matrix-org/matrix-doc/pull/950>`_).
   - Spell out the way that state is handled by ``POST /createRoom``
     (`#362 <https://github.com/matrix-org/matrix-doc/pull/362>`_).

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -51,6 +51,9 @@
 
 - Spec clarifications:
 
+  - Fixed an example of ``m.room.member`` event and added a clarification
+    on the membership event sent upon profile uppdate
+    (`#950 <https://github.com/matrix-org/matrix-doc/pull/950>`_).
   - Spell out the way that state is handled by ``POST /createRoom``
     (`#362 <https://github.com/matrix-org/matrix-doc/pull/362>`_).
   - Clarify the fields which are applicable to different types of push rule

--- a/event-schemas/examples/m.room.member
+++ b/event-schemas/examples/m.room.member
@@ -1,7 +1,7 @@
 {
   "age": 242352,
   "content": {
-    "membership": "join",
+    "membership": "invite",
     "avatar_url": "mxc://localhost/SEsfnsuifSDFSSEF#auto",
     "displayname": "Alice Margatroid"
   },

--- a/event-schemas/examples/m.room.member
+++ b/event-schemas/examples/m.room.member
@@ -1,26 +1,10 @@
 {
   "age": 242352,
   "content": {
-    "membership": "invite",
+    "membership": "join",
     "avatar_url": "mxc://localhost/SEsfnsuifSDFSSEF#auto",
     "displayname": "Alice Margatroid"
   },
-  "invite_room_state": [
-    {
-      "type": "m.room.name",
-      "state_key": "",
-      "content": {
-        "name": "Forest of Magic"
-      }
-    },
-    {
-      "type": "m.room.join_rules",
-      "state_key": "",
-      "content": {
-        "join_rules": "invite"
-      }
-    }
-  ],
   "state_key": "@alice:localhost",
   "origin_server_ts": 1431961217939,
   "event_id": "$WLGTSEFSEF:localhost",

--- a/event-schemas/examples/m.room.member#invite_room_state
+++ b/event-schemas/examples/m.room.member#invite_room_state
@@ -1,7 +1,7 @@
 {
   "age": 242352,
   "content": {
-    "membership": "join",
+    "membership": "invite",
     "avatar_url": "mxc://localhost/SEsfnsuifSDFSSEF#auto",
     "displayname": "Alice Margatroid"
   },

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1341,8 +1341,8 @@ many places of a client's display, changes to these fields cause an automatic
 propagation event to occur, informing likely-interested parties of the new
 values. This change is conveyed using two separate mechanisms:
 
-- a ``m.room.member`` event is sent to every room the user is a member of,
-  to update the ``displayname`` and ``avatar_url``.
+- a ``m.room.member`` event (with a ``join`` membership) is sent to every room
+  the user is a member of, to update the ``displayname`` and ``avatar_url``.
 - a ``m.presence`` presence status update is sent, again containing the new
   values of the ``displayname`` and ``avatar_url`` keys, in addition to the
   required ``presence`` key containing the current presence state of the user.


### PR DESCRIPTION
* Fixed an incorrect `membership` attribute in an example (which was contradictory with the memberships list above it)
* Added a precision on the `membership` attribute of the `m.room.member` event sent upon a profile update