### PR TITLE
Fix inconsistency: `join_rules` => `join_rule`

### DIFF
--- a/event-schemas/examples/m.room.member#invite_room_state
+++ b/event-schemas/examples/m.room.member#invite_room_state
@@ -17,7 +17,7 @@
       "type": "m.room.join_rules",
       "state_key": "",
       "content": {
-        "join_rules": "invite"
+        "join_rule": "invite"
       }
     }
   ],


### PR DESCRIPTION
All other docs do not have `join_rules` but `join_rule`
This PR fix this inconsistency.

Mentioned by [@digital:sorunome.de](https://matrix.to/#/@digital:sorunome.de) in [#matrix-dev:matrix.org](https://matrix.to/#/!XqBunHwQIXUiqCaoxq:matrix.org/$150142347531959wjGGm:sorunome.de)