### PR TITLE
Add matterbridge to list of Matrix bridges

### DIFF
--- a/supporting-docs/projects/2017-08-21-matterbridge.md
+++ b/supporting-docs/projects/2017-08-21-matterbridge.md
@@ -7,6 +7,6 @@ maturity: Alpha
 ---
 
 # {{ page.title }}
-This project implement bridges between Matrix rooms and Mattermost, IRC, XMPP, Gitter, Slack, Discord, Telegram, Rocket.Chat, Hipchat(via xmpp), Steam.
+This project implements bridges between Matrix rooms and Mattermost, IRC, XMPP, Gitter, Slack, Discord, Telegram, Rocket.Chat, Hipchat(via xmpp), Steam.
 
 Get it and report issues at [github](https://github.com/42wim/matterbridge)!

--- a/supporting-docs/projects/2017-08-21-matterbridge.md
+++ b/supporting-docs/projects/2017-08-21-matterbridge.md
@@ -1,0 +1,12 @@
+---
+layout: project
+title: matterbridge
+categories: projects as
+author: 42wim
+maturity: Alpha
+---
+
+# {{ page.title }}
+This project implement bridges between Matrix rooms and Mattermost, IRC, XMPP, Gitter, Slack, Discord, Telegram, Rocket.Chat, Hipchat(via xmpp), Steam.
+
+Get it and report issues at [github](https://github.com/42wim/matterbridge)!

--- a/supporting-docs/projects/2017-08-21-matterbridge.md
+++ b/supporting-docs/projects/2017-08-21-matterbridge.md
@@ -1,12 +1,13 @@
 ---
 layout: project
 title: matterbridge
-categories: projects as
+categories: projects other
+description: Bot for bridging Matrix and Mattermost, IRC, XMPP, Gitter, Slack, Discord, Telegram, Rocket.Chat, Hipchat(via xmpp), Steam.
 author: 42wim
-maturity: Alpha
+maturity: Stable
 ---
 
 # {{ page.title }}
 This project implements bridges between Matrix rooms and Mattermost, IRC, XMPP, Gitter, Slack, Discord, Telegram, Rocket.Chat, Hipchat(via xmpp), Steam.
 
-Get it and report issues at [github](https://github.com/42wim/matterbridge)!
+Get it and report issues at [github](https://github.com/42wim/matterbridge)


### PR DESCRIPTION
@42wim please approve adding Mattermost to offical list of Matrix bridges at https://matrix.org/docs/projects/try-matrix-now.html#application-services webpage.