### PR TITLE
Add remote invites and third-party invites to the federation spec

### DIFF
--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -51,6 +51,10 @@
 
 - Spec clarifications:
 
+  - Add endpoints and logic for invites and third-party invites to the federation
+    spec and update the JSON of the request sent by the identity server upon 3PID
+    binding
+    (`#997 <https://github.com/matrix-org/matrix-doc/pull/997>`)
   - Fix response format and 404 example for room alias lookup
     (`#960 <https://github.com/matrix-org/matrix-doc/pull/960>`)
   - Fix examples of ``m.room.member`` event and room state change,

--- a/specification/identity_service_api.rst
+++ b/specification/identity_service_api.rst
@@ -239,19 +239,27 @@ At a later point, if the owner of that particular 3pid binds it with a Matrix us
  Content-Type: application/json
 
  {
-   "invites": [{
-     "mxid": "@foo:bar.com",
-     "token": "abc123",
-     "signatures": {
-       "my.id.server": {
-         "ed25519:0": "def987"
-       }
-     }
-   }],
-
-   "medium": "email",
-   "address": "foo@bar.com",
-   "mxid": "@foo:bar.com"
+  "medium": "email",
+  "address": "foo@bar.baz",
+  "mxid": "@alice:example.tld",
+  "invites": [
+    {
+      "medium": "email",
+      "address": "foo@bar.baz",
+      "mxid": "@alice:example.tld",
+      "room_id": "!something:example.tld",
+      "sender": "@bob:example.tld",
+      "signed": {
+        "mxid": "@alice:example.tld",
+        "signatures": {
+          "vector.im": {
+            "ed25519:0": "somesignature"
+          }
+        },
+        "token": "sometoken"
+      }
+    }
+  ]
  }
 
 Where the signature is produced using a long-term private key.

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -888,7 +888,7 @@ Verifying the invite
 When a homeserver receives a ``m.room.member`` invite event for a room it's in
 with a ``third_party_invite`` object, it must verify that the association between
 the third-party identifier initially invited to the room and the Matrix ID that
-claim to be bound to it has been verified without having to rely on a third-party
+claims to be bound to it has been verified without having to rely on a third-party
 server.
 
 To do so, it will fetch from the room's state events the ``m.room.third_party_invite``

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -818,8 +818,6 @@ phone number).
 This identifier and its bindings to Matrix IDs are verified by an identity server
 implementing the `Identity Service API`_.
 
-.. _`Identity Service API`: ../identity_service/unstable.html
-
 Cases where an association exists for a third-party identifier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1304,6 +1302,7 @@ that are too long.
 
 
 .. _`Invitation storage`: ../identity_service/unstable.html#invitation-storage
+.. _`Identity Service API`: ../identity_service/unstable.html
 .. _`Client-Server API`: ../client_server/unstable.html#m-room-member
 .. _`Inviting to a room`: #inviting-to-a-room
 .. _`Canonical JSON`: ../appendices.html#canonical-json

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -1300,7 +1300,6 @@ that are too long.
   [[TODO(markjh) We might want to allow the server to omit the output of well
   known hash functions like SHA-256 when none of the keys have been redacted]]
 
-
 .. _`Invitation storage`: ../identity_service/unstable.html#invitation-storage
 .. _`Identity Service API`: ../identity_service/unstable.html
 .. _`Client-Server API`: ../client_server/unstable.html#m-room-member

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -752,7 +752,7 @@ that requested by the requestor in the ``v`` parameter).
 Inviting to a room
 ------------------
 
-When a user wishes to invite an other user to a local room and this other user
+When a user wishes to invite an other user to a local room and the other user
 is on a different server, the inviting server will send a request to the invited
 server::
 

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -749,6 +749,64 @@ that requested by the requestor in the ``v`` parameter).
   Specify (or remark that it is unspecified) how the server handles divergent
   history. DFS? BFS? Anything weirder?
 
+Inviting to a room
+------------------
+
+When a user wishes to invite an other user to a local room and this other user
+is on a different server, the inviting server will send a request to the invited
+server::
+
+  PUT .../invite/{roomId}/{eventId}
+
+The required fields in the JSON body are:
+
+==================== ======== ============
+ Key                  Type     Description
+==================== ======== ============
+``room_id``          String   The room ID of the room. Must be the same as the
+                              room ID specified in the path.
+``event_id``         String   The ID of the event. Must be the same as the event
+                              ID specified in the path.
+``type``             String   The value ``m.room.member``.
+``auth_events``      List     An event-reference list containing the IDs of the
+                              authorization events that would allow this member
+                              to be invited in the room.
+``content``          Object   The content of the event.
+``depth``            Integer  The depth of the event.
+``origin``           String   The name of the inviting homeserver.
+``origin_server_ts`` Integer  A timestamp added by the inviting homeserver.
+``prev_events``      List     An event-reference list containing the IDs of the
+                              immediate predecessor events.
+``sender``           String   The Matrix ID of the user who sent the original
+                              `m.room.third_party_invite`.
+``state_key``        String   The Matrix ID of the invited user.
+``signatures``       Object   The signature of the event from the origin server.
+``unsigned``         Object   An object containing the properties that aren't
+                              part of the signature's computation.
+==================== ======== ============
+
+Where the ``content`` key contains the content for the ``m.room.member`` event
+specified in the `Client-Server API`_. Note that the ``membership`` property of
+the content must be ``invite``.
+
+Upon receiving this request, the invited homeserver will append its signature to
+the event and respond to the request with the following JSON body::
+
+ [
+   200,
+   "event": {...}
+ ]
+
+Where ``event`` contains the event signed by both homeservers, using the same
+JSON keys as the initial request on ``/invite/{roomId}/{eventId}``. Note that,
+except for the ``signatures`` object (which now contains an additional signature),
+all of the event's keys remain the same as in the event initially provided.
+
+This response format is due to a typo in Synapse, the first implementation of
+Matrix's APIs, and is preserved to maintain compatibility.
+
+Now that the event has been signed by both the inviting homeserver and the
+invited homeserver, it can be sent to all of the users in the room.
 
 Authentication
 --------------
@@ -1143,5 +1201,8 @@ that are too long.
   [[TODO(markjh) We might want to allow the server to omit the output of well
   known hash functions like SHA-256 when none of the keys have been redacted]]
 
+
+.. _`Invitation storage`: ../identity_service/unstable.html#invitation-storage
+.. _`Client-Server API`: ../client_server/unstable.html#m-room-member
 .. _`Canonical JSON`: ../appendices.html#canonical-json
 .. _`Unpadded Base64`:  ../appendices.html#unpadded-base64


### PR DESCRIPTION
This PR:

* Adds a "Inviting to a room" section to the federation spec explaining how to send a `m.room.member` invite event to a remote server
* Adds a "Third-party invites" section to the federation spec explaining the process and logic for handling third-party invites
* Updates the body of the `POST .../_matrix/federation/v1/3pid/onbind` request specified in the identity service spec

Fixes #989 
Fixes #991 
Fixes #992 