### PR TITLE
Add status for unknown user's filter ID

### DIFF
--- a/api/client-server/filter.yaml
+++ b/api/client-server/filter.yaml
@@ -147,5 +147,7 @@ paths:
             type: object
             allOf:
               - $ref: "definitions/sync_filter.yaml"
+        400:
+          description: "Unknown filter."
       tags:
         - Room participation

--- a/api/client-server/filter.yaml
+++ b/api/client-server/filter.yaml
@@ -147,7 +147,7 @@ paths:
             type: object
             allOf:
               - $ref: "definitions/sync_filter.yaml"
-        400:
+        404:
           description: "Unknown filter."
       tags:
         - Room participation


### PR DESCRIPTION
This PR fixes a spec omission about the specific status code returned when an unknown user's filter ID is requested.

Signed-off-by: Max Dor @ Kamax.io (no email to avoid spam)