### PR TITLE
Specify namespaces for tags

### DIFF
--- a/specification/modules/tags.rst
+++ b/specification/modules/tags.rst
@@ -56,6 +56,14 @@ Two special names are listed in the specification:
 
 {{m_tag_event}}
 
+Tags namespaces are defined in the following way, depending on how the client are expected to interpret them:
+
+* The namespace ``m.*`` is reserved for tags defined in the current specification
+* The namespace ``u.*`` is reserved for user-defined tags, and the client should not try to interpret as anything other than an utf8 string
+* A client or app willing to use special tags for advanced functionnality should namespace them similarly to state keys: ``tld.name.*``
+* Any tag in the ``tld.name.*`` form but not matching the namespace of the current client should be ignored
+* Any tag not matching the previous rules should be interpreted as an user tag from the ``u.*`` namespace
+
 Client Behaviour
 ----------------
 


### PR DESCRIPTION
This is a proposition for closing #931, which as received very little feedback for a long time.

This should be a fairly uncontroversial addition (apart from bike-shedding), which only defines behavior for clients that want use tags or expose tagging functionality to their users.

The idea of adding this to the spec is to ensure clients can peacefully share the tag namespace without conflicting with each other, using rules similar to namespaces for state keys.

Note that as no client currently exposes tag functionality to their users (apart from the speced `m.favourite` and `m.lowpriority` tags), this change to the spec does not require any implementation in neither synapse nor riot, but should hopefully ensure a smooth inter-operation between different clients on this matter.