### PR TITLE
Add missing required key for sync format

### DIFF
--- a/api/client-server/definitions/event.yaml
+++ b/api/client-server/definitions/event.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 properties:
+  event_id:
+    description: The ID of this event.
+    type: string
   content:
     description: The content of this event. The fields in this object will vary depending
       on the type of event.


### PR DESCRIPTION
`event_id` is missing into the `Event` format.

Signed-off-by: Max Dor @ Kamax.io (no email to avoid spam)