### PR TITLE
Spec /account/whoami

### DIFF
--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -13,15 +13,13 @@
 # limitations under the License.
 swagger: '2.0'
 info:
-  title: "Matrix Client-Server Client Config API"
+  title: "Matrix Client-Server Account Identification API"
   version: "1.0.0"
 host: localhost:8008
 schemes:
   - https
   - http
 basePath: /_matrix/client/%CLIENT_MAJOR_VERSION%
-consumes:
-  - application/json
 produces:
   - application/json
 securityDefinitions:
@@ -31,8 +29,7 @@ paths:
     get:
       summary: Gets information about the owner of an access token.
       description: |-
-        Gets information about the owner of a given access token. Currently this
-        only supports returning the user id that owns the token.
+        Gets information about the owner of a given access token.
       security:
         - accessToken: []
       parameters: []

--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -43,6 +43,7 @@ paths:
               }
           schema:
             type: object
+            required: ["user_id"]
             properties:
               user_id:
                 type: string

--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -1,0 +1,54 @@
+# Copyright 2017 Travis Ralston
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+swagger: '2.0'
+info:
+  title: "Matrix Client-Server Client Config API"
+  version: "1.0.0"
+host: localhost:8008
+schemes:
+  - https
+  - http
+basePath: /_matrix/client/%CLIENT_MAJOR_VERSION%
+consumes:
+  - application/json
+produces:
+  - application/json
+securityDefinitions:
+  $ref: definitions/security.yaml
+paths:
+  "/account/whoami":
+    get:
+      summary: Gets information about the owner of an access token.
+      description: |-
+        Gets information about the owner of a given access token. Currently this
+        only supports returning the user id that owns the token.
+      security:
+        - accessToken: []
+      parameters: []
+      responses:
+        200:
+          description:
+            The account_data was successfully added.
+          examples:
+            application/json: {
+                "user_id": "@joe:example.org"
+              }
+          schema:
+            type: object
+            properties:
+              user_id:
+                type: string
+                description: The user id that owns the access token.
+      tags:
+        - User data

--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -39,7 +39,7 @@ paths:
       responses:
         200:
           description:
-            The account_data was successfully added.
+            The token belongs to a known user.
           examples:
             application/json: {
                 "user_id": "@joe:example.org"

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -60,6 +60,9 @@
     - ``GET /rooms/{roomId}/joined_members``
       (`#999 <https://github.com/matrix-org/matrix-doc/pull/999>`_).
 
+    - ``GET /account/whoami``
+      (`#1063 <https://github.com/matrix-org/matrix-doc/pull/1063>`_).
+
 - Spec clarifications:
 
   - Add endpoints and logic for invites and third-party invites to the federation

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -786,6 +786,11 @@ This is independent of any information kept by any Identity Servers.
 
 {{administrative_contact_cs_http_api}}
 
+Current account information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+{{whoami_cs_http_api}}
+
 Pagination
 ----------
 


### PR DESCRIPTION
Clients may wish to be able to identify which user they are supposed to be representing from only an access token. This new endpoint gives limited information to the client about the authenticated user.