### PR TITLE
Use proper room event type for redaction

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -584,13 +584,13 @@ the state of the room.
 
    #. Otherwise, allow.
 
-#. If type is ``m.room.redact``:
+#. If type is ``m.room.redaction``:
 
    #. If the ``sender``'s power level is greater than or equal to the *redact
       level*, allow.
 
    #. If the ``sender`` of the event being redacted is the same as the
-      ``sender`` of the ``m.room.redact``, allow.
+      ``sender`` of the ``m.room.redaction``, allow.
 
    #. Otherwise, reject.
 


### PR DESCRIPTION
The SS spec refers to the redaction room event ID as `m.room.redact` in the rules where it should be `m.room.redaction` as per other various spec locations and synapse/dendrite code and data in DB.

This PR fixes references to `m.room.redact` and use `m.room.redaction` instead.

Signed-off-by: Max Dor @ Kamax.io