### PR TITLE
Add createRoom guest_can_join parameter

### DIFF
--- a/api/client-server/create_room.yaml
+++ b/api/client-server/create_room.yaml
@@ -179,6 +179,10 @@ paths:
                   This flag makes the server set the ``is_direct`` flag on the
                   ``m.room.member`` events sent to the users in ``invite`` and
                   ``invite_3pid``. See `Direct Messaging`_ for more information.
+              guest_can_join:
+                type: boolean
+                description: |-
+                  Allows guests to join the room. See `Guest Access`_ for more information.
       responses:
         200:
           description: Information about the newly created room.

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -61,6 +61,8 @@ r0.3.0
   - Add ``m.room.pinned_events`` state event for rooms.
     (`#1007 <https://github.com/matrix-org/matrix-doc/pull/1007>`_).
   - Add mention of ability to send Access Token via an Authorization Header.
+  - Add ``guest_can_join`` parameter to ``POST /createRoom``
+    (`#1093 <https://github.com/matrix-org/matrix-doc/pull/1093>`_).
 
   - New endpoints:
 


### PR DESCRIPTION
Added an undocumented parameter for `createRoom` found in Synapse implementation.

Synapse implementation:
https://github.com/matrix-org/synapse/blob/master/synapse/handlers/room.py#L363

Signed-off-by: Thibaut CHARLES <cromfr@gmail.com>