### PR TITLE
Fix example in email based registration endpoint

### DIFF
--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -215,7 +215,7 @@ paths:
               send_attempt:
                 type: number
                 description: Used to distinguish protocol level retries from requests to re-send the email.
-                example: "1"
+                example: 1
             required: ["client_secret", "email", "send_attempt"]
       responses:
         200:


### PR DESCRIPTION
The spec says `send_attempt` should be a number, but the example shows it as a string.

Signed-off-by: Gergely Polonkai <gergely@polonkai.eu>