### PR TITLE
Mark `home_server` field deprecated

### DIFF
--- a/api/client-server/login.yaml
+++ b/api/client-server/login.yaml
@@ -112,11 +112,12 @@ paths:
               home_server:
                 type: string
                 description: |-
-                  The server_name of the homeserver on which the account has been registered.
+                  The server_name of the homeserver on which the account has
+                  been registered.
 
                   **Deprecated**. Clients should extract the server_name from
-                  ``user_id`` if they require it. Note also that ``homeserver``
-                  is not spelt this way.
+                  ``user_id`` (by splitting at the first colon) if they require
+                  it. Note also that ``homeserver`` is not spelt this way.
               device_id:
                 type: string
                 description: |-

--- a/api/client-server/login.yaml
+++ b/api/client-server/login.yaml
@@ -96,7 +96,6 @@ paths:
             application/json: {
                 "user_id": "@cheeky_monkey:matrix.org",
                 "access_token": "abc123",
-                "home_server": "matrix.org",
                 "device_id": "GHTYAJCE"
               }
           schema:
@@ -112,7 +111,12 @@ paths:
                   This access token can then be used to authorize other requests.
               home_server:
                 type: string
-                description: The hostname of the homeserver on which the account has been registered.
+                description: |-
+                  The server_name of the homeserver on which the account has been registered.
+
+                  **Deprecated**. Clients should extract the server_name from
+                  ``user_id`` if they require it. Note also that ``homeserver``
+                  is not spelt this way.
               device_id:
                 type: string
                 description: |-

--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -144,11 +144,12 @@ paths:
               home_server:
                 type: string
                 description: |-
-                  The server_name of the homeserver on which the account has been registered.
+                  The server_name of the homeserver on which the account has
+                  been registered.
 
                   **Deprecated**. Clients should extract the server_name from
-                  ``user_id`` if they require it. Note also that ``homeserver``
-                  is not spelt this way.
+                  ``user_id`` (by splitting at the first colon) if they require
+                  it. Note also that ``homeserver`` is not spelt this way.
               device_id:
                 type: string
                 description: |-

--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -124,7 +124,6 @@ paths:
             application/json: {
                 "user_id": "@cheeky_monkey:matrix.org",
                 "access_token": "abc123",
-                "home_server": "matrix.org",
                 "device_id": "GHTYAJCE"
               }
           schema:
@@ -144,7 +143,12 @@ paths:
                   This access token can then be used to authorize other requests.
               home_server:
                 type: string
-                description: The hostname of the homeserver on which the account has been registered.
+                description: |-
+                  The server_name of the homeserver on which the account has been registered.
+
+                  **Deprecated**. Clients should extract the server_name from
+                  ``user_id`` if they require it. Note also that ``homeserver``
+                  is not spelt this way.
               device_id:
                 type: string
                 description: |-

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -1,7 +1,11 @@
 Unreleased changes
 ==================
 
-No changes as yet.
+- Spec clarifications:
+
+  - Mark ``home_server`` return field for ``/login`` and ``/register``
+    endpoints as deprecated
+    (`#1097 <https://github.com/matrix-org/matrix-doc/pull/1097>`_).
 
 r0.3.0
 ======


### PR DESCRIPTION
This is spelt wrong, and is redundant to user_id, so let's stop people using it.