### PR TITLE
Forbid colons in MXIDs

### DIFF
--- a/specification/appendices/identifier_grammar.rst
+++ b/specification/appendices/identifier_grammar.rst
@@ -139,7 +139,7 @@ history includes events with a ``sender`` which does not conform. In order to
 handle these rooms successfully, clients and servers MUST accept user IDs with
 localparts from the expanded character set::
 
-  extended_user_id_char = %x21-7E
+  extended_user_id_char = %x21-39 / %x3B-7F  ; all ascii printing chars except :
 
 Mapping from other character sets
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
There is a single (AS) user on matrix.org who has a colon in their localpart,
but I suspect that is an artifact of old bridge code and won't work over
federation anyway.

Colons in MXIDs are particularly harmful because they make it impossible to
split mxids into local- and remote-parts