### PR TITLE
send_join: clarify auth_chain description

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -941,7 +941,7 @@ following keys:
 ============== ===== ============
  Key            Type  Description
 ============== ===== ============
-``auth_chain`` List  A list of events giving the all of the events in the auth
+``auth_chain`` List  A list of events giving all of the events in the auth
                      chains for the join event and the events in ``state``.
 ``state``      List  A complete list of the prevailing state events at the
                      instant just before accepting the new ``m.room.member``

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -941,11 +941,11 @@ following keys:
 ============== ===== ============
  Key            Type  Description
 ============== ===== ============
-``auth_chain`` List  A list of events giving the authorization chain for this
-                     join event
+``auth_chain`` List  A list of events giving the all of the events in the auth
+                     chains for the join event and the events in ``state``.
 ``state``      List  A complete list of the prevailing state events at the
                      instant just before accepting the new ``m.room.member``
-                     event
+                     event.
 ============== ===== ============
 
 .. TODO-spec


### PR DESCRIPTION
The auth_chain field should contain all of the auth events required to auth the
state events, as well as those required to auth the join event itself.

(cf https://github.com/matrix-org/synapse/blob/e148438/synapse/handlers/federation.py#L1076-L1077).