### PR TITLE
Add identicon spec

### DIFF
--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -269,3 +269,32 @@ paths:
             "$ref": "definitions/error.yaml"
       tags:
         - Media
+  "/identicon/{seed}":
+    get:
+      summary: "Generates an identicon for the given seed string"
+      description: |-
+        Generates an `identicon <https://en.wikipedia.org/wiki/Identicon>`_ for the given seed
+      operationId: getIdenticon
+      produces: ["image/*"]
+      parameters:
+        - in: path
+          type: string
+          x-example: "my_cool_username"
+          name: seed
+          description: "The seed for the identicon generator"
+          required: false
+      responses:
+        200:
+          description: "The identicon for the seed string"
+          headers:
+            Content-Type:
+              description: "The content type of the identicon. Should be an image."
+              type: "string"
+          schema:
+            type: file
+        429:
+          description: This request was rate-limited.
+          schema:
+            "$ref": "definitions/error.yaml"
+      tags:
+        - Media

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -318,6 +318,7 @@ paths:
           x-example: "my_cool_username"
           name: seed
           description: "The seed for the identicon generator"
+          required: true
         - in: query
           type: integer
           x-example: 96

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -283,6 +283,18 @@ paths:
           name: seed
           description: "The seed for the identicon generator"
           required: false
+        - in: query
+          type: integer
+          x-example: 96
+          name: width
+          description: |-
+            The width of the identicon to generate. Defaults to 96.
+        - in: query
+          type: integer
+          x-example: 96
+          name: height
+          description: |-
+            The height of the identicon to generate. Defaults to the width.
       responses:
         200:
           description: "The identicon for the seed string"

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -269,6 +269,42 @@ paths:
             "$ref": "definitions/error.yaml"
       tags:
         - Media
+  "/identicon":
+    get:
+      summary: "Generates an identicon with an empty string as the seed"
+      description: |-
+        Generates an `identicon <https://en.wikipedia.org/wiki/Identicon>`_ with an empty string
+        as the seed
+      operationId: getIdenticon
+      produces: ["image/*"]
+      parameters:
+        - in: query
+          type: integer
+          x-example: 96
+          name: width
+          description: |-
+            The width of the identicon to generate. Defaults to 96.
+        - in: query
+          type: integer
+          x-example: 96
+          name: height
+          description: |-
+            The height of the identicon to generate. Defaults to the width.
+      responses:
+        200:
+          description: "The identicon for the seed string"
+          headers:
+            Content-Type:
+              description: "The content type of the identicon. Should be an image."
+              type: "string"
+          schema:
+            type: file
+        429:
+          description: This request was rate-limited.
+          schema:
+            "$ref": "definitions/error.yaml"
+      tags:
+        - Media
   "/identicon/{seed}":
     get:
       summary: "Generates an identicon for the given seed string"
@@ -282,7 +318,6 @@ paths:
           x-example: "my_cool_username"
           name: seed
           description: "The seed for the identicon generator"
-          required: false
         - in: query
           type: integer
           x-example: 96

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -8,7 +8,7 @@ Unreleased changes
     - ``POST /user_directory/search``
       (`#1096 <https://github.com/matrix-org/matrix-doc/pull/1096>`_).
 
-    - ``GET /media/{version}/identicon``
+    - ``GET /media/{version}/identicon/{optionalSeed}``
       (`#1102 <https://github.com/matrix-org/matrix-doc/pull/1102>`_).
 
 - Spec clarifications:

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -8,6 +8,9 @@ Unreleased changes
     - ``POST /user_directory/search``
       (`#1096 <https://github.com/matrix-org/matrix-doc/pull/1096>`_).
 
+    - ``GET /media/{version}/identicon``
+      (`#1102 <https://github.com/matrix-org/matrix-doc/pull/1102>`_).
+
 - Spec clarifications:
 
   - Mark ``home_server`` return field for ``/login`` and ``/register``


### PR DESCRIPTION
Adds a spec for identicons, based on the synapse implementation: https://github.com/matrix-org/synapse/blob/master/synapse/rest/media/v1/identicon_resource.py