### PR TITLE
Typo in client-server spec: ether -> either

### DIFF
--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -192,7 +192,7 @@ requests can be handled correctly.
 
 By default, the `Login`_ and `Registration`_ processes auto-generate a new
 ``device_id``. A client is also free to generate its own ``device_id`` or,
-provided the user remains the same, reuse a device: in ether case the client
+provided the user remains the same, reuse a device: in either case the client
 should pass the ``device_id`` in the request body. If the client sets the
 ``device_id``, the server will invalidate any access token previously assigned
 to that device. There is therefore at most one active access token assigned to


### PR DESCRIPTION
I'm not sure about versioning - presumably this may need to be backported to previous versions of the spec?