### PR TITLE
Spec a format for calendar events in rooms.

### DIFF
--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -23,6 +23,11 @@ Unreleased changes
   - Add 'token' parameter to /keys/query endpoint
     (`#1104 <https://github.com/matrix-org/matrix-doc/pull/1104>`_).
 
+- New Event Types:
+
+    - ``m.room.calendar.event``
+      (`#1116 <https://github.com/matrix-org/matrix-doc/pull/1116>`_).
+
 r0.3.0
 ======
 

--- a/event-schemas/examples/m.room.calendar.event
+++ b/event-schemas/examples/m.room.calendar.event
@@ -1,0 +1,33 @@
+{
+  "age": 242352,
+  "content": {
+      "title": "Party at Bob's House",
+      "start_time": 922838400000,
+      "end_time": 922924800000,
+      "location_description": "123 Fake Street",
+      "location": {
+        "geometry": {
+          "type": "Point",
+          "coordinates": [125.6, 10.1]
+        }
+      },
+      "description": {
+        "body": "Party at Bob's house to celebrate the release of a sci-fi film. *Bring 🍺 and 🍿*",
+        "formatted_body":  "Party at Bob's house to celebrate the release of a sci-fi film. <i>Bring 🍺 and 🍿</i>",
+        "format": "org.matrix.custom.html"
+      },
+      "thumbnail": {
+        "uri": "mxc://localhost/JWEIFJgwEIhweiWJE",
+        "width": 256,
+        "height": 256,
+        "mimetype": "image/jpeg",
+        "size": 1024000
+      }
+  },
+  "state_key": "",
+  "origin_server_ts": 1431961217939,
+  "event_id": "$WLGTSEFSEF:localhost",
+  "type": "m.room.name",
+  "room_id": "!Cuyf34gef24t:localhost",
+  "sender": "@bob:localhost"
+}

--- a/event-schemas/examples/m.room.calendar.event
+++ b/event-schemas/examples/m.room.calendar.event
@@ -24,7 +24,6 @@
         "size": 1024000
       }
   },
-  "state_key": "",
   "origin_server_ts": 1431961217939,
   "event_id": "$WLGTSEFSEF:localhost",
   "type": "m.room.calendar.event",

--- a/event-schemas/examples/m.room.calendar.event
+++ b/event-schemas/examples/m.room.calendar.event
@@ -12,8 +12,8 @@
         }
       },
       "description": {
-        "body": "Party at Bob's house to celebrate the release of a sci-fi film. *Bring 🍺 and 🍿*",
-        "formatted_body":  "Party at Bob's house to celebrate the release of a sci-fi film. <i>Bring 🍺 and 🍿</i>",
+        "body": "Party at Bob's house to celebrate the release of a sci-fi film. *Bring beer and popcorn*",
+        "formatted_body":  "Party at Bob's house to celebrate the release of a sci-fi film. <i>Bring beer and popcorn</i>",
         "format": "org.matrix.custom.html"
       },
       "thumbnail": {
@@ -27,7 +27,7 @@
   "state_key": "",
   "origin_server_ts": 1431961217939,
   "event_id": "$WLGTSEFSEF:localhost",
-  "type": "m.room.name",
+  "type": "m.room.calendar.event",
   "room_id": "!Cuyf34gef24t:localhost",
   "sender": "@bob:localhost"
 }

--- a/event-schemas/schema/m.room.calendar.event
+++ b/event-schemas/schema/m.room.calendar.event
@@ -7,7 +7,7 @@ properties:
   content:
     properties:
       title:
-        description: Descriptive shortname name for the event.
+        description: Descriptive short name for the event.
         type: string
       start_time:
         description: When the event is due to start in milliseconds since epoch, UTC time.
@@ -19,7 +19,7 @@ properties:
         description: A string representation of the location of the event.
         type: string
       location:
-        description: A object containing valid GeoJSON
+        description: An object containing valid GeoJSON
         type: object
       description:
         properties:
@@ -38,7 +38,7 @@ properties:
       thumbnail:
         properties:
           uri:
-            description: Matrix MXC uri of the thumbnail.
+            description: The content URI to the thumbnail.
             type: string
           width:
             description: Width of the thumbnail.
@@ -54,7 +54,6 @@ properties:
             type: integer
         required:
           - uri
-          - mimetype
         type: object
     required:
       - title

--- a/event-schemas/schema/m.room.calendar.event
+++ b/event-schemas/schema/m.room.calendar.event
@@ -1,0 +1,68 @@
+---
+$schema: http://json-schema.org/draft-04/schema#
+allOf:
+  - $ref: core-event-schema/room_event.yaml
+description: This event represents a single calendar event item. Clients may convert this into other formats such as iCal for users to put into third party calendars.
+properties:
+  content:
+    properties:
+      title:
+        description: Descriptive shortname name for the event.
+        type: string
+      start_time:
+        description: When the event is due to start in milliseconds since epoch, UTC time.
+        type: integer
+      end_time:
+        description: When the event is due to end in milliseconds since epoch, UTC time.
+        type: integer
+      location_description:
+        description: A string representation of the location of the event.
+        type: string
+      location:
+        description: A object containing valid GeoJSON
+      description:
+        properties:
+          body:
+            description: Plaintext long description for the event.
+            type: string
+          formatted_body:
+            description: Formatted long description for the event.
+            type: string
+          format:
+            description: Format type of the formatted_body.
+            type: string
+        required:
+          - body
+        type: object
+      thumbnail:
+        properties:
+          uri:
+            description: Matrix MXC uri of the thumbnail.
+            type: string
+          width:
+            description: Width of the thumbnail.
+            type: integer
+          height:
+            description: Height of the thumbnail.
+            type: integer
+          mimetype:
+            description: Mimetype of the thumbnail.
+            type: string
+          size:
+            description: Size in bytes of the thumbnail.
+            type: integer
+        required:
+          - uri
+          - mimetype
+        type: object
+    required:
+      - title
+      - start_time
+      - end_time
+    type: object
+  type:
+    enum:
+      - m.room.calendar.event
+    type: string
+title: Calendar Event
+type: object

--- a/event-schemas/schema/m.room.calendar.event
+++ b/event-schemas/schema/m.room.calendar.event
@@ -20,6 +20,7 @@ properties:
         type: string
       location:
         description: A object containing valid GeoJSON
+        type: object
       description:
         properties:
           body:

--- a/specification/events.rst
+++ b/specification/events.rst
@@ -70,4 +70,10 @@ prefixed with ``m.``
 
 {{m_room_redaction_event}}
 
+Room Calendar Events
+--------------------
+
+{{m_room_calendar_event_event}}
+
+
 .. _`Canonical JSON`: ../appendices.html#canonical-json


### PR DESCRIPTION
in the form of ``m.room.calendar event``.

The idea behind this is that it will let people create/upload calendar events in a universal matrix format, look prettier than a iCal and eventually integrate with aggregations and replies so that matrix users can respond to them.

GDoc: https://docs.google.com/document/d/1kfR5aVflEtZ9spHkqa2gOkS5eGr6nYfWVY7BcM5DAZg/edit?usp=sharing

Discsussion Room: https://matrix.to/#/#mcalsupport:half-shot.uk