### PR TITLE
Document transaction and related endpoints

### DIFF
--- a/api/server-server/room_get_missing_events.yaml
+++ b/api/server-server/room_get_missing_events.yaml
@@ -1,0 +1,85 @@
+# Copyright 2018 Kamax.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+swagger: '2.0'
+info:
+  title: "Matrix Federation Get Missing Events API"
+  version: "1.0.0"
+host: localhost:8448
+schemes:
+  - https
+basePath: /_matrix/federation/v1
+produces:
+  - application/json
+paths:
+  "/get_missing_events/{roomId}":
+    post:
+      summary: Get missing events within a room.
+      description: "**UNKNOWN**"
+      operationId: getMissingEventsInRoom
+      parameters:
+        - in: path
+          name: roomId
+          description: The room in which the search should be done.
+          type: string
+          example: "!roomId:example.org"
+        - in: body
+          name: body
+          schema:
+            type: object
+            properties:
+              earliest_events:
+                type: array
+                description: "**UNKNOWN**"
+                items:
+                  type: string
+                  title: Events
+                  example: "$earlyEventId:example.org"
+              latest_events:
+                type: array
+                description: "**UNKNOWN**"
+                items:
+                  type: string
+                  title: Events
+                  example: "$lateEventId:example.org"
+              min_depth:
+                type: integer
+                description: "**UNKNOWN**"
+                example: 1
+              limit:
+                type: integer
+                description: "**UNKNOWN**"
+                example: 10
+            required:
+              - "earliest_events"
+      responses:
+        200:
+          description: The request was processed successfully.
+          examples:
+            application/json: {
+              "events": [
+                {}
+              ]
+            }
+          schema:
+            type: object
+            properties:
+              events:
+                type: array
+                description: "**UNKNOWN**"
+                items:
+                  type: object
+                  title: PDUs
+            required:
+              - "events"

--- a/api/server-server/room_get_missing_events.yaml
+++ b/api/server-server/room_get_missing_events.yaml
@@ -25,7 +25,7 @@ produces:
 paths:
   "/get_missing_events/{roomId}":
     post:
-      summary: Get missing events within a room.
+      summary: Gets missing events within a room.
       description: "**UNKNOWN**"
       operationId: getMissingEventsInRoom
       parameters:

--- a/api/server-server/room_get_state.yaml
+++ b/api/server-server/room_get_state.yaml
@@ -1,0 +1,130 @@
+# Copyright 2018 Kamax.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+swagger: '2.0'
+info:
+  title: "Matrix Federation Get State API"
+  version: "1.0.0"
+host: localhost:8448
+schemes:
+  - https
+basePath: /_matrix/federation/v1
+produces:
+  - application/json
+paths:
+  "/state/{roomId}":
+    get:
+      summary: Get room state for a specific event.
+      description: Get room state for a specific event.
+      operationId: getStateForEventInRoom
+      parameters:
+        - in: path
+          name: roomId
+          type: string
+          description: The room ID of the event referenced in query parameters.
+          example: "!roomid:example.org"
+        - in: query
+          name: event_id
+          type: string
+          description: The event ID for which we want the state.
+          example: "$eventid:example.org"
+      responses:
+        200:
+          description: The room state for that event, including the authentication chain for the state.
+          examples:
+            application/json: {
+              "auth_chain": [
+                {
+                  
+                },
+                {
+                  
+                }
+              ],
+              "pdus": [
+                {
+                  
+                },
+                {
+                  
+                }
+              ]
+            }
+          schema:
+            type: object
+            properties:
+              auth_chain:
+                type: array
+                description: Authentication chain that validate the PDUs.
+                items:
+                  type: object
+                  title: PDUs
+              pdus:
+                type: array
+                description: Events that make up the state.
+                items:
+                  type: object
+                  title: PDUs
+            required:
+              - "auth_chain"
+              - "pdus"
+  "/state_ids/{roomId}":
+    get:
+      summary: Get room state's event IDs for a specific event.
+      description: Get room state's event IDs for a specific event.
+      operationId: getStateIdsForEventInRoom
+      parameters:
+        - in: path
+          name: roomId
+          type: string
+          required: true
+          description: The room ID of the event referenced in query parameters.
+          example: "!roomid:example.org"
+        - in: query
+          name: event_id
+          type: string
+          required: true
+          description: The event ID for which we want the state.
+          example: "$eventid:example.org"
+      responses:
+        200:
+          description: The room state for that event, including the authentication chain for the state.
+          examples:
+            application/json: {
+              "auth_chain_ids": [
+                "!authChainEventId1:example.org",
+                "!authChainEventId2:example.org"
+              ],
+              "pdu_ids": [
+                "!pduId1:example.org",
+                "!pduId2:example.org"
+              ],
+            }
+          schema:
+            type: object
+            properties:
+              auth_chain_ids:
+                type: array
+                description: Event IDs of the PDUs' authentication chain.
+                items:
+                  type: string
+              pdu_ids:
+                type: array
+                description: Event IDs that make up the state.
+                items:
+                  type: string
+                  title: PDUs
+            required:
+              - "auth_chain_ids"
+              - "pdu_ids"

--- a/api/server-server/room_get_state.yaml
+++ b/api/server-server/room_get_state.yaml
@@ -25,8 +25,8 @@ produces:
 paths:
   "/state/{roomId}":
     get:
-      summary: Get room state for a specific event.
-      description: Get room state for a specific event.
+      summary: Gets room state for a specific event.
+      description: Gets room state for a specific event.
       operationId: getStateForEventInRoom
       parameters:
         - in: path
@@ -41,23 +41,25 @@ paths:
           example: "$eventid:example.org"
       responses:
         200:
-          description: The room state for that event, including the authentication chain for the state.
+          description: |
+            The room state for that event, including the authentication chain
+            for the state.
           examples:
             application/json: {
               "auth_chain": [
                 {
-                  
+                  "**UNKNOWN**": "**UNKNOWN**"
                 },
                 {
-                  
+                  "**UNKNOWN**": "**UNKNOWN**"
                 }
               ],
               "pdus": [
                 {
-                  
+                  "**UNKNOWN**": "**UNKNOWN**"
                 },
                 {
-                  
+                  "**UNKNOWN**": "**UNKNOWN**"
                 }
               ]
             }
@@ -99,7 +101,9 @@ paths:
           example: "$eventid:example.org"
       responses:
         200:
-          description: The room state for that event, including the authentication chain for the state.
+          description: |
+            The room state for that event, including the authentication chain
+            for the state.
           examples:
             application/json: {
               "auth_chain_ids": [

--- a/api/server-server/transaction.yaml
+++ b/api/server-server/transaction.yaml
@@ -25,8 +25,8 @@ produces:
 paths:
   "/send/{transactionId}":
     put:
-      summary: Send a transaction.
-      description: Send a transaction to a remote homeserver.
+      summary: Sends a transaction.
+      description: Sends a transaction to a remote homeserver.
       operationId: sendTransaction
       parameters:
         - in: path
@@ -47,12 +47,16 @@ paths:
                 example: "example.org"
               origin_server_ts:
                 type: integer
-                description: Timestamp in milliseconds on originating homeserver when this transaction started.
+                description: |
+                  Timestamp in milliseconds on originating homeserver when this
+                  transaction started.
                 required: true
                 example: 1404835423000
               edus:
                 type: array
-                description: List of ephemeral messages. May be omitted if there are no ephemeral messages to be sent.
+                description: |
+                  List of ephemeral messages. May be omitted if there are no
+                  ephemeral messages to be sent.
                 example: [
                   ...
                 ]

--- a/api/server-server/transaction.yaml
+++ b/api/server-server/transaction.yaml
@@ -1,0 +1,92 @@
+# Copyright 2018 Kamax.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+swagger: '2.0'
+info:
+  title: "Matrix Federation Transaction Push API"
+  version: "1.0.0"
+host: localhost:8448
+schemes:
+  - https
+basePath: /_matrix/federation/v1
+produces:
+  - application/json
+paths:
+  "/send/{transactionId}":
+    put:
+      summary: Send a transaction.
+      description: Send a transaction to a remote homeserver.
+      operationId: sendTransaction
+      parameters:
+        - in: path
+          name: transactionId
+          type: string
+          description: The ID for this transaction.
+          required: true
+          example: "123456789abcdef"
+        - in: body
+          name: body
+          schema:
+            type: object
+            properties:
+              origin:
+                type: string
+                description: Server name of the homeserver sending this transaction.
+                required: true
+                example: "example.org"
+              origin_server_ts:
+                type: integer
+                description: Timestamp in milliseconds on originating homeserver when this transaction started.
+                required: true
+                example: 1404835423000
+              edus:
+                type: array
+                description: List of ephemeral messages. May be omitted if there are no ephemeral messages to be sent.
+                example: [
+                  ...
+                ]
+                items:
+                  type: EDU
+              pdus:
+                type: array
+                description: List of persistent updates to rooms.
+                required: true
+                example: [
+                  ...
+                ]
+                items:
+                  type: PDU
+            required:
+              - "origin"
+              - "origin_server_ts"
+              - "pdus"
+      responses:
+        200:
+          description: The request was processed successfully.
+          examples:
+            application/json: {
+              "pdus": {
+                "!eventId:example.org": {}
+              }
+            }
+          schema:
+            type: object
+            properties:
+              pdus:
+                type: object
+                description: Processing outcome of each PDU.
+                additionalProperties:
+                  type: object
+            required:
+              - "pdus"

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -976,8 +976,8 @@ Exchanging room data
 Because of the decentralized and federated nature of Matrix, it is very likely
 that data is not received in order or delayed in transit.
 
-Matrix provide several proactive flows so homeservers can try to complete their
-DAG if they become aware that part(s) of it are missing.
+Matrix provides several proactive flows so homeservers can try to complete their
+DAG if they become aware that parts of it are missing.
 
 {{room_get_missing_events_ss_http_api}}
 

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -316,33 +316,7 @@ Each transaction has:
  - A list of PDUs and EDUs - the actual message payload that the Transaction
    carries.
 
-Transaction Fields
-~~~~~~~~~~~~~~~~~~
-
-==================== =================== ======================================
-    Key              Type                         Description
-==================== =================== ======================================
-``origin``           String              **Required**. ``server_name`` of homeserver sending
-                                         this transaction.
-``origin_server_ts`` Integer             **Required**. Timestamp in milliseconds on
-                                         originating homeserver when this
-                                         transaction started.
-``pdus``             List of Objects     **Required**. List of persistent updates to rooms.
-``edus``             List of Objects     List of ephemeral messages. May be omitted
-                                         if there are no ephemeral messages to
-                                         be sent.
-==================== =================== ======================================
-
-Example:
-
-.. code:: json
-
- {
-  "origin_server_ts":1404835423000,
-  "origin":"matrix.org",
-  "pdus":[...],
-  "edus":[...]
- }
+{{transaction_ss_http_api}}
 
 PDUs
 ----
@@ -991,6 +965,23 @@ that requested by the requestor in the ``v`` parameter).
 .. TODO-spec
   Specify (or remark that it is unspecified) how the server handles divergent
   history. DFS? BFS? Anything weirder?
+
+Exchanging room data
+---------------------
+
+.. WARNING::
+  This section is incomplete and only act as a knowledge holder until it is
+  formalized.
+
+Because of the decentralized and federated nature of Matrix, it is very likely
+that data is not received in order or delayed in transit.
+
+Matrix provide several proactive flows so homeservers can try to complete their
+DAG if they become aware that part(s) of it are missing.
+
+{{room_get_missing_events_ss_http_api}}
+
+{{room_get_state_ss_http_api}}
 
 Inviting to a room
 ------------------


### PR DESCRIPTION
This covers the transaction endpoint and the three related endpoints that tend to be called by synapse and can make a transaction exchange fail.

As this is currently work in progress, the intended purpose of each field and endpoint that is not understood are marked with ``**UNKNOWN**`` for later review.

Signed-off-by: Max Dor @ Kamax.io