### PR TITLE
[draft] server discovery for client connections

### DIFF
--- a/api/client-server/wellknown.yaml
+++ b/api/client-server/wellknown.yaml
@@ -1,0 +1,54 @@
+# Copyright 2018 Hubert Chathi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+swagger: '2.0'
+info:
+  title: "Matrix Client-Server server discovery API"
+  version: "1.0.0"
+host: localhost:8008
+schemes:
+  - https
+  - http
+basePath: /.well-known
+produces:
+  - application/json
+paths:
+  "/matrix":
+    get:
+      summary: Gets Matrix server discovery information about the domain.
+      description: |-
+        Gets discovery information about the domain.  *(decide on the actual format)*
+      operationId: getWellknown
+      responses:
+        200:
+          description: Server discovery information
+          examples:
+            application/json: {
+                "homeserver_url": "https://matrix.org"
+              }
+          schema:
+            type: object
+            properties:
+              homeserver_url:
+                type: string
+                description: The homeserver address for client-server connections. *(or make it array to allow for specifying multiple addresses?)*
+              federation_homeserver_url:
+                type: string
+                description: "The homeserver address for server-server connections. *(do we want to use .well-known for federation?)*"
+              identityserver_url:
+                type: string
+                description: "*(do we need this?  ask Maximus about the use case for this)*"
+        404:
+          description: No server discovery information available
+      tags:
+        - Server administration

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -10,6 +10,8 @@ Unreleased changes
     - ``GET /rooms/{roomId}/event/{eventId}``
       (`#1110 <https://github.com/matrix-org/matrix-doc/pull/1110>`_).
 
+  - Add server discovery rules (FIXME: add PR #)
+
 - Spec clarifications:
 
   - Mark ``home_server`` return field for ``/login`` and ``/register``

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -164,6 +164,63 @@ recommended.
 
 {{versions_cs_http_api}}
 
+Server Discovery
+~~~~~~~~~~~~~~~~
+
+Resolving Server Names
+++++++++++++++++++++++
+
+*(first two sentences, as well as the heading names are copied from the
+Server-Server API, section 2.1.  Should we also copy the server name grammar
+from there?)*
+*(wording is a bit confusing here, with different terms that sound similar --
+"server name", "DNS name", "server address".  Wording suggestions welcome.)*
+
+Each matrix homeserver is identified by a server name consisting of a DNS name
+and an optional TLS port.
+
+If the port is present then the server is discovered by looking up an AAAA or A
+record for the DNS name and connecting to the specified TLS port.  If the port
+is absent, then a client may use one or more of the methods below to determine
+the server address.  The methods are listed in order of preference, so if
+multiple methods succeed, then the first method listed should be given
+priority.
+
+*(do we want to include SRV lookups?)*
+*(3 and 4 are "guessing" the server address.  Do we want those?)*
+
+1. Perform an HTTPS GET request on the path ``/.well-known/matrix`` (or should
+   it be ``.well-known/matrix.json``?)to the web server at the DNS name, on
+   port 443.  If the request succeeds, is formatted according to `Well-known
+   URI`_, and has a ``homeserver_url`` field, then use the server address is
+   the ``homeserver_url`` field declared within the file.
+2. Look up the ``_matrix-client._tcp`` SRV record for the DNS name.
+3. Perform an HTTPS GET request on the path ``/_matrix/client/versions`` to the
+   web server at the DNS name, on port 443.  If the request succeeds and is
+   formatted according to `GET /_matrix/client/versions`_, then the server
+   address is the DNS name.
+4. Perform an HTTPS GET request on the path ``/_matrix/client/versions`` to the
+   web server at the DNS name with ``matrix.`` prepended, on port 443.  For
+   example, if the DNS name is ``example.com``, then the client would perform
+   the GET request to the web server at ``matrix.example.com``.  If the request
+   succeeds and is formatted according to `GET /_matrix/client/versions`_, then
+   the server address is the DNS name with ``matrix.`` prepended.
+5. Prompt the user to supply the server address.
+
+When checking the validity of the server's TLS certficate, the client must use
+the resolved server address, rather than the given DNS name, as the certificate
+subject name.  *(except for in the SRV case?)*
+
+Well-known URI
+++++++++++++++
+
+A client may make an HTTPS GET request on port 443 ``/.well-known/matrix`` to a
+domain name in order to gather discovery information about Matrix-related
+servers for that domain.  The request, if successful, must return a JSON object.
+
+{{wellknown_cs_http_api}}
+
+
 Client Authentication
 ---------------------
 


### PR DESCRIPTION
This is an initial draft of a spec change for https://github.com/matrix-org/matrix-doc/issues/433.

This patch does make some suggestions based on previous discussion, but its main purposes are to outline how the spec would probably need to look like, as well as to highlight what issues need to be discussed and decided on.  The issues that need discussing are indicated by `*(` ... `)*`

(see also https://github.com/kamax-io/matrix-java-sdk/issues/23)