### PR TITLE
Add IS ping endpoint

### DIFF
--- a/api/identity/ping.yaml
+++ b/api/identity/ping.yaml
@@ -1,0 +1,44 @@
+# Copyright 2018 Kamax Sàrl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+swagger: "2.0"
+info:
+  title: "Matrix Client-Identity Versions API"
+  version: "1.0.0"
+host: localhost:8090
+schemes:
+  - https
+basePath: /_matrix/identity
+produces:
+  - application/json
+paths:
+  "/api/v1":
+    get:
+      summary: Checks that an Identity server is available at this API endpopint.
+      description: |-
+        Checks that an Identity server is available at this API endpopint.
+
+        To discover that an Identity server is available at a specific URL,
+        this endpoint can be queried and will return an empty object.
+
+        This is primarly used for auto-discovery and health check purposes
+        by entities acting as a client for the Identity server.
+      operationId: ping
+      responses:
+        200:
+          description: An Identity server is ready to serve requests.
+          examples:
+            application/json: {}
+          schema:
+            type: object

--- a/specification/identity_service_api.rst
+++ b/specification/identity_service_api.rst
@@ -67,6 +67,11 @@ should allow a 3pid to be mapped to a Matrix user identity, but not in the other
 direction (i.e. one should not be able to get all 3pids associated with a Matrix
 user ID, or get all 3pids associated with a 3pid).
 
+Status check
+------------
+
+{{ping_is_http_api}}
+
 Key management
 --------------
 


### PR DESCRIPTION
As a requirement for the well-known auto-discovery proposal and as a long overdue endpoint to "ping" the Identity server, and to help provide an endpoint similar to `/_matrix/client/versions` that is currently being (mis)used.

Signed-off-by: Max @ Kamax dot io