### PR TITLE
Make m.presence match what synapse returns

### DIFF
--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -19,6 +19,8 @@ Unreleased changes
     (`#1106 <https://github.com/matrix-org/matrix-doc/pull/1106>`_).
   - Clarify default values for some fields on the /search API
     (`#1109 <https://github.com/matrix-org/matrix-doc/pull/1109>`_).
+  - Fix the representation of ``m.presence`` events
+    (`#1137 <https://github.com/matrix-org/matrix-doc/pull/1137>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 

--- a/event-schemas/examples/m.presence
+++ b/event-schemas/examples/m.presence
@@ -4,8 +4,7 @@
     "last_active_ago": 2478593,
     "presence": "online",
     "currently_active": false,
-    "user_id": "@example:localhost"
   },
-  "event_id": "$WLGTSEFSEF:localhost",
+  "sender": "@example:localhost",
   "type": "m.presence"
 }

--- a/event-schemas/schema/m.presence
+++ b/event-schemas/schema/m.presence
@@ -29,21 +29,17 @@
                 "currently_active": {
                     "type": boolean,
                     "description": "Whether the user is currently active"
-                },
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID."
                 }
             },
-            "required": ["presence", "user_id"]
+            "required": ["presence"]
         },
         "type": {
             "type": "string",
             "enum": ["m.presence"]
         },
-        "event_id": {
+        "sender": {
             "type": "string"
         }
     },
-    "required": ["event_id", "type", "content"]
+    "required": ["sender", "type", "content"]
 }


### PR DESCRIPTION
Considering this is the behaviour that is embedded into most client libraries and the most popular homeserver, it should be adopted as the standard.