### PR TITLE
Tag ordering is defined as a number between 0 and 1, not strings

### DIFF
--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -19,6 +19,8 @@ Unreleased changes
     (`#1106 <https://github.com/matrix-org/matrix-doc/pull/1106>`_).
   - Clarify default values for some fields on the /search API
     (`#1109 <https://github.com/matrix-org/matrix-doc/pull/1109>`_).
+  - Clarify that ``m.tag`` ordering is done with numbers, not strings
+    (`#1139 <https://github.com/matrix-org/matrix-doc/pull/1139>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 

--- a/event-schemas/examples/m.tag
+++ b/event-schemas/examples/m.tag
@@ -2,7 +2,7 @@
   "type": "m.tag",
   "content": {
     "tags": {
-      "work": {"order": 1}
+      "u.work": {"order": 1}
     }
   }
 }

--- a/specification/modules/tags.rst
+++ b/specification/modules/tags.rst
@@ -35,12 +35,11 @@ the tags are for.
 Each tag has an associated JSON object with information about the tag, e.g how
 to order the rooms with a given tag.
 
-Ordering information is given under the ``order`` key as a string. The string
-are compared lexicographically by unicode codepoint to determine which should
-displayed first. So a room with a tag with an ``order`` key of ``"apples"``
-would appear before a room with a tag with an ``order`` key of ``"oranges"``.
-If a room has a tag without an ``order`` key then it should appear after the
-rooms with that tag that have an ``order`` key.
+Ordering information is given under teh ``order`` key as a number between 0 and 
+1. The numbers are compared such that 0 is displayed first. Therefore a room 
+with an ``order`` of ``0.2`` would be displayed before a room with an ``order`` 
+of ``0.7``. If a room has a tag without an ``order`` key then it should appear 
+after the rooms with that tag that have an ``order`` key.
 
 The name of a tag MUST not exceed 255 bytes.
 


### PR DESCRIPTION
Riot, etc all use numbers for ordering.