### PR TITLE
Minor improvements to help with building the spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /scripts/continuserv/continuserv
 /scripts/speculator/speculator
 /scripts/swagger
+/scripts/tmp
 /templating/out
 *.pyc
 *.swp

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ specs and event schemas in this repository.
 Preparation
 -----------
 
-To use the scripts, it is best to create a Python virtualenv as follows::
+To use the scripts, it is best to create a Python 2.x virtualenv as follows::
 
   virtualenv env
   env/bin/pip install -r scripts/requirements.txt


### PR DESCRIPTION
Just a couple minor changes:
* If your build fails, `scripts/tmp` ends up in your changes - ignore that folder.
* Specifically declare the python version required to build the spec.