### PR TITLE
Improve documentation around /account/whoami

### DIFF
--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -58,11 +58,11 @@ paths:
                 description: The user id that owns the access token.
         401:
           description:
-            The token is not recongized
+            The token is not recognised
           examples:
             application/json: {
               "errcode": "M_UNKNOWN_TOKEN",
-              "error": "Unrecongised access token."
+              "error": "Unrecognised access token."
             }
           schema:
             "$ref": "definitions/error.yaml"

--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -29,7 +29,13 @@ paths:
     get:
       summary: Gets information about the owner of an access token.
       description: |-
-        Gets information about the owner of a given access token.
+        Gets information about the owner of a given access token. 
+        
+        If the owner of the access token is an application service, 
+        the server should return the user ID making the request. The
+        server should respect the application service client/server API
+        extensions during this request. If the request is made for a 
+        virtual user, the server should verify that it is registered.
       operationId: getTokenOwner
       security:
         - accessToken: []
@@ -40,8 +46,8 @@ paths:
             The token belongs to a known user.
           examples:
             application/json: {
-                "user_id": "@joe:example.org"
-              }
+              "user_id": "@joe:example.org"
+            }
           schema:
             type: object
             required: ["user_id"]
@@ -49,5 +55,29 @@ paths:
               user_id:
                 type: string
                 description: The user id that owns the access token.
+        401:
+          description:
+            The token is not recongized
+          examples:
+            application/json: {
+              "errcode": "M_UNKNOWN_TOKEN",
+              "error": "Unrecongised access token."
+            }
+          schema:
+            "$ref": "definitions/error.yaml"
+        403:
+          description:
+            The appservice cannot masquerade the user or has not registered them.
+          examples:
+            application/json: {
+              "errcode": "M_FORBIDDEN",
+              "error": "Application service has not registered this user."
+            }
+          schema:
+            "$ref": "definitions/error.yaml"
+        429:
+          description: This request was rate-limited.
+          schema:
+            "$ref": "definitions/error.yaml"
       tags:
         - User data

--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -31,15 +31,26 @@ paths:
       description: |-
         Gets information about the owner of a given access token. 
         
-        If the owner of the access token is an application service, 
+        If the owner of the access token is an application service,
         the server should return the user ID making the request. The
-        server should respect the application service client/server API
-        extensions during this request. If the request is made for a 
-        virtual user, the server should verify that it is registered.
+        user ID making the request can be determined by checking to
+        see if the ``user_id`` query parameter was also supplied. If
+        the parameter is not present, the default application service
+        user ID should be used (defined as the ``sender_localpart``
+        in the registration). If the parameter is present, the given
+        user ID should be verified to be both registered and in the
+        application service's namespace.
       operationId: getTokenOwner
       security:
         - accessToken: []
-      parameters: []
+      parameters:
+        # TODO: Break this out to a template or something (and apply it everywhere)
+        - in: query
+          name: user_id
+          type: string
+          required: false
+          description: |-
+            The user ID to masquerade as. Only applies to application services.
       responses:
         200:
           description:
@@ -67,7 +78,7 @@ paths:
             "$ref": "definitions/error.yaml"
         403:
           description:
-            The appservice cannot masquerade the user or has not registered them.
+            The appservice cannot masquerade as the user or has not registered them.
           examples:
             application/json: {
               "errcode": "M_FORBIDDEN",

--- a/api/client-server/whoami.yaml
+++ b/api/client-server/whoami.yaml
@@ -31,26 +31,16 @@ paths:
       description: |-
         Gets information about the owner of a given access token. 
         
-        If the owner of the access token is an application service,
-        the server should return the user ID making the request. The
-        user ID making the request can be determined by checking to
-        see if the ``user_id`` query parameter was also supplied. If
-        the parameter is not present, the default application service
-        user ID should be used (defined as the ``sender_localpart``
-        in the registration). If the parameter is present, the given
-        user ID should be verified to be both registered and in the
-        application service's namespace.
+        Note that, as with the rest of the Client-Server API, 
+        Application Services may masquerade as users within their 
+        namespace by giving a ``user_id`` query parameter. In this 
+        situation, the server should verify that the given ``user_id``
+        is registered by the appservice, and return it in the response 
+        body.
       operationId: getTokenOwner
       security:
         - accessToken: []
-      parameters:
-        # TODO: Break this out to a template or something (and apply it everywhere)
-        - in: query
-          name: user_id
-          type: string
-          required: false
-          description: |-
-            The user ID to masquerade as. Only applies to application services.
+      parameters: []
       responses:
         200:
           description:

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -23,6 +23,8 @@ Unreleased changes
     (`#1137 <https://github.com/matrix-org/matrix-doc/pull/1137>`_).
   - Clarify that ``m.tag`` ordering is done with numbers, not strings
     (`#1139 <https://github.com/matrix-org/matrix-doc/pull/1139>`_).
+  - Clarify that ``/account/whoami`` should consider application services
+    (`#1152 <https://github.com/matrix-org/matrix-doc/pull/1152>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 


### PR DESCRIPTION
Clarifies: https://github.com/matrix-org/matrix-doc/issues/1135

* Add a blurb about appservices as a reminder to read the appservice spec
* The request can be ratelimited
* Document what the server should do when an invalid access token is given
* Document explicitly how the server should react to appservices
* Formatting of some examples