### PR TITLE
Add instructions on how Windows users can build this project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,23 @@ To rebuild the specification, use ``scripts/gendoc.py``::
 The above will write the rendered version of the specification to
 ``scripts/gen``. To view it, point your browser at ``scripts/gen/index.html``.
 
+Windows users
+~~~~~~~~~~~~~
+
+If you're on Windows Vista or higher, be sure that the "Symbolic Links"
+option was selected when installing Git prior to cloning this repository. If 
+you're still seeing errors about files not being found it is likely because 
+the symlink at ``api/client-server/definitions/event-schemas`` looks like a 
+file. To correct the problem, open an Administrative/Elevated shell in your 
+cloned matrix-doc directory and run the following::
+
+  cd api\client-server\definitions
+  del event-schemas
+  mklink /D event-schemas "..\..\..\event-schemas"
+
+This will delete the file and replace it with a symlink. Git should not detect
+this as a change, and you should be able to go back to building the project.
+
 Generating the OpenAPI (Swagger) specs
 --------------------------------------
 


### PR DESCRIPTION
Addresses #1149 

I went the route of documenting how to fix the problem instead of trying to fix the project for a couple reasons:
* Symlinks and Windows just don't get along very well (event in modern times)
* Removing the symlink and making everything use the absolute path would be a nightmare and just look really bad (as everything needs `../../../` suddenly)
* Git for Windows doesn't even like supporting symlinks and has the option as default off

The documentation provided here starts by following the documentation to enable symlinks in git, however for me that didn't actually work (I even set up a fresh windows vm, installed git with the option selected, then cloned the project to no avail). This is why the portion about administrative shells was added. An administrative shell is required because that's just how `mklink` works for whatever reason. Further, the slashes in the example **must** be as documented, otherwise the symlink will appear correctly but cause windows to claim the file doesn't exist when using it.