### PR TITLE
Add metadata about the sticker pack that a sticker image belongs to.

### DIFF
--- a/event-schemas/examples/m.sticker
+++ b/event-schemas/examples/m.sticker
@@ -19,7 +19,7 @@
     "stickerpack": {
       "name": "Rabbits",
       "description": "Cute rabbit stickers",
-      "stickerpack_url": "https://scalar.vector.im/integration/stickerpicker/rabbits123"
+      "integration_manager_url": "https://scalar.vector.im/integration/stickerpicker/rabbits123?utm_source=matrix.org&utm_medium=email&utm_campaign=january_newsletter&promotional_code=10"
     }
   },
   "origin_server_ts": 1431961217939,

--- a/event-schemas/examples/m.sticker
+++ b/event-schemas/examples/m.sticker
@@ -15,7 +15,12 @@
       "w": 140,
       "size": 73602
     },
-    "url": "mxc://matrix.org/sHhqkFCvSkFwtmvtETOtKnLP"
+    "url": "mxc://matrix.org/sHhqkFCvSkFwtmvtETOtKnLP",
+    "stickerpack": {
+      "name": "Rabbits",
+      "description": "Cute rabbit stickers",
+      "stickerpack_url": "https://scalar.vector.im/integration/stickerpicker/rabbits123"
+    }
   },
   "origin_server_ts": 1431961217939,
   "event_id": "$WLGTSEFSEF:localhost",

--- a/event-schemas/schema/core-event-schema/msgtype_infos/stickerpack_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/stickerpack_info.yaml
@@ -1,0 +1,15 @@
+$schema: http://json-schema.org/draft-04/schema#
+description: Metadata about a sticker pack.
+properties:
+  name:
+    description: The human-readable name of the sticker pack.
+    type: string
+  description:
+    description: |-
+      Description of the sticker pack contents.
+    type: string
+  stickerpack_url:
+    description: The URL to view / add the sticker pack in an integration manager.
+    type: string
+title: StickerpackInfo
+type: object

--- a/event-schemas/schema/core-event-schema/msgtype_infos/stickerpack_info.yaml
+++ b/event-schemas/schema/core-event-schema/msgtype_infos/stickerpack_info.yaml
@@ -8,8 +8,9 @@ properties:
     description: |-
       Description of the sticker pack contents.
     type: string
-  stickerpack_url:
-    description: The URL to view / add the sticker pack in an integration manager.
+  integration_manager_url:
+    description: |-
+      The URL to view / add the sticker pack in an integration manager.
     type: string
 title: StickerpackInfo
 type: object

--- a/event-schemas/schema/m.sticker
+++ b/event-schemas/schema/m.sticker
@@ -21,6 +21,11 @@ properties:
         description: |-
           The URL to the sticker image. This must be a valid ``mxc://`` URI.
         type: string
+      stickerpack:
+        allOf:
+          - $ref:  core-event-schema/msgtype_infos/stickerpack_info.yaml
+        description: |-
+          Metadata about the sticker pack that the sticker image belongs to.
     required:
       - body
       - info

--- a/specification/modules/stickers.rst
+++ b/specification/modules/stickers.rst
@@ -39,7 +39,7 @@ Sticker events are received as a single ``m.sticker`` event in the
 Integration manager referral URL
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
-In order to aid `widget` or `asset` sharing and discovery, sticker events can
+In order to aid widget or asset sharing and discovery, sticker events can
 specify an ``integration_manager_url`` property under ``StickerpackInfo``.
 
 This URL is intended to link the user to an appropriate page within the relevant

--- a/specification/modules/stickers.rst
+++ b/specification/modules/stickers.rst
@@ -39,37 +39,54 @@ Sticker events are received as a single ``m.sticker`` event in the
 Integration manager referral URL
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
-In order to aid widget or asset sharing and discovery, sticker events can
+In order to aid widget and asset sharing and discovery, sticker events can
 specify an ``integration_manager_url`` property under ``StickerpackInfo``.
 
-This URL is intended to link the user to an appropriate page within the relevant
-Integration Manager to enable them to add / purchase the associated integration
-or integration asset (e.g. a stickerpicker widget, or stickerpack).
+This URL should be rendered by matrix clients as a button or similar control.
+This control should initiate opening an appropriate page within the relevant
+Integration Manager to enable addition (and purchase where relevant) of an
+integration or integration asset (e.g. a stickerpicker widget, or stickerpack).
 
-The ``integration manager referral URL`` should have the following format::
+The ``integration_manager_url`` should have the following format::
 
-  https://<hostname>/<integration manager base path>/integration/<integration_type>/<asset_id>?utm_source=<utm_source>&utm_medium=<utm_medium>&utm_campaign=<utm_campaign>&promotional_code=<promotional_code>
+  https://<hostname>/<integration manager base path>/integration/<integration_type>/<asset_id>
 
 Where:
 
 * The ``hostname`` and ``integration manager base path`` should point to the
   Integration Manager that the stickerpack or associated asset can be purchased
   from.
-* ``integration_type`` is the type name of the widget/integration (e.g.
-  'stickerpicker'),
-* Optionally ``asset_id`` can be set to a unique identifier for an asset to
-  be used with the specified widget. E.g. This could be set to 'rabbits123'
-  to direct the user to a page to purchase a specific stickerpack (of rabbit
-  stickers).
-* All query parameters are optional. They may be used for referral tracking and
-  promotional codes (depending on the terms of service of the integration
-  manager).
-  For example:
+* ``integration_type`` is the type of the widget or integration (e.g.
+  'm.stickerpicker').
+* Optionally, ``asset_id`` can be set to a unique identifier for an asset to
+  be used with the specified widget. For example, this could be set to *'rabbits123'*
+  to direct the user to a page to add (and optionally purchase) a specific
+  stickerpack (of rabbit stickers).
 
-  - ``utm_source`` - The referral source / website (E.g. 'matrix.org')
-  - ``utm_medium`` - The referral medium (E.g. 'email')
-  - ``utm_campaign`` - The referral campaign (E.g. 'january_newsletter')
-  - ``promotional_code`` - A  promotional code to be applied to the purchase
+The ``integration_manager_url`` should be specified by the
+stickerpicker widget when sending a sticker event to the matrix client.
+
+Query parameters may optionally be added to the URL by Matrix clients in
+order to aid referral tracking and promotional codes (depending on the terms of
+service of the integration manager).
+
+The following parameters should be supported by integration managers and
+added to the URL by Matrix clients, where available:
+
+* ``utm_source`` - The referral source (E.g. 'matrix.org'). This should be the
+  domain name of the website or application hosting or sending the
+  ``integration_manager_url`` link.
+* ``utm_medium`` - The referral medium. Should be one of *'matrix_client'*,
+  *'email'*, *'sms'*, *'website'* or *'other'*.
+* ``utm_campaign`` - The referral campaign. This can be any string value (e.g.
+  *'january_newsletter'*). However, for Matrix clients this should be
+  set to the client name (e.g. *'riot-web'*).
+* ``promotional_code`` - An optional promotional code to be applied to the
+  purchase. For example, *'discount20'* could be passed to denote that a 20%
+  promotional discount should be applied to a product purchase. The integration
+  manager should perform validation that the code is valid and applicable to the
+  specified product.
+
 
 Client behaviour
 ----------------

--- a/specification/modules/stickers.rst
+++ b/specification/modules/stickers.rst
@@ -36,6 +36,41 @@ Sticker events are received as a single ``m.sticker`` event in the
 
 {{m_sticker_event}}
 
+Integration manager referral URL
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+
+In order to aid `widget` or `asset` sharing and discovery, sticker events can
+specify an ``integration_manager_url`` property under ``StickerpackInfo``.
+
+This URL is intended to link the user to an appropriate page within the relevant
+Integration Manager to enable them to add / purchase the associated integration
+or integration asset (e.g. a stickerpicker widget, or stickerpack).
+
+The ``integration manager referral URL`` should have the following format::
+
+  https://<hostname>/<integration manager base path>/integration/<integration_type>/<asset_id>?utm_source=<utm_source>&utm_medium=<utm_medium>&utm_campaign=<utm_campaign>&promotional_code=<promotional_code>
+
+Where:
+
+* The ``hostname`` and ``integration manager base path`` should point to the
+  Integration Manager that the stickerpack or associated asset can be purchased
+  from.
+* ``integration_type`` is the type name of the widget/integration (e.g.
+  'stickerpicker'),
+* Optionally ``asset_id`` can be set to a unique identifier for an asset to
+  be used with the specified widget. E.g. This could be set to 'rabbits123'
+  to direct the user to a page to purchase a specific stickerpack (of rabbit
+  stickers).
+* All query parameters are optional. They may be used for referral tracking and
+  promotional codes (depending on the terms of service of the integration
+  manager).
+  For example:
+
+  - ``utm_source`` - The referral source / website (E.g. 'matrix.org')
+  - ``utm_medium`` - The referral medium (E.g. 'email')
+  - ``utm_campaign`` - The referral campaign (E.g. 'january_newsletter')
+  - ``promotional_code`` - A  promotional code to be applied to the purchase
+
 Client behaviour
 ----------------
 


### PR DESCRIPTION
We need to add information about the sticker pack that sticker images belong so that users can discover integrations (and add / use them themselves).