### PR TITLE
Type cleanup

### DIFF
--- a/api/client-server/admin.yaml
+++ b/api/client-server/admin.yaml
@@ -105,7 +105,8 @@ paths:
                                   type: string
                                   description: Most recently seen IP address of the session.
                                 last_seen:
-                                  type: number
+                                  type: integer
+                                  format: int64
                                   description: Unix timestamp that the session was last active.
                                 user_agent:
                                   type: string

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -229,7 +229,8 @@ paths:
           description: "The URL to get a preview of"
           required: true
         - in: query
-          type: number
+          type: integer
+          format: int64
           x-example: 1510610716656
           name: ts
           description: |-
@@ -246,7 +247,8 @@ paths:
             type: object
             properties:
               "matrix:image:size":
-                type: number
+                type: integer
+                format: int64
                 description: |-
                   The byte-size of the image. Omitted if there is no image attached.
               "og:image":

--- a/api/client-server/joining.yaml
+++ b/api/client-server/joining.yaml
@@ -101,6 +101,11 @@ paths:
               "room_id": "!d41d8cd:matrix.org"}
           schema:
             type: object
+            properties:
+              room_id:
+                type: string
+                description: The joined room id
+            required: ["room_id"]
         403:
           description: |-
             You do not have permission to join the room. A meaningful ``errcode`` and description error text will be returned. Example reasons for rejection are:
@@ -197,6 +202,11 @@ paths:
               "room_id": "!d41d8cd:matrix.org"}
           schema:
             type: object
+            properties:
+              room_id:
+                type: string
+                description: The joined room id
+            required: ["room_id"]
         403:
           description: |-
             You do not have permission to join the room. A meaningful ``errcode`` and description error text will be returned. Example reasons for rejection are:

--- a/api/client-server/list_public_rooms.yaml
+++ b/api/client-server/list_public_rooms.yaml
@@ -119,7 +119,7 @@ paths:
       parameters:
         - in: query
           name: limit
-          type: number
+          type: integer
           description: |-
             Limit the number of results returned.
         - in: query
@@ -173,7 +173,8 @@ paths:
                       description: |-
                         The name of the room, if any.
                     num_joined_members:
-                      type: number
+                      type: integer
+                      format: int64
                       description: |-
                         The number of members joined to the room.
                     room_id:
@@ -210,7 +211,8 @@ paths:
                   absence of this token means there are no results before this
                   batch, i.e. this is the first batch.
               total_room_count_estimate:
-                type: number
+                type: integer
+                format: int64
                 description: |-
                    An estimate on the total number of public rooms, if the
                    server has an estimate.
@@ -260,7 +262,7 @@ paths:
             type: object
             properties:
               limit:
-                type: number
+                type: integer
                 description: |-
                   Limit the number of results returned.
               since:
@@ -320,7 +322,8 @@ paths:
                       description: |-
                         The name of the room, if any.
                     num_joined_members:
-                      type: number
+                      type: integer
+                      format: int64
                       description: |-
                         The number of members joined to the room.
                     room_id:
@@ -357,7 +360,8 @@ paths:
                   absence of this token means there are no results before this
                   batch, i.e. this is the first batch.
               total_room_count_estimate:
-                type: number
+                type: integer
+                format: int64
                 description: |-
                    An estimate on the total number of public rooms, if the
                    server has an estimate.

--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -107,6 +107,7 @@ paths:
                 items:
                   type: object
                   title: RoomEvent
+                  "$ref": "definitions/event-schemas/schema/core-event-schema/room_event.yaml"
           examples:
             application/json: {
                 "start": "t47429-4392820_219380_26003_2265",

--- a/api/client-server/notifications.yaml
+++ b/api/client-server/notifications.yaml
@@ -45,11 +45,11 @@ paths:
           required: false
           x-example: "xxxxx"
         - in: query
-          type: number
+          type: integer
           name: limit
           description: Limit on the number of events to return in this request.
           required: false
-          x-example: "20"
+          x-example: 20
         - in: query
           name: only
           type: string
@@ -133,6 +133,7 @@ paths:
                       type: string
                       description: The ID of the room in which the event was posted.
                     ts:
+                      format: int64
                       type: integer
                       description: |-
                         The unix timestamp at which the event notification was sent,

--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -218,7 +218,7 @@ paths:
                 description: The email address
                 example: "example@example.com"
               send_attempt:
-                type: number
+                type: integer
                 description: Used to distinguish protocol level retries from requests to re-send the email.
                 example: 1
             required: ["client_secret", "email", "send_attempt"]

--- a/api/client-server/search.yaml
+++ b/api/client-server/search.yaml
@@ -74,7 +74,7 @@ paths:
                 properties:
                   room_events:
                     type: object
-                    title: "Room Events"
+                    title: Room Events Criteria
                     description: Mapping of category name to search criteria.
                     properties:
                       search_term:
@@ -103,7 +103,7 @@ paths:
                           The order in which to search for results.
                           By default, this is ``"rank"``.
                       event_context:
-                        title: "Event Context"
+                        title: "Include Event Context"
                         type: object
                         description: |-
                           Configures whether any context for the events
@@ -169,13 +169,13 @@ paths:
             properties:
               search_categories:
                 type: object
-                title: Categories
+                title: Result Categories
                 description: Describes which categories to search in and
                   their criteria.
                 properties:
                   room_events:
                     type: object
-                    title: Room Event Results
+                    title: Result Room Events
                     description: Mapping of category name to search criteria.
                     properties:
                       count:

--- a/api/client-server/search.yaml
+++ b/api/client-server/search.yaml
@@ -179,7 +179,8 @@ paths:
                     description: Mapping of category name to search criteria.
                     properties:
                       count:
-                        type: number
+                        type: integer
+                        format: int64
                         description: An approximate count of the total number of results found.
                       results:
                         type: array

--- a/api/client-server/users.yaml
+++ b/api/client-server/users.yaml
@@ -47,7 +47,7 @@ paths:
                 description: The term to search for
                 example: "foo"
               limit:
-                type: number
+                type: integer
                 description: The maximum number of results to return (Defaults to 10).
                 example: 10
             required: ["search_term"]

--- a/event-schemas/schema/core-event-schema/room_event.yaml
+++ b/event-schemas/schema/core-event-schema/room_event.yaml
@@ -16,7 +16,8 @@ properties:
   origin_server_ts:
     description: Timestamp in milliseconds on originating homeserver
       when this event was sent.
-    type: number
+    type: integer
+    format: int64
   unsigned:
     description: Contains optional extra information about the event.
     properties:


### PR DESCRIPTION
`type: number` is replaced with `type: integer` (with `format: int64` where it makes sense) for parameters that I can reasonably assume to never have fractional part. I did not turn types in `m.room.power_levels` to integers as I wasn't sure they must be integer (and if yes, whether they should be 64-bit - most likely no). Please advise what to do with `m.room.power_levels`.