### PR TITLE
GET media/config

### DIFF
--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -279,8 +279,7 @@ paths:
                **NOTE:** Both clients and server administrators should be aware that proxies
                between the client and the server may affect the apparent behaviour of content
                repository APIs, for example, proxies may enforce a lower upload size limit
-               than is advertised by the server on this endpoint. Clients should handle such
-               situations gracefully.
+               than is advertised by the server on this endpoint.
       operationId: getConfig
       produces: ["application/json"]
       security:

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -269,9 +269,9 @@ paths:
             "$ref": "definitions/error.yaml"
       tags:
         - Media
-  "/limits":
+  "/config":
     get:
-      summary: Get limits on what can be uploaded to the content repository.
+      summary: Get the config for the media repository.
                Clients SHOULD use this as a guide when uploading content.
                All values are intentionally left optional, the client MUST assume
                that any field not given is not limited.

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -277,6 +277,9 @@ paths:
                that any field not given is not limited.
 
                **NOTE:** Reverse proxies may apply their own limits.
+
+               If auth is not supplied, this endpoint gives the global limit of the server.
+               Otherwise it should give the limits applied to the authenticated user.
       operationId: getLimits
       produces: ["application/json"]
       security:

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -274,7 +274,7 @@ paths:
       summary: Get the configuration for the media repository.
                Clients SHOULD use this as a guide when uploading content.
                All values are intentionally left optional. Clients SHOULD follow
-               the advise given in the field description when the field is not avaliable.
+               the advice given in the field description when the field is not available.
 
                **NOTE:** Reverse proxies may apply their own configuration.
                

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -273,6 +273,8 @@ paths:
     get:
       summary: Get the configuration for the content repository.
       description: |-
+        This endpoint allows clients to retrieve the configuration of the content
+        repository, such as upload limitations.
         Clients SHOULD use this as a guide when using content repository endpoints.
         All values are intentionally left optional. Clients SHOULD follow
         the advice given in the field description when the field is not available.

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -272,14 +272,14 @@ paths:
   "/config":
     get:
       summary: Get the configuration for the content repository.
-               Clients SHOULD use this as a guide when using content repository endpoints.
-               All values are intentionally left optional. Clients SHOULD follow
-               the advice given in the field description when the field is not available.
+      description: Clients SHOULD use this as a guide when using content repository endpoints.
+                   All values are intentionally left optional. Clients SHOULD follow
+                   the advice given in the field description when the field is not available.
 
-               **NOTE:** Both clients and server administrators should be aware that proxies
-               between the client and the server may affect the apparent behaviour of content
-               repository APIs, for example, proxies may enforce a lower upload size limit
-               than is advertised by the server on this endpoint.
+                   **NOTE:** Both clients and server administrators should be aware that proxies
+                   between the client and the server may affect the apparent behaviour of content
+                   repository APIs, for example, proxies may enforce a lower upload size limit
+                   than is advertised by the server on this endpoint.
       operationId: getConfig
       produces: ["application/json"]
       security:

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -269,3 +269,30 @@ paths:
             "$ref": "definitions/error.yaml"
       tags:
         - Media
+  "/limits":
+    get:
+      summary: Get limits on what can be uploaded to the content repository.
+               Clients SHOULD use this as a guide when uploading content.
+               All values are intentionally left optional, the client MUST assume
+               that any field not given is not limited.
+
+               **NOTE:** Reverse proxies may apply their own limits.
+      operationId: getLimits
+      produces: ["application/json"]
+      security:
+        - accessToken: []
+      responses:
+        200:
+          description: The limits exposed by the matrix server.
+          schema:
+            type: object
+            properties:
+              size:
+                type: number
+                description: "The maximum size a upload can be in bytes."
+          examples:
+            application/json: {
+                "size": 50000000
+              }
+      tags:
+        - Media

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -272,15 +272,13 @@ paths:
   "/config":
     get:
       summary: Get the configuration for the media repository.
-               Clients SHOULD use this as a guide when uploading content.
+               Clients SHOULD use this as a guide when using media endpoints.
                All values are intentionally left optional. Clients SHOULD follow
                the advice given in the field description when the field is not available.
 
-               **NOTE:** Reverse proxies may apply their own configuration.
-               
-
-               If an accessToken is supplied, the configuration applied to the authenticated user is returned.
-               Otherwise it should give the configuration applied globally to the server.
+               **NOTE:** The /config endpoint is a guide. Other middleware such as 
+               reverse proxies may apply their own configuration not described on this
+               endpoint.
       operationId: getConfig
       produces: ["application/json"]
       security:
@@ -294,8 +292,9 @@ paths:
               m.upload.size:
                 type: number
                 description: |- 
-                  The maximum size an upload can be in bytes. If not listed or null,
-                  the upload limit should be treated as unknown.
+                  The maximum size an upload can be in bytes.
+                  Clients SHOULD use this as a guide when uploading content.
+                  If not listed or null, the size limit should be treated as unknown.
           examples:
             application/json: {
                "m.upload.size": 50000000

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -292,7 +292,7 @@ paths:
             properties:
               upload_size:
                 type: number
-                description: "The maximum size a upload can be in bytes."
+                description: "The maximum size an upload can be in bytes."
           examples:
             application/json: {
                 "upload_size": 50000000

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -271,8 +271,8 @@ paths:
         - Media
   "/config":
     get:
-      summary: Get the configuration for the media repository.
-               Clients SHOULD use this as a guide when using media endpoints.
+      summary: Get the configuration for the content repository.
+               Clients SHOULD use this as a guide when using content endpoints.
                All values are intentionally left optional. Clients SHOULD follow
                the advice given in the field description when the field is not available.
 

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -272,7 +272,7 @@ paths:
   "/config":
     get:
       summary: Get the configuration for the content repository.
-               Clients SHOULD use this as a guide when using content endpoints.
+               Clients SHOULD use this as a guide when using content repository endpoints.
                All values are intentionally left optional. Clients SHOULD follow
                the advice given in the field description when the field is not available.
 

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -290,12 +290,12 @@ paths:
           schema:
             type: object
             properties:
-              upload_size:
+              m.upload.size:
                 type: number
                 description: "The maximum size an upload can be in bytes."
           examples:
             application/json: {
-                "upload_size": 50000000
+                "m.upload.size": 50000000
               }
       tags:
         - Media

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -276,9 +276,11 @@ paths:
                All values are intentionally left optional. Clients SHOULD follow
                the advice given in the field description when the field is not available.
 
-               **NOTE:** The /config endpoint is a guide. Other middleware such as 
-               reverse proxies may apply their own configuration not described on this
-               endpoint.
+               **NOTE:** Both clients and server administrators should be aware that proxies
+               between the client and the server may affect the apparent behaviour of content
+               repository APIs, for example, proxies may enforce a lower upload size limit
+               than is advertised by the server on this endpoint. Clients should handle such
+               situations gracefully.
       operationId: getConfig
       produces: ["application/json"]
       security:

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -273,13 +273,13 @@ paths:
     get:
       summary: Get the configuration for the media repository.
                Clients SHOULD use this as a guide when uploading content.
-               All values are intentionally left optional, the client MUST assume
-               that any field not given is not limited.
+               All values are intentionally left optional. Clients SHOULD follow
+               the advise given in the field description when the field is not avaliable.
 
                **NOTE:** Reverse proxies may apply their own configuration.
                
 
-               If an accessToken is supplied, the configuration applied to the authenticated user.
+               If an accessToken is supplied, the configuration applied to the authenticated user is returned.
                Otherwise it should give the configuration applied globally to the server.
       operationId: getConfig
       produces: ["application/json"]
@@ -293,7 +293,9 @@ paths:
             properties:
               m.upload.size:
                 type: number
-                description: "The maximum size an upload can be in bytes."
+                description: |- 
+                  The maximum size an upload can be in bytes. If not listed or null,
+                  the upload limit should be treated as unknown.
           examples:
             application/json: {
                "m.upload.size": 50000000

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -272,14 +272,15 @@ paths:
   "/config":
     get:
       summary: Get the configuration for the content repository.
-      description: Clients SHOULD use this as a guide when using content repository endpoints.
-                   All values are intentionally left optional. Clients SHOULD follow
-                   the advice given in the field description when the field is not available.
+      description: |-
+        Clients SHOULD use this as a guide when using content repository endpoints.
+        All values are intentionally left optional. Clients SHOULD follow
+        the advice given in the field description when the field is not available.
 
-                   **NOTE:** Both clients and server administrators should be aware that proxies
-                   between the client and the server may affect the apparent behaviour of content
-                   repository APIs, for example, proxies may enforce a lower upload size limit
-                   than is advertised by the server on this endpoint.
+        **NOTE:** Both clients and server administrators should be aware that proxies
+        between the client and the server may affect the apparent behaviour of content
+        repository APIs, for example, proxies may enforce a lower upload size limit
+        than is advertised by the server on this endpoint.
       operationId: getConfig
       produces: ["application/json"]
       security:

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -287,12 +287,12 @@ paths:
           schema:
             type: object
             properties:
-              size:
+              upload_size:
                 type: number
                 description: "The maximum size a upload can be in bytes."
           examples:
             application/json: {
-                "size": 50000000
+                "upload_size": 50000000
               }
       tags:
         - Media

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -271,16 +271,17 @@ paths:
         - Media
   "/config":
     get:
-      summary: Get the config for the media repository.
+      summary: Get the configuration for the media repository.
                Clients SHOULD use this as a guide when uploading content.
                All values are intentionally left optional, the client MUST assume
                that any field not given is not limited.
 
-               **NOTE:** Reverse proxies may apply their own limits.
+               **NOTE:** Reverse proxies may apply their own configuration.
+               
 
-               If auth is not supplied, this endpoint gives the global limit of the server.
-               Otherwise it should give the limits applied to the authenticated user.
-      operationId: getLimits
+               If an accessToken is supplied, the configuration applied to the authenticated user.
+               Otherwise it should give the configuration applied globally to the server.
+      operationId: getConfig
       produces: ["application/json"]
       security:
         - accessToken: []
@@ -297,5 +298,10 @@ paths:
             application/json: {
                "m.upload.size": 50000000
             }
+        429:
+          description: This request was rate-limited.
+          schema:
+            "$ref": "definitions/error.yaml"
+
       tags:
         - Media

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -286,7 +286,7 @@ paths:
         - accessToken: []
       responses:
         200:
-          description: The limits exposed by the matrix server.
+          description: The public content repository configuration for the matrix server.
           schema:
             type: object
             properties:
@@ -295,7 +295,7 @@ paths:
                 description: "The maximum size an upload can be in bytes."
           examples:
             application/json: {
-                "m.upload.size": 50000000
-              }
+               "m.upload.size": 50000000
+            }
       tags:
         - Media


### PR DESCRIPTION
## Rationale
Often I'll upload things that are too large to the homeserver and then find that it only gets rejected once it has uploaded a sizable portion. This is intensely frustrating when I am on a mobile network or a slow connection.

This PR adds the endpoint for the homeserver to specify limits to uploads. Currently, this is only maximum size, but I would eventually expect this to be adapted to content types, per-user limits or something else.

Clients can then decide whether to attempt an upload.

GDoc https://docs.google.com/document/d/1fI4ZqQcyAyBEPMtS1MCZWpN84kEPdm9SDw6SVZsJvYY/edit?usp=sharing

### Collection of PRs
- Synapse https://github.com/matrix-org/synapse/pull/3184
- Matrix JS SDK https://github.com/matrix-org/matrix-js-sdk/pull/644
- Matrix React SDK https://github.com/matrix-org/matrix-react-sdk/pull/1876