### PR TITLE
/rooms/{roomId}/members: specify access_token requirement

### DIFF
--- a/api/client-server/rooms.yaml
+++ b/api/client-server/rooms.yaml
@@ -288,6 +288,8 @@ paths:
           description: The room to get the member events for.
           required: true
           x-example: "!636q39766251:example.com"
+      security:
+        - accessToken: []
       responses:
         200:
           description: |-

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -35,6 +35,8 @@ Unreleased changes
     (`#1139 <https://github.com/matrix-org/matrix-doc/pull/1139>`_).
   - Clarify that ``/account/whoami`` should consider application services
     (`#1152 <https://github.com/matrix-org/matrix-doc/pull/1152>`_).
+  - Mark ``GET /rooms/{roomId}/members`` as requiring authentication
+    (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 


### PR DESCRIPTION
as the behaviour of which members the users see is user-specific
and therefore requires authentication:

> A list of members of the room. If you are joined to the room then this will be the current members of the room. If you have left the room then this will be the members of the room when you left.

More details at #1245