### PR TITLE
Add 'default' to formally enforce the description

### DIFF
--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -100,6 +100,7 @@ paths:
           name: allow_remote
           x-example: false
           required: false
+          default: true
           description: |
             Indicates to the server that it should not attempt to fetch the media if it is deemed
             remote. This is to prevent routing loops where the server contacts itself. Defaults to 
@@ -154,6 +155,7 @@ paths:
           name: allow_remote
           x-example: false
           required: false
+          default: true
           description: |
             Indicates to the server that it should not attempt to fetch the media if it is deemed
             remote. This is to prevent routing loops where the server contacts itself. Defaults to 
@@ -221,6 +223,7 @@ paths:
           name: allow_remote
           x-example: false
           required: false
+          default: true
           description: |
             Indicates to the server that it should not attempt to fetch the media if it is deemed
             remote. This is to prevent routing loops where the server contacts itself. Defaults to 


### PR DESCRIPTION
As a quick follow up on #1265, rather than just say in the description that a parameter defaults to 'true', enforce the same in the API definition.