### PR TITLE
Add verbage for how per-room profiles work

### DIFF
--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -56,6 +56,8 @@ Unreleased changes
     (`#1263 <https://github.com/matrix-org/matrix-doc/pull/1263>`_).
   - Document `highlights` field in /search response
     (`#1274 <https://github.com/matrix-org/matrix-doc/pull/1274>`_).
+  - Document how per-room profiles work
+    (`#1302 <https://github.com/matrix-org/matrix-doc/pull/1302>`_).
 
 r0.3.0
 ======

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1372,6 +1372,19 @@ users, they should include the display name and avatar URL fields in these
 events so that clients already have these details to hand, and do not have to
 perform extra round trips to query it.
 
+Per-room Profiles
++++++++++++++++++
+Users may wish to have a different display name or avatar or both in a specific
+room. To accomplish this, the client should modify the ``displayname`` and 
+``avatar_url`` properties of the user's ``m.room.member`` event in the room. 
+
+Homeservers SHOULD NOT overwrite ``m.room.member`` events that were updated in
+this way when the client invokes the dedicated profile API. Further, homeservers
+should not return per-room profiles as part of this profile API.
+
+Clients SHOULD use the ``m.room.member`` event for users in a room when showing
+profiles to the user.
+
 Security
 --------
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/545

## Note

This assumes the following is desired in the spec:
> we might need server-side support to ensure you can still change your "default" displayname without breaking per-room displaynames

https://github.com/matrix-org/matrix-doc/issues/545#issuecomment-306156163