### PR TITLE
2.3.3 Appservice should use auth.type

### DIFF
--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -253,8 +253,10 @@ including the AS token on a ``/register`` request, along with a login type of
   /register?access_token=$as_token
 
   Content:
-  {
-    type: "m.login.application_service",
+  { 
+    auth: {
+      type: "m.login.application_service"
+    },
     username: "<desired user localpart in AS namespace>"
   }
 


### PR DESCRIPTION
...rather than type for registration. The reason for this is that the C-S api /register uses ``auth.type`` and the AS api was using ``type`` as a holdover from those days. This PR brings it up to date.