### PR TITLE
Don't suggest reusing old issues for spec proposals

### DIFF
--- a/specification/proposals_intro.rst
+++ b/specification/proposals_intro.rst
@@ -31,8 +31,9 @@ The process for submitting a Matrix Spec Change (MSC) Proposal is as follows:
     is available.
 
 - Make a new issue at https://github.com/matrix-org/matrix-doc/issues, whose
-  description should list the metadata as per below. If an existing issue
-  relates to your proposal, link to it in your new issue.
+  description should list the metadata as per below. Use the github search
+  function to attempt to locate any related github issues, and link any that
+  are found in the body of the new issue.
 - Gather feedback as widely as possible from the community and core team on
   the proposal.
 

--- a/specification/proposals_intro.rst
+++ b/specification/proposals_intro.rst
@@ -30,9 +30,9 @@ The process for submitting a Matrix Spec Change (MSC) Proposal is as follows:
     <https://docs.google.com/document/d/1CoLCPTcRFvD4PqjvbUl3ZIWgGLpmRNbqxsT2Tu7lCzI/>`_
     is available.
 
-- Make a new issue at https://github.com/matrix-org/matrix-doc/issues (or
-  modify an existing one), whose description should list the metadata as per
-  below.
+- Make a new issue at https://github.com/matrix-org/matrix-doc/issues, whose
+  description should list the metadata as per below. If an existing issue
+  relates to your proposal, link to it in your new issue.
 - Gather feedback as widely as possible from the community and core team on
   the proposal.
 


### PR DESCRIPTION
In practice this was confusing for people, so instead we should encourage people to create new issues and reference the existing ones.

This also serves as a self-declared trial run for https://github.com/matrix-org/matrix-doc/issues/1308