### PR TITLE
Deprecate several fields on /createRoom

### DIFF
--- a/api/client-server/create_room.yaml
+++ b/api/client-server/create_room.yaml
@@ -93,6 +93,12 @@ paths:
                   If this is included, an ``m.room.name`` event will be sent
                   into the room to indicate the name of the room. See Room
                   Events for more information on ``m.room.name``.
+              avatar:
+                type: string
+                description: |-
+                  If this is included, an ``m.room.avatar`` event will be sent
+                  into the room to indicate the avatar for the room. See Room
+                  Events for more information on ``m.room.avatar``.
               topic:
                 type: string
                 description: |-

--- a/api/client-server/create_room.yaml
+++ b/api/client-server/create_room.yaml
@@ -92,19 +92,19 @@ paths:
                 description: |-
                   If this is included, an ``m.room.name`` event will be sent
                   into the room to indicate the name of the room. See Room
-                  Events for more information on ``m.room.name``.
-              avatar:
-                type: string
-                description: |-
-                  If this is included, an ``m.room.avatar`` event will be sent
-                  into the room to indicate the avatar for the room. See Room
-                  Events for more information on ``m.room.avatar``.
+                  Events for more information on ``m.room.name``. 
+
+                  **Deprecated**. Clients should use ``initial_state`` instead
+                  to set the room's name.
               topic:
                 type: string
                 description: |-
                   If this is included, an ``m.room.topic`` event will be sent
                   into the room to indicate the topic for the room. See Room
                   Events for more information on ``m.room.topic``.
+
+                  **Deprecated**. Clients should use ``initial_state`` instead
+                  to set the room's topic.
               invite:
                 type: array
                 description: |-
@@ -149,7 +149,7 @@ paths:
                   with type, state_key and content keys set.
 
                   Takes precedence over events set by ``presets``, but gets
-                  overriden by the ``name``, ``topic``, and ``avatar`` keys.
+                  overriden by ``name`` and ``topic`` keys.
                 items:
                   type: object
                   title: StateEvent

--- a/api/client-server/create_room.yaml
+++ b/api/client-server/create_room.yaml
@@ -189,6 +189,9 @@ paths:
                 type: boolean
                 description: |-
                   Allows guests to join the room. See `Guest Access`_ for more information.
+
+                  **Deprecated**. Clients should use ``initial_state`` instead
+                  to set the room's guest access policy.
       responses:
         200:
           description: Information about the newly created room.

--- a/api/client-server/create_room.yaml
+++ b/api/client-server/create_room.yaml
@@ -149,7 +149,7 @@ paths:
                   with type, state_key and content keys set.
 
                   Takes precedence over events set by ``presets``, but gets
-                  overriden by ``name`` and ``topic`` keys.
+                  overriden by the ``name``, ``topic``, and ``avatar`` keys.
                 items:
                   type: object
                   title: StateEvent

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -56,7 +56,7 @@ Unreleased changes
     (`#1263 <https://github.com/matrix-org/matrix-doc/pull/1263>`_).
   - Document `highlights` field in /search response
     (`#1274 <https://github.com/matrix-org/matrix-doc/pull/1274>`_).
-  - Add the option of setting an avatar for a room when creating it
+  - Deprecate the ``name`` and ``topic`` fields on ``/createRoom``
     (`#1326 <https://github.com/matrix-org/matrix-doc/pull/1326>`_).
 
 r0.3.0

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -56,6 +56,8 @@ Unreleased changes
     (`#1263 <https://github.com/matrix-org/matrix-doc/pull/1263>`_).
   - Document `highlights` field in /search response
     (`#1274 <https://github.com/matrix-org/matrix-doc/pull/1274>`_).
+  - Add the option of setting an avatar for a room when creating it
+    (`#1326 <https://github.com/matrix-org/matrix-doc/pull/1326>`_).
 
 r0.3.0
 ======

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -56,7 +56,7 @@ Unreleased changes
     (`#1263 <https://github.com/matrix-org/matrix-doc/pull/1263>`_).
   - Document `highlights` field in /search response
     (`#1274 <https://github.com/matrix-org/matrix-doc/pull/1274>`_).
-  - Deprecate the ``name`` and ``topic`` fields on ``/createRoom``
+  - Deprecate several fields on ``/createRoom``
     (`#1326 <https://github.com/matrix-org/matrix-doc/pull/1326>`_).
 
 r0.3.0


### PR DESCRIPTION
Originally this PR was to add an `avatar` field, however after discussion with the community it was determined that deprecating the parameters would be better than adding a third. Clients can use `initial_state` to set the name, avatar, and topic.