### PR TITLE
Document StateEvent for /createRoom

### DIFF
--- a/api/client-server/create_room.yaml
+++ b/api/client-server/create_room.yaml
@@ -157,6 +157,7 @@ paths:
                     content:
                       type: object
                       description: The content of the event.
+                  required: ["type", "content"]
               preset:
                 type: string
                 enum: ["private_chat", "public_chat", "trusted_private_chat"]

--- a/api/client-server/create_room.yaml
+++ b/api/client-server/create_room.yaml
@@ -150,10 +150,13 @@ paths:
                   properties:
                     type:
                       type: string
+                      description: The type of event to send.
                     state_key:
                       type: string
+                      description: The state_key of the state event. Defaults to an empty string.
                     content:
                       type: object
+                      description: The content of the event.
               preset:
                 type: string
                 enum: ["private_chat", "public_chat", "trusted_private_chat"]

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -37,6 +37,8 @@ Unreleased changes
     (`#1152 <https://github.com/matrix-org/matrix-doc/pull/1152>`_).
   - Mark ``GET /rooms/{roomId}/members`` as requiring authentication
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
+  - Describe ``StateEvent`` for ``/createRoom``
+    (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 


### PR DESCRIPTION
I mostly copied and pasted from https://matrix.org/docs/spec/client_server/r0.3.0.html#get-matrix-client-r0-rooms-roomid-state-eventtype-statekey but obviously changed it where needed. I also tidied up the English to read better e.g. "Defaults to the empty string" => "Defaults to an empty string"

Fixes #1327 