### PR TITLE
Consolidate backwards-compatible client changes

### DIFF
--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -15,6 +15,22 @@ Unreleased changes
   - Sticker messages:
     - Add sticker message event definition.
     (`#1158 <https://github.com/matrix-org/matrix-doc/pull/1158>`_).
+  - Add 'token' parameter to /keys/query endpoint
+    (`#1104 <https://github.com/matrix-org/matrix-doc/pull/1104>`_).
+  - Add the room visibility options for the room directory
+    (`#1141 <https://github.com/matrix-org/matrix-doc/pull/1141>`_).
+  - Add spec for ignoring users
+    (`#1142 <https://github.com/matrix-org/matrix-doc/pull/1142>`_).
+  - Add the ``/register/available`` endpoint for username availability
+    (`#1151 <https://github.com/matrix-org/matrix-doc/pull/1151>`_).
+  - Add ``allow_remote`` to the content repo to avoid routing loops
+    (`#1265 <https://github.com/matrix-org/matrix-doc/pull/1265>`_).
+  - Add report content API
+    (`#1264 <https://github.com/matrix-org/matrix-doc/pull/1264>`_).
+  - Document ``/logout/all`` endpoint
+    (`#1263 <https://github.com/matrix-org/matrix-doc/pull/1263>`_).
+  - Document `highlights` field in /search response
+    (`#1274 <https://github.com/matrix-org/matrix-doc/pull/1274>`_).
 
 - Spec clarifications:
 
@@ -39,25 +55,6 @@ Unreleased changes
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
   - Describe ``StateEvent`` for ``/createRoom``
     (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
-
-- Changes to the API which will be backwards-compatible for clients:
-
-  - Add 'token' parameter to /keys/query endpoint
-    (`#1104 <https://github.com/matrix-org/matrix-doc/pull/1104>`_).
-  - Add the room visibility options for the room directory
-    (`#1141 <https://github.com/matrix-org/matrix-doc/pull/1141>`_).
-  - Add spec for ignoring users
-    (`#1142 <https://github.com/matrix-org/matrix-doc/pull/1142>`_).
-  - Add the ``/register/available`` endpoint for username availability
-    (`#1151 <https://github.com/matrix-org/matrix-doc/pull/1151>`_).
-  - Add ``allow_remote`` to the content repo to avoid routing loops
-    (`#1265 <https://github.com/matrix-org/matrix-doc/pull/1265>`_).
-  - Add report content API
-    (`#1264 <https://github.com/matrix-org/matrix-doc/pull/1264>`_).
-  - Document ``/logout/all`` endpoint
-    (`#1263 <https://github.com/matrix-org/matrix-doc/pull/1263>`_).
-  - Document `highlights` field in /search response
-    (`#1274 <https://github.com/matrix-org/matrix-doc/pull/1274>`_).
 
 r0.3.0
 ======


### PR DESCRIPTION
You have two sections for the same things.

`Signed-off-by: Remi Rampin <remirampin@gmail.com>`