### PR TITLE
Document the GET version of /login

### DIFF
--- a/api/client-server/login.yaml
+++ b/api/client-server/login.yaml
@@ -28,6 +28,42 @@ securityDefinitions:
   $ref: definitions/security.yaml
 paths:
   "/login":
+    get:
+      summary: Get the supported login types to authenticate users
+      description: |-
+        Gets the homeserver's supported login types to authenticate users. Clients
+        should pick one of these and supply it as the ``type`` when logging in.
+      operationId: getLoginFlows
+      responses:
+        200:
+          description: The login types the homeserver supports
+          examples:
+            application/json: {
+              "flows": [
+                {"type": "m.login.password"}
+              ]
+            }
+          schema:
+            type: object
+            properties:
+              flows:
+                type: array
+                description: The homeserver's supported login types
+                items:
+                  type: object
+                  title: LoginFlow
+                  properties:
+                    type:
+                      description: |-
+                        The login type. This is supplied as the ``type`` when
+                        logging in.
+                      type: string
+        429:
+          description: This request was rate-limited.
+          schema:
+            "$ref": "definitions/error.yaml"
+      tags:
+        - Session management
     post:
       summary: Authenticates the user.
       description: |-

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -15,6 +15,8 @@ Unreleased changes
   - Sticker messages:
     - Add sticker message event definition.
     (`#1158 <https://github.com/matrix-org/matrix-doc/pull/1158>`_).
+  - Document the GET version of ``/login``
+    (`#1361 <https://github.com/matrix-org/matrix-doc/pull/1361>`_).
 
 - Spec clarifications:
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/677

This PR documents existing behaviour and does not attempt to improve or change the situation.

Reference: https://github.com/matrix-org/synapse/blob/53969e196004659c6a9f138f5d8abd86f4957d74/synapse/rest/client/v1/login.py#L105-L127