### PR TITLE
Explicitly declare that the kick/ban reason will be on the membership event

### DIFF
--- a/api/client-server/banning.yaml
+++ b/api/client-server/banning.yaml
@@ -61,7 +61,8 @@ paths:
                 description: The fully qualified user ID of the user being banned.
               reason:
                 type: string
-                description: The reason the user has been banned.
+                description: The reason the user has been banned. This will be supplied as the 
+                  ``reason`` on the target's updated `m.room.member`_ event.
             required: ["user_id"]
       responses:
         200:

--- a/api/client-server/kicking.yaml
+++ b/api/client-server/kicking.yaml
@@ -34,6 +34,10 @@ paths:
         Kick a user from the room.
 
         The caller must have the required power level in order to perform this operation.
+        
+        Kicking a user adjusts the target member's membership state to be ``leave`` with an
+        optional ``reason``. Like with other membership changes, a user can directly adjust
+        the target member's state by making a request to ``/rooms/<room id>/state/m.room.member/<user id>``.
       operationId: kick
       security:
         - accessToken: []
@@ -59,7 +63,9 @@ paths:
                 description: The fully qualified user ID of the user being kicked.
               reason:
                 type: string
-                description: The reason the user has been kicked.
+                description: |-
+                  The reason the user has been kicked. This will be supplied as the 
+                  ``reason`` on the target's updated `m.room.member`_ event.
             required: ["user_id"]
       responses:
         200:

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -39,6 +39,8 @@ Unreleased changes
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
   - Describe ``StateEvent`` for ``/createRoom``
     (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
+  - Describe how the ``reason`` is handled for kicks/bans
+    (`#1362 <https://github.com/matrix-org/matrix-doc/pull/1362>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/798

This PR documents existing behaviour and does not attempt to improve or change the situation.

Reference: https://github.com/matrix-org/synapse/blob/53969e196004659c6a9f138f5d8abd86f4957d74/synapse/rest/client/v1/room.py#L639-L641