### PR TITLE
Document the server_name query parameter on /join/{roomIdOrAlias}

### DIFF
--- a/api/client-server/joining.yaml
+++ b/api/client-server/joining.yaml
@@ -147,7 +147,6 @@ paths:
           type: array
           items:
             type: string
-          explode: true
           name: server_name
           description: |-
             The servers to attempt to join the room through. One of the servers

--- a/api/client-server/joining.yaml
+++ b/api/client-server/joining.yaml
@@ -143,6 +143,16 @@ paths:
           description: The room identifier or alias to join.
           required: true
           x-example: "#monkeys:matrix.org"
+        - in: query
+          type: array
+          items:
+            type: string
+          explode: true
+          name: server_name
+          description: |-
+            The servers to attempt to join the room through. One of the servers
+            must be participating in the room.
+          x-example: ["matrix.org", "elsewhere.ca"]
         - in: body
           name: third_party_signed
           schema:

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -15,6 +15,8 @@ Unreleased changes
   - Sticker messages:
     - Add sticker message event definition.
     (`#1158 <https://github.com/matrix-org/matrix-doc/pull/1158>`_).
+  - Document the ``server_name`` parameter on ``/join/{roomIdOrAlias}``
+    (`#1364 <https://github.com/matrix-org/matrix-doc/pull/1364>`_).
 
 - Spec clarifications:
 

--- a/scripts/templating/matrix_templates/units.py
+++ b/scripts/templating/matrix_templates/units.py
@@ -502,6 +502,11 @@ class MatrixUnits(Units):
                 # assign value expected for this param
                 val_type = param.get("type")  # integer/string
 
+                if val_type == "array":
+                    items = param.get("items")
+                    if items:
+                        val_type = "[%s]" % items.get("type")
+
                 if param.get("enum"):
                     val_type = "enum"
                     desc += (


### PR DESCRIPTION
Fixes: https://github.com/matrix-org/matrix-doc/issues/904

This PR documents existing behaviour and does not attempt to improve or change the situation.

Reference material:
* https://github.com/matrix-org/synapse/pull/794
* https://github.com/matrix-org/synapse/issues/2171

This parameter is not included on the `/rooms/!room/join` endpoint because that is not currently done. See https://github.com/matrix-org/matrix-doc/issues/1363