### PR TITLE
Document how per-room profiles work

### DIFF
--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -41,6 +41,8 @@ Unreleased changes
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
   - Describe ``StateEvent`` for ``/createRoom``
     (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
+  - Describe how per-room profiles work
+    (`#1367 <https://github.com/matrix-org/matrix-doc/pull/1367>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1372,6 +1372,15 @@ users, they should include the display name and avatar URL fields in these
 events so that clients already have these details to hand, and do not have to
 perform extra round trips to query it.
 
+Per-room Profiles
++++++++++++++++++
+Users may wish to have a different display name or avatar or both in a specific
+room. To accomplish this, the client should modify the ``displayname`` and 
+``avatar_url`` properties of the user's ``m.room.member`` event in the room. 
+
+Clients SHOULD use the ``m.room.member`` event for users in a room when showing
+profiles to the user.
+
 Security
 --------
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/545

This PR documents existing behaviour and does not attempt to improve or change the situation.

This is another attempt at https://github.com/matrix-org/matrix-doc/pull/1302, however with the controversial parts removed.