### PR TITLE
Getting presence requires authentication

### DIFF
--- a/api/client-server/presence.yaml
+++ b/api/client-server/presence.yaml
@@ -123,6 +123,15 @@ paths:
           description: |-
             There is no presence state for this user. This user may not exist or
             isn't exposing presence information to you.
+        403:
+          description: You are not allowed to see this user's presence status.
+          examples:
+            application/json: {
+              "errcode": "M_FORBIDDEN",
+              "error": "You are not allowed to see their presence"
+            }
+          schema:
+            "$ref": "definitions/error.yaml"
       tags:
         - Presence
   "/presence/list/{userId}":

--- a/api/client-server/presence.yaml
+++ b/api/client-server/presence.yaml
@@ -83,6 +83,8 @@ paths:
       description: |-
         Get the given user's presence state.
       operationId: getPresence
+      security:
+        - accessToken: []
       parameters:
         - in: path
           type: string

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -39,6 +39,8 @@ Unreleased changes
     (`#1152 <https://github.com/matrix-org/matrix-doc/pull/1152>`_).
   - Mark ``GET /rooms/{roomId}/members`` as requiring authentication
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
+  - Mark ``GET /presence/{userId}/status`` as requiring authentication
+    (`#1371 <https://github.com/matrix-org/matrix-doc/pull/1371>`_).
   - Describe ``StateEvent`` for ``/createRoom``
     (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
 


### PR DESCRIPTION
This PR documents existing behaviour and does not attempt to improve or change the situation.

Synapse does this:
```
$ curl -s https://t2l.io/_matrix/client/r0/presence/@travis:t2l.io/status
{
    "errcode": "M_MISSING_TOKEN",
    "error": "Missing access token."
}
```