### PR TITLE
Document that clients must leave before forgetting rooms

### DIFF
--- a/api/client-server/leaving.yaml
+++ b/api/client-server/leaving.yaml
@@ -78,8 +78,8 @@ paths:
         for this room. If all users on a homeserver forget a room, the room is
         eligible for deletion from that homeserver.
 
-        If the user is currently joined to the room, they will implicitly leave
-        the room as part of this API call.
+        If the user is currently joined to the room, they must leave the room
+        before calling this API.
       operationId: forgetRoom
       security:
         - accessToken: []

--- a/api/client-server/leaving.yaml
+++ b/api/client-server/leaving.yaml
@@ -99,6 +99,15 @@ paths:
               }
           schema:
             type: object
+        400:
+          description: The user has not left the room
+          examples:
+            application/json: {
+              "errcode": "M_UNKNOWN",
+              "error": "User @example:matrix.org is in room !au1ba7o:matrix.org"
+            }
+          schema:
+            "$ref": "definitions/error.yaml"
         429:
           description: This request was rate-limited.
           schema:

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -41,6 +41,8 @@ Unreleased changes
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
   - Describe ``StateEvent`` for ``/createRoom``
     (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
+  - Clarify that clients must leave rooms before forgetting them
+    (`#1378 <https://github.com/matrix-org/matrix-doc/pull/1378>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1011

This PR documents existing behaviour and does not attempt to improve or change the situation.

Reference: https://github.com/matrix-org/synapse/pull/673