### PR TITLE
Define RoomEvent on /rooms/{roomId}/messages

### DIFF
--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -107,6 +107,7 @@ paths:
                 items:
                   type: object
                   title: RoomEvent
+                  "$ref": "definitions/event-schemas/schema/core-event-schema/room_event.yaml"
           examples:
             application/json: {
                 "start": "t47429-4392820_219380_26003_2265",

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -39,6 +39,8 @@ Unreleased changes
     (`#1152 <https://github.com/matrix-org/matrix-doc/pull/1152>`_).
   - Mark ``GET /rooms/{roomId}/members`` as requiring authentication
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
+  - Define what a ``RoomEvent`` is on ``/rooms/{roomId}/messages``
+    (`#1380 <https://github.com/matrix-org/matrix-doc/pull/1380>`_).
   - Describe ``StateEvent`` for ``/createRoom``
     (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
 


### PR DESCRIPTION
Cherry-picked from https://github.com/matrix-org/matrix-doc/pull/1186 (thanks @KitsuneRal!)

Fixes https://github.com/matrix-org/matrix-doc/issues/1184

This PR documents existing behaviour and does not attempt to improve or change the situation.