### PR TITLE
Rename some titles to avoid confusion between request and response schemas 

### DIFF
--- a/api/client-server/search.yaml
+++ b/api/client-server/search.yaml
@@ -74,7 +74,7 @@ paths:
                 properties:
                   room_events:
                     type: object
-                    title: "Room Events"
+                    title: Room Events Criteria
                     description: Mapping of category name to search criteria.
                     properties:
                       search_term:
@@ -103,7 +103,7 @@ paths:
                           The order in which to search for results.
                           By default, this is ``"rank"``.
                       event_context:
-                        title: "Event Context"
+                        title: "Include Event Context"
                         type: object
                         description: |-
                           Configures whether any context for the events
@@ -169,13 +169,13 @@ paths:
             properties:
               search_categories:
                 type: object
-                title: Categories
+                title: Result Categories
                 description: Describes which categories to search in and
                   their criteria.
                 properties:
                   room_events:
                     type: object
-                    title: Room Event Results
+                    title: Result Room Events
                     description: Mapping of category name to search criteria.
                     properties:
                       count:

--- a/api/client-server/search.yaml
+++ b/api/client-server/search.yaml
@@ -103,7 +103,7 @@ paths:
                           The order in which to search for results.
                           By default, this is ``"rank"``.
                       event_context:
-                        title: "Include Event Context"
+                        title: Include Event Context
                         type: object
                         description: |-
                           Configures whether any context for the events

--- a/changelogs/client_server.rst
+++ b/changelogs/client_server.rst
@@ -41,6 +41,8 @@ Unreleased changes
     (`#1245 <https://github.com/matrix-org/matrix-doc/pull/1244>`_).
   - Describe ``StateEvent`` for ``/createRoom``
     (`#1329 <https://github.com/matrix-org/matrix-doc/pull/1329>`_).
+  - Clarify the request and result types on ``/search``
+    (`#1381 <https://github.com/matrix-org/matrix-doc/pull/1381>`_).
 
 - Changes to the API which will be backwards-compatible for clients:
 


### PR DESCRIPTION
Cherry-picked from https://github.com/matrix-org/matrix-doc/pull/1186 (thanks @KitsuneRal!)

This PR documents existing behaviour and does not attempt to improve or change the situation.