### PR TITLE
Add a config for circleci which builds the doc preview

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build-docs:
+    docker:
+      - image: uhoreg/matrix-doc-build
+    steps:
+      - checkout
+      - run: python scripts/gendoc.py
+
+workflows:
+  version: 2
+
+  egg-info:
+    jobs:
+      - build-docs
+
+notify:
+  webhooks:
+    - url: https://giles.cadair.com/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,17 @@
+gendoc: &gendoc
+  name: Generate the docs
+  command: |
+    source /env/bin/activate
+    scripts/gendoc.py
+
 version: 2
 jobs:
   build-docs:
     docker:
-      - image: circleci/python:2.7
+      - image: uhoreg/matrix-doc-build
     steps:
       - checkout
-      - run: pip install -r scripts/requirements.txt
-      - run: python scripts/gendoc.py
+      - run: *gendoc
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - checkout
       - run: *gendoc
+      - store_artifacts:
+          path: scripts/gen
+      - run:
+          name: "Doc build is available at:"
+          command: DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/scripts/gen/index.html"; echo $DOCS_URL
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,10 @@ version: 2
 jobs:
   build-docs:
     docker:
-      - image: uhoreg/matrix-doc-build
+      - image: circleci/python:2.7
     steps:
       - checkout
+      - run: pip install -r scripts/requirements.txt
       - run: python scripts/gendoc.py
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,12 @@ gendoc: &gendoc
     source /env/bin/activate
     scripts/gendoc.py
 
+gendoc: &genswagger
+  name: Generate the swagger
+  command: |
+    source /env/bin/activate
+    scripts/dump-swagger.py
+
 version: 2
 jobs:
   build-docs:
@@ -18,12 +24,25 @@ jobs:
           name: "Doc build is available at:"
           command: DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/scripts/gen/index.html"; echo $DOCS_URL
 
+  build-swagger:
+    docker:
+      - image: uhoreg/matrix-doc-build
+    steps:
+      - checkout
+      - run: *genswagger
+      - store_artifacts:
+          path: scripts/swagger/api-docs.json
+      - run:
+          name: "Swagger UI is available at:"
+          command: SWAGGER_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/scripts/swagger/api-docs.json"; echo "https://matrix.org/docs/api/client-server/?url="$SWAGGER_URL
+
 workflows:
   version: 2
 
-  egg-info:
+  build-spec:
     jobs:
       - build-docs
+      - build-swagger
 
 notify:
   webhooks:


### PR DESCRIPTION
The swagger build doesn't work for lack of the Cross Origin Header from circleci, but the documentation one does.