### PR TITLE
Document message formats as-is

### DIFF
--- a/changelogs/client_server/newsfragments/1397.feature
+++ b/changelogs/client_server/newsfragments/1397.feature
@@ -1,0 +1,1 @@
+Document message formats on ``m.text`` and ``m.emote`` messages

--- a/event-schemas/examples/m.room.message#m.emote
+++ b/event-schemas/examples/m.room.message#m.emote
@@ -2,7 +2,9 @@
   "age": 242352,
   "content": {
     "body": "thinks this is an example emote",
-    "msgtype": "m.emote"
+    "msgtype": "m.emote",
+    "format": "org.matrix.custom.html",
+    "formatted_body": "thinks <b>this</b> is an example emote"
   },
   "origin_server_ts": 1431961217939,
   "event_id": "$WLGTSEFSEF:localhost",

--- a/event-schemas/examples/m.room.message#m.text
+++ b/event-schemas/examples/m.room.message#m.text
@@ -2,7 +2,9 @@
   "age": 242352,
   "content": {
     "body": "This is an example text message",
-    "msgtype": "m.text"
+    "msgtype": "m.text",
+    "format": "org.matrix.custom.html",
+    "formatted_body": "<b>This is an example text message</b>"
   },
   "origin_server_ts": 1431961217939,
   "event_id": "$WLGTSEFSEF:localhost",

--- a/event-schemas/schema/m.room.message#m.emote
+++ b/event-schemas/schema/m.room.message#m.emote
@@ -12,6 +12,16 @@ properties:
         enum:
           - m.emote
         type: string
+      format:
+        description: |-
+          The format used in the ``formatted_body``. Currently only
+          ``org.matrix.custom.html`` is supported.
+        type: string
+      formatted_body:
+        description: |-
+          The formatted version of the ``body``. This is required if ``format``
+          is specified.
+        type: string
     required:
       - msgtype
       - body

--- a/event-schemas/schema/m.room.message#m.text
+++ b/event-schemas/schema/m.room.message#m.text
@@ -12,6 +12,16 @@ properties:
         enum:
           - m.text
         type: string
+      format:
+        description: |-
+          The format used in the ``formatted_body``. Currently only
+          ``org.matrix.custom.html`` is supported.
+        type: string
+      formatted_body:
+        description: |-
+          The formatted version of the ``body``. This is required if ``format``
+          is specified.
+        type: string
     required:
       - msgtype
       - body


### PR DESCRIPTION
This is likely to later be replaced by mixins (https://github.com/matrix-org/matrix-doc/issues/1225), however this is being documented now so clients aren't left in the dark.

Fixes https://github.com/matrix-org/matrix-doc/issues/917

This PR documents existing behaviour and does not attempt to improve or change the situation.