### PR TITLE
Convert the general query API to swagger

### DIFF
--- a/api/server-server/directory.yaml
+++ b/api/server-server/directory.yaml
@@ -1,4 +1,5 @@
 # Copyright 2017 Kamax.io
+# Copyright 2018 New Vector Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +15,7 @@
 
 swagger: '2.0'
 info:
-  title: "Matrix Federation Query Directory API"
+  title: "Matrix Federation Query API"
   version: "1.0.0"
 host: localhost:8448
 schemes:

--- a/api/server-server/query_general.yaml
+++ b/api/server-server/query_general.yaml
@@ -1,0 +1,44 @@
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+swagger: '2.0'
+info:
+  title: "Matrix Federation Query API"
+  version: "1.0.0"
+host: localhost:8448
+schemes:
+  - https
+basePath: /_matrix/federation/v1
+produces:
+  - application/json
+paths:
+  "/query/{queryType}":
+    get:
+      summary: Query for information
+      description: |-
+        Performs a single query request on the receiving homeserver. The query string
+        arguments are dependent on which type of query is being made. Known query types
+        are specified as their own endpoints as an extension to this definition.
+      operationId: queryInfo
+      parameters:
+        - in: path
+          name: queryType
+          type: string
+          description: The type of query to make
+          required: true
+          x-example: profile
+      responses:
+        200:
+          description: |-
+            The query response. The schema varies depending on the query being made.

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -801,16 +801,7 @@ Retrieves all of the transactions later than any version given by the "v"
 arguments.
 
 
-To make a query::
-
-  GET .../query/<query_type>
-    Query args: as specified by the individual query types
-    Response: JSON encoding of a response object
-
-Performs a single query request on the receiving homeserver. The Query Type
-part of the path specifies the kind of query being made, and its query
-arguments have a meaning specific to that kind of query. The response is a
-JSON-encoded object whose meaning also depends on the kind of query.
+{{query_general_ss_http_api}}
 
 
 To join a room::


### PR DESCRIPTION
Includes "moving" the directory query API into the same area. This will make more sense once the other query types are specified.

A later PR will improve the section. The goal here is to convert the code block to swagger.

Rendered: https://matrix.org/speculator/spec/1412/server_server/unstable.html#get-matrix-federation-v1-query-querytype