### PR TITLE
[WIP] Upgrade to OpenAPI/Swagger 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ buildswaggerui: &buildswaggerui
     mkdir -p api/client-server/json
     cp scripts/swagger/api-docs.json api/client-server/json/
     wget https://raw.githubusercontent.com/matrix-org/matrix.org/master/content/swagger.css -O api/client-server/swagger.css
-    wget https://raw.githubusercontent.com/matrix-org/matrix-doc/c035d51081b667d2ee945e9dc1eb10d6e758b7e2/scripts/swagger-ui.patch
+    wget https://raw.githubusercontent.com/matrix-org/matrix-doc/0cb85d579cd36a85ce28097504ba402415a1dcfa/scripts/swagger-ui.patch
     patch api/client-server/index.html swagger-ui.patch
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ buildswaggerui: &buildswaggerui
     cp scripts/swagger/api-docs.json api/client-server/json/
     wget https://raw.githubusercontent.com/matrix-org/matrix.org/master/content/swagger.css -O api/client-server/swagger.css
     wget https://raw.githubusercontent.com/matrix-org/matrix.org/master/scripts/swagger-ui.patch
-    patch api/client-server/index.html swagger-ui.patch
+    #patch api/client-server/index.html swagger-ui.patch
 
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ buildswaggerui: &buildswaggerui
   command: |
     ls scripts/
     mkdir -p api/client-server
-    git clone https://github.com/matrix-org/swagger-ui swagger-ui
+    git clone https://github.com/swagger-api/swagger-ui swagger-ui
     cp -r swagger-ui/dist/* api/client-server/
     mkdir -p api/client-server/json
     cp scripts/swagger/api-docs.json api/client-server/json/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ buildswaggerui: &buildswaggerui
     mkdir -p api/client-server/json
     cp scripts/swagger/api-docs.json api/client-server/json/
     wget https://raw.githubusercontent.com/matrix-org/matrix.org/master/content/swagger.css -O api/client-server/swagger.css
-    wget https://raw.githubusercontent.com/matrix-org/matrix.org/master/scripts/swagger-ui.patch
-    #patch api/client-server/index.html swagger-ui.patch
+    wget https://raw.githubusercontent.com/matrix-org/matrix-doc/c035d51081b667d2ee945e9dc1eb10d6e758b7e2/scripts/swagger-ui.patch
+    patch api/client-server/index.html swagger-ui.patch
 
 
 version: 2

--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -75,7 +75,7 @@ output = {
     },
     "securityDefinitions": {},
     "paths": {},
-    "swagger": "2.0",
+    "swagger": "3.0",
 }
 
 cs_api_dir = os.path.join(api_dir, 'client-server')

--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -75,7 +75,7 @@ output = {
     },
     "securityDefinitions": {},
     "paths": {},
-    "swagger": "3.0",
+    "openapi": "3.0.0",
 }
 
 cs_api_dir = os.path.join(api_dir, 'client-server')

--- a/scripts/swagger-ui.patch
+++ b/scripts/swagger-ui.patch
@@ -1,0 +1,41 @@
+diff --git a/original b/changed
+index 3b1ff23..c4af3c3 100644
+--- a/original
++++ b/changed
+@@ -4,6 +4,7 @@
+   <head>
+     <meta charset="UTF-8">
+     <title>Swagger UI</title>
++    <link rel="stylesheet" type="text/css" href="/swagger.css" >
+     <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
+     <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+     <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+@@ -40,7 +41,7 @@
+ 
+       // Build a system
+       const ui = SwaggerUIBundle({
+-        url: "https://petstore.swagger.io/v2/swagger.json",
++        url: window.location.pathname.replace(/[^/]*$/, '') + "json/api-docs.json";
+         dom_id: '#swagger-ui',
+         deepLinking: true,
+         presets: [
+@@ -54,6 +55,19 @@
+       })
+ 
+       window.ui = ui
++
++      $("#url_selector").submit(function(ev) {
++          ev.preventDefault();
++          window.hs_url = $("#serverurl").attr("value");
++          setHsUrl(window.hs_url);
++      });
++    }
++
++    function setHsUrl(hs_url) {
++      var r = hs_url.split("://", 2);
++      $("#serverurl").attr("value", hs_url);
++      window.swaggerUi.api.setSchemes([r[0]]);
++      window.swaggerUi.api.setHost(r[1]);
+     }
+   </script>
+   </body>

--- a/scripts/swagger-ui.patch
+++ b/scripts/swagger-ui.patch
@@ -1,7 +1,7 @@
-diff --git a/original b/changed
-index 3b1ff23..c4af3c3 100644
---- a/original
-+++ b/changed
+diff --git a/home/user/Desktop/original b/home/user/Desktop/changed
+index 3b1ff23..fbbdb02 100644
+--- a/home/user/Desktop/original
++++ b/home/user/Desktop/changed
 @@ -4,6 +4,7 @@
    <head>
      <meta charset="UTF-8">
@@ -15,7 +15,7 @@ index 3b1ff23..c4af3c3 100644
        // Build a system
        const ui = SwaggerUIBundle({
 -        url: "https://petstore.swagger.io/v2/swagger.json",
-+        url: window.location.pathname.replace(/[^/]*$/, '') + "json/api-docs.json";
++        url: window.location.pathname.replace(/[^/]*$/, '') + "json/api-docs.json",
          dom_id: '#swagger-ui',
          deepLinking: true,
          presets: [


### PR DESCRIPTION
Upgrading to OpenAPI v3.0 allows us to use a few very useful new features that would help out with some [current issues](https://github.com/matrix-org/matrix-doc/blob/2e5f530cca62b8c7e971670a80cc3b8dc13eac99/api/client-server/search.yaml#L92-L95) in [the spec](https://github.com/matrix-org/matrix-doc/pull/1414#issuecomment-407216721).

Closes #1429

Edit: Looks like https://github.com/matrix-org/swagger-ui will need to be upgraded to 3.0 as well in some manner.