### PR TITLE
Only get issues that are proposals when finding proposals

### DIFF
--- a/scripts/proposals.py
+++ b/scripts/proposals.py
@@ -28,7 +28,7 @@ def getpage(url, page):
 def getbylabel(label):
     pagecount = 1
     json = list()
-    urlbase = 'https://api.github.com/repos/matrix-org/matrix-doc/issues?state=all&labels=' + label + '&page='
+    urlbase = 'https://api.github.com/repos/matrix-org/matrix-doc/issues?state=all&labels=proposal,' + label + '&page='
     print(urlbase)
     json.extend(getpage(urlbase, 1))
     for page in range(2, int(pagecount) + 1):


### PR DESCRIPTION
Otherwise we end up with not-proposals showing up in the list. The current issue at hand is all the PRs which were flagged as `blocked` (now removed as of ~1hr ago) showed up as proposals on matrix.org despite not being a proposal.

I've gone through and made sure all the proposals have a `proposal` label already.