### PR TITLE
Document how leaving rooms/rejecting invites over federation works

### DIFF
--- a/api/server-server/leaving.yaml
+++ b/api/server-server/leaving.yaml
@@ -1,0 +1,266 @@
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+swagger: '2.0'
+info:
+  title: "Matrix Federation Leave Room API"
+  version: "1.0.0"
+host: localhost:8448
+schemes:
+  - https
+basePath: /_matrix/federation/v1
+produces:
+  - application/json
+paths:
+  "/make_leave/{roomId}/{userId}":
+    get:
+      summary: Get information required to make a join event for a room
+      description: |-
+        Asks the receiving server to return information that the sending
+        server will need to prepare a leave event to get out of the room.
+      operationId: makeLeave
+      parameters:
+        - in: path
+          name: roomId
+          type: string
+          description: The room ID that is about to be left.
+          required: true
+          x-example: "!abc123:matrix.org"
+        - in: path
+          name: userId
+          type: string
+          description: The user ID the leave event will be for.
+          required: true
+          x-example: "@someone:example.org"
+      responses:
+        200:
+          description: |-
+            An unsigned event that the sending server may use as a template
+            for when it calls ``/send_leave``.
+          schema:
+            allOf:
+              - $ref: "definitions/unsigned_pdu.yaml"
+              - type: object
+                properties:
+                  # Note: we override a bunch of parameters to change their descriptions
+                  sender:
+                    type: string
+                    description: The user ID of the leaving member.
+                    example: "@someone:example.org"
+                  origin:
+                    type: string
+                    description: The name of the resident homeserver.
+                    example: "matrix.org"    
+                  origin_server_ts:
+                    type: integer
+                    format: int64
+                    description: A timestamp added by the resident homeserver.
+                    example: 1234567890
+                  type:
+                    type: string
+                    description: The value ``m.room.member``.
+                    example: "m.room.member"
+                  state_key:
+                    type: string
+                    description: The user ID of the leaving member.
+                    example: "@someone:example.org"
+                  content:
+                    type: object
+                    title: Membership Event Content
+                    description: The content of the event.
+                    example: {"membership": "leave"}
+                    properties:
+                      membership:
+                        type: string
+                        description: The value ``leave``.
+                        example: "leave"
+                    required: ['membership']
+                  auth_events:
+                    type: array
+                    description: |-
+                      An event reference list containing the authorization events that would
+                      allow the member to leave the room. This should normally be the 
+                      ``m.room.create``, ``m.room.power_levels``, and ``m.room.join_rules``
+                      events.
+                    items:
+                      type: array
+                      maxItems: 2
+                      minItems: 2
+                      items:
+                        - type: string
+                          title: Event ID
+                          example: "$abc123:matrix.org"
+                        - type: object
+                          title: Event Hash
+                          example: {
+                            "sha256": "abase64encodedsha256hashshouldbe43byteslong"
+                          }
+                          properties:
+                            sha256:
+                              type: string
+                              description: The event hash.
+                              example: abase64encodedsha256hashshouldbe43byteslong
+                          required: ['sha256']
+                  redacts:
+                    type: string
+                    description: Not used.
+                required:
+                  # Every other field is already flagged as required by the $ref
+                  - state_key
+          examples:
+            application/json: {
+              "$ref": "examples/unsigned_pdu.json",
+              "type": "m.room.member",
+              "state_key": "@someone:example.org",
+              "content": {
+                  "membership": "leave"
+              },
+              "auth_events": [
+                ["$room_cre4te_3vent:matrix.org", {"sha256": "abase64encodedsha256hashshouldbe43byteslong"}],
+                ["$room_j0in_rul3s_3vent:matrix.org", {"sha256": "abase64encodedsha256hashshouldbe43byteslong"}],
+                ["$room_p0wer_l3vels_3vent:matrix.org", {"sha256": "abase64encodedsha256hashshouldbe43byteslong"}]
+              ]
+            }
+        403:
+          description: |-
+            The request is not authorized. This could mean that the user is not in the room.
+          schema:
+            $ref: "../client-server/definitions/errors/error.yaml"
+          examples:
+            application/json: {
+              "errcode": "M_FORBIDDEN",
+              "error": "User is not in the room."
+            }
+  "/send_leave/{roomId}/{eventId}":
+    put:
+      summary: Submit a signed leave event to a resident server
+      description: |-
+        Submits a signed leave event to the resident server for it
+        to accept it into the room's graph.
+      operationId: sendLeave
+      parameters:
+        - in: path
+          name: roomId
+          type: string
+          description: The room ID that is about to be left.
+          required: true
+          x-example: "!abc123:matrix.org"
+        - in: path
+          name: eventId
+          type: string
+          description: The event ID for the leave event.
+          required: true
+          x-example: "$abc123:example.org"
+        - in: body
+          name: body
+          type: object
+          required: true
+          schema:
+            allOf:
+              - $ref: "definitions/pdu.yaml"
+              - type: object
+                properties:
+                  # Note: we override a bunch of parameters to change their descriptions
+                  sender:
+                    type: string
+                    description: The user ID of the leaving member.
+                    example: "@someone:example.org"
+                  origin:
+                    type: string
+                    description: The name of the leaving homeserver.
+                    example: "matrix.org"    
+                  origin_server_ts:
+                    type: integer
+                    format: int64
+                    description: A timestamp added by the leaving homeserver.
+                    example: 1234567890
+                  type:
+                    type: string
+                    description: The value ``m.room.member``.
+                    example: "m.room.member"
+                  state_key:
+                    type: string
+                    description: The user ID of the leaving member.
+                    example: "@someone:example.org"
+                  content:
+                    type: object
+                    title: Membership Event Content
+                    description: The content of the event.
+                    example: {"membership": "leave"}
+                    properties:
+                      membership:
+                        type: string
+                        description: The value ``leave``.
+                        example: "leave"
+                    required: ['membership']
+                  depth:
+                    type: integer
+                    description: This field must be present but is ignored; it may be 0.
+                    example: 12
+                  auth_events:
+                    type: array
+                    description: |-
+                      An event reference list containing the authorization events that would
+                      allow the member to leave the room.
+                    items:
+                      type: array
+                      maxItems: 2
+                      minItems: 2
+                      items:
+                        - type: string
+                          title: Event ID
+                          example: "$abc123:matrix.org"
+                        - type: object
+                          title: Event Hash
+                          example: {
+                            "sha256": "abase64encodedsha256hashshouldbe43byteslong"
+                          }
+                          properties:
+                            sha256:
+                              type: string
+                              description: The event hash.
+                              example: abase64encodedsha256hashshouldbe43byteslong
+                          required: ['sha256']
+                  redacts:
+                    type: string
+                    description: Not used.
+                required:
+                  # Every other field is already flagged as required by the $ref
+                  - state_key
+          example: {
+            "$ref": "examples/pdu.json",
+            "type": "m.room.member",
+            "state_key": "@someone:example.org",
+            "content": {
+                "membership": "leave"
+            }
+          }
+      responses:
+        200:
+          description: |-
+            An empty response to indicate the event was accepted into the graph by
+            the receiving homeserver.
+          schema:
+            type: array
+            minItems: 2
+            maxItems: 2
+            items:
+              - type: integer
+                description: The value ``200``.
+                example: 200
+              - type: object
+                title: Empty Object
+                description: An empty object.
+          examples:
+            application/json: [200, {}]

--- a/api/server-server/leaving.yaml
+++ b/api/server-server/leaving.yaml
@@ -25,7 +25,7 @@ produces:
 paths:
   "/make_leave/{roomId}/{userId}":
     get:
-      summary: Get information required to make a join event for a room
+      summary: Get information required to make a leave event for a room
       description: |-
         Asks the receiving server to return information that the sending
         server will need to prepare a leave event to get out of the room.

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -881,6 +881,26 @@ Inviting to a room
 
 {{invites_ss_http_api}}
 
+Leaving Rooms (Rejecting Invites)
+---------------------------------
+
+Normally homeservers can send appropriate ``m.room.member`` events to have users
+leave the room, or to reject local invites. Remote invites from other homeservers
+do not involve the server in the graph and therefore need another approach to 
+reject the invite. Joining the room and promptly leaving is not recommended as 
+clients and servers will interpret that as accepting the invite, then leaving the
+room rather than rejecting the invite.
+
+Similar to the `Joining Rooms`_ handshake, the server which wishes to leave the
+room starts with sending a ``/make_leave`` request to a resident server. In the
+case of rejecting invites, the resident server may be the server which sent the
+invite. After receiving a template event from ``/make_leave``, the leaving server
+signs the event and replaces the ``event_id`` with it's own. This is then sent to
+the resident server via ``/send_leave``. The resident server will then send the
+event to other servers in the room.
+
+{{leaving_ss_http_api}}
+
 Third-party invites
 -------------------
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1401

This is very similar to the joining rooms handshake, and much of it is a near copy/paste of the make_join and send_join API. The major difference is the send_leave API doesn't return anything.

References:
* Handling of make_leave: https://github.com/matrix-org/synapse/blob/d69decd5c78c72abef50b597a689e2bc55a39702/synapse/handlers/federation.py#L1285-L1310
* send_leave route: https://github.com/matrix-org/synapse/blob/d69decd5c78c72abef50b597a689e2bc55a39702/synapse/federation/transport/client.py#L267
* make_leave route: https://github.com/matrix-org/synapse/blob/d69decd5c78c72abef50b597a689e2bc55a39702/synapse/federation/transport/server.py#L396
* send_leave returning nothing: https://github.com/matrix-org/synapse/blob/d69decd5c78c72abef50b597a689e2bc55a39702/synapse/handlers/federation.py#L1346