### PR TITLE
Make check_examples.py work on Windows

### DIFF
--- a/api/check_examples.py
+++ b/api/check_examples.py
@@ -43,22 +43,25 @@ except ImportError as e:
     raise
 
 
+def check_schema(filepath, example, schema):
+    # Setting the 'id' tells jsonschema where the file is so that it
+    # can correctly resolve relative $ref references in the schema
+    schema['id'] = "file://" + os.path.abspath(filepath)
+    example = resolve_references(filepath, example)
+    resolver = jsonschema.RefResolver(filepath, schema, handlers={"file": load_file})
+    jsonschema.validate(example, schema, resolver=resolver)
+
+
 def check_parameter(filepath, request, parameter):
     schema = parameter.get("schema")
     example = schema.get('example')
 
-    fileurl = "file://" + os.path.abspath(filepath)
     if example and schema:
         try:
             print ("Checking request schema for: %r %r" % (
                 filepath, request
             ))
-            # Setting the 'id' tells jsonschema where the file is so that it
-            # can correctly resolve relative $ref references in the schema
-            schema['id'] = fileurl
-            example = resolve_references(filepath, example)
-            resolver = jsonschema.RefResolver(filepath, schema, handlers={"file": load_file})
-            jsonschema.validate(example, schema, resolver=resolver)
+            check_schema(filepath, example, schema)
         except Exception as e:
             raise ValueError("Error validating JSON schema for %r" % (
                 request
@@ -68,18 +71,12 @@ def check_parameter(filepath, request, parameter):
 def check_response(filepath, request, code, response):
     example = response.get('examples', {}).get('application/json')
     schema = response.get('schema')
-    fileurl = "file://" + os.path.abspath(filepath)
     if example and schema:
         try:
             print ("Checking response schema for: %r %r %r" % (
                 filepath, request, code
             ))
-            # Setting the 'id' tells jsonschema where the file is so that it
-            # can correctly resolve relative $ref references in the schema
-            schema['id'] = fileurl
-            example = resolve_references(filepath, example)
-            resolver = jsonschema.RefResolver(filepath, schema, handlers={"file": load_file})
-            jsonschema.validate(example, schema, resolver=resolver)
+            check_schema(filepath, example, schema)
         except Exception as e:
             raise ValueError("Error validating JSON schema for %r %r" % (
                 request, code
@@ -127,30 +124,18 @@ def resolve_references(path, schema):
         return schema
 
 
-def load_yaml(path):
-    if not path.startswith("file:///"):
-        raise Exception("Bad ref: %s" % (path,))
-    path = path[len("file://"):]
-    with open(path, "r") as f:
-        return yaml.load(f)
-
-
-def load_json(path):
-    if not path.startswith("file:///"):
-        raise Exception("Bad ref: %s" % (path,))
-    path = path[len("file://"):]
-    with open(path, "r") as f:
-        return json.load(f)
-
-
 def load_file(path):
     print("Loading reference: %s" % path)
-    if path.endswith(".json"):
-        return load_json(path)
-    else:
-        # We have to assume it's YAML because some of the YAML examples 
-        # do not have file extensions.
-        return load_yaml(path)
+    if not path.startswith("file:///"):
+        raise Exception("Bad ref: %s" % (path,))
+    path = path[len("file://"):]
+    with open(path, "r") as f:
+        if path.endswith(".json"):
+            return json.load(f)
+        else:
+            # We have to assume it's YAML because some of the YAML examples
+            # do not have file extensions.
+            return yaml.load(f)
 
 
 if __name__ == '__main__':

--- a/api/check_examples.py
+++ b/api/check_examples.py
@@ -126,7 +126,7 @@ def resolve_references(path, schema):
 
 def load_file(path):
     print("Loading reference: %s" % path)
-    if not path.startswith("file:///"):
+    if not path.startswith("file://"):
         raise Exception("Bad ref: %s" % (path,))
     path = path[len("file://"):]
     with open(path, "r") as f:

--- a/api/check_examples.py
+++ b/api/check_examples.py
@@ -44,16 +44,14 @@ except ImportError as e:
 
 
 def check_schema(filepath, example, schema):
-    # Setting the 'id' tells jsonschema where the file is so that it
-    # can correctly resolve relative $ref references in the schema
-    schema['id'] = "file://" + os.path.abspath(filepath)
     example = resolve_references(filepath, example)
+    schema = resolve_references(filepath, schema)
     resolver = jsonschema.RefResolver(filepath, schema, handlers={"file": load_file})
     jsonschema.validate(example, schema, resolver=resolver)
 
 
 def check_parameter(filepath, request, parameter):
-    schema = parameter.get("schema")
+    schema = parameter.get("schema", {})
     example = schema.get('example')
 
     if example and schema:

--- a/api/check_examples.py
+++ b/api/check_examples.py
@@ -51,7 +51,7 @@ def check_schema(filepath, example, schema):
 
 
 def check_parameter(filepath, request, parameter):
-    schema = parameter.get("schema", {})
+    schema = parameter.get("schema")
     example = schema.get('example')
 
     if example and schema:

--- a/api/check_examples.py
+++ b/api/check_examples.py
@@ -58,7 +58,7 @@ def check_parameter(filepath, request, parameter):
 
     if example and schema:
         try:
-            print ("Checking request schema for: %r %r" % (
+            print("Checking request schema for: %r %r" % (
                 filepath, request
             ))
             check_schema(filepath, example, schema)


### PR DESCRIPTION
The changes boil down to:
1. Using only `file://`, not `file:///`
2. Bypassing jsonschema's reference resolver because it renders completely nonsensical "URL"s for local files on Windows; our own `resolve_references` is used instead (which means that remote references no more work but we fortunately don't have those).

The sign-off is in the last commit message.