### PR TITLE
General clean up on the s2s spec

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -576,7 +576,44 @@ A *conflict* occurs between states where those states have different
 affected are said to be *conflicting* events.
 
 
+Backfilling and retrieving missing events
+-----------------------------------------
 
+Once a homeserver has joined a room, it receives all the events emitted by
+other homeservers in that room, and is thus aware of the entire history of the
+room from that moment onwards. Since users in that room are able to request the
+history by the ``/messages`` client API endpoint, it's possible that they might
+step backwards far enough into history before the homeserver itself was a
+member of that room.
+
+To cover this case, the federation API provides a server-to-server analog of
+the ``/messages`` client API, allowing one homeserver to fetch history from
+another. This is the ``/backfill`` API.
+
+To request more history, the requesting homeserver picks another homeserver 
+that it thinks may have more (most likely this should be a homeserver for 
+some of the existing users in the room at the earliest point in history it 
+has currently), and makes a ``/backfill`` request.
+
+Similar to backfilling a room's history, a server may not have all the events
+in the graph. That server may use the ``/get_missing_events`` API to acquire
+the events it is missing.
+
+.. TODO-spec
+  Specify (or remark that it is unspecified) how the server handles divergent
+  history. DFS? BFS? Anything weirder?
+
+{{backfill_ss_http_api}}
+
+Retrieving events
+----------------
+
+In some circumstances, a homeserver may be missing a particular event or information
+about the room which cannot be easily determined from backfilling. These APIs provide
+homeservers with the option of getting events and the state of the room at a given
+point in the timeline.
+
+{{events_ss_http_api}}
 
 
 Joining Rooms
@@ -663,45 +700,6 @@ participating in the room.
   - (paul) I don't really understand why the full auth_chain events are given
     here. What purpose does it serve expanding them out in full, when surely
     they'll appear in the state anyway?
-
-Backfilling and retrieving missing events
------------------------------------------
-
-Once a homeserver has joined a room, it receives all the events emitted by
-other homeservers in that room, and is thus aware of the entire history of the
-room from that moment onwards. Since users in that room are able to request the
-history by the ``/messages`` client API endpoint, it's possible that they might
-step backwards far enough into history before the homeserver itself was a
-member of that room.
-
-To cover this case, the federation API provides a server-to-server analog of
-the ``/messages`` client API, allowing one homeserver to fetch history from
-another. This is the ``/backfill`` API.
-
-To request more history, the requesting homeserver picks another homeserver 
-that it thinks may have more (most likely this should be a homeserver for 
-some of the existing users in the room at the earliest point in history it 
-has currently), and makes a ``/backfill`` request.
-
-Similar to backfilling a room's history, a server may not have all the events
-in the graph. That server may use the ``/get_missing_events`` API to acquire
-the events it is missing.
-
-.. TODO-spec
-  Specify (or remark that it is unspecified) how the server handles divergent
-  history. DFS? BFS? Anything weirder?
-
-{{backfill_ss_http_api}}
-
-Retrieving events
-----------------
-
-In some circumstances, a homeserver may be missing a particular event or information
-about the room which cannot be easily determined from backfilling. These APIs provide
-homeservers with the option of getting events and the state of the room at a given
-point in the timeline.
-
-{{events_ss_http_api}}
 
 Inviting to a room
 ------------------

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -23,14 +23,13 @@ Federation API
 
 Matrix homeservers use the Federation APIs (also known as server-server APIs)
 to communicate with each other. Homeservers use these APIs to push messages to
-each other in real-time, to
-historic messages from each other, and to
+each other in real-time, to retrieve historic messages from each other, and to
 query profile and presence information about users on each other's servers.
 
-The APIs are implemented using HTTPS GETs and PUTs between each of the
-servers. These HTTPS requests are strongly authenticated using public key
-signatures at the TLS transport layer and using public key signatures in
-HTTP Authorization headers at the HTTP layer.
+The APIs are implemented using HTTPS requests between each of the servers. 
+These HTTPS requests are strongly authenticated using public key signatures 
+at the TLS transport layer and using public key signatures in HTTP 
+Authorization headers at the HTTP layer.
 
 There are three main kinds of communication that occur between homeservers:
 
@@ -485,15 +484,9 @@ A *conflict* occurs between states where those states have different
 ``event_ids`` for the same ``(state_type, state_key)``. The events thus
 affected are said to be *conflicting* events.
 
-Protocol URLs
--------------
 
-.. WARNING::
-  This section may be misleading or inaccurate.
 
-All these URLs are name-spaced within a prefix of::
 
-  /_matrix/federation/v1/...
 
 Joining Rooms
 -------------


### PR DESCRIPTION
Rendered: see 'docs' commit status.

This PR is blocked on the following PRs, as this PR relies on portions of the other PRs being merged:
* [x] https://github.com/matrix-org/matrix-doc/pull/1477
* [x] https://github.com/matrix-org/matrix-doc/pull/1475
* [x] https://github.com/matrix-org/matrix-doc/pull/1469
* [x] https://github.com/matrix-org/matrix-doc/pull/1463
* [x] https://github.com/matrix-org/matrix-doc/pull/1450
* [x] https://github.com/matrix-org/matrix-doc/pull/1443

----

Changes:
* Tidy up the specification
  * Minor word choice changes
  * Remove the now-empty "Protocol URLs" section
* Move the Authentication section higher in the spec
  * It forms the foundation for all the requests under it, so it should appear before the endpoints that need it.
* Move backfill and getting events so that joins, invites, and leaves are together
