### PR TITLE
Federation: Document the Host header; Clarify how literal IP addresses are handled

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -98,6 +98,15 @@ default fallback port number of 8448.
 Homeservers may use SRV records to load balance requests between multiple TLS
 endpoints or to failover to another endpoint if an endpoint fails.
 
+If the DNS name is a literal IP address, the port specified or the fallback
+port should be used.
+
+When making requests to servers, use the DNS name of the target server in the
+``Host`` header, regardless of the host given in the SRV record. For example,
+if making a request to ``example.org``, and the SRV record resolves to ``matrix.
+example.org``, the ``Host`` header in the request should be ``example.org``. The
+port number for target server should not appear in the ``Host`` header.
+
 Server implementation
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Rendered: see 'docs' commit status

----

Fixes https://github.com/matrix-org/matrix-doc/issues/1161

The IP address clarification is to add an explicit mention of how to handle the case. The prior documentation assumed that all servers would be resolvable with DNS, and does technically have a fallback to use the fallback port, however making it clear feels like a good idea.