### PR TITLE
Specify which federation swagger APIs consume JSON

### DIFF
--- a/api/server-server/joins.yaml
+++ b/api/server-server/joins.yaml
@@ -20,6 +20,8 @@ host: localhost:8448
 schemes:
   - https
 basePath: /_matrix/federation/v1
+consumes:
+  - application/json
 produces:
   - application/json
 paths:

--- a/api/server-server/keys_query.yaml
+++ b/api/server-server/keys_query.yaml
@@ -20,6 +20,8 @@ host: localhost:8448
 schemes:
   - https
 basePath: /_matrix/key/v2
+consumes:
+  - application/json
 produces:
   - application/json
 paths:

--- a/api/server-server/leaving.yaml
+++ b/api/server-server/leaving.yaml
@@ -20,6 +20,8 @@ host: localhost:8448
 schemes:
   - https
 basePath: /_matrix/federation/v1
+consumes:
+  - application/json
 produces:
   - application/json
 paths:

--- a/api/server-server/third_party_invite.yaml
+++ b/api/server-server/third_party_invite.yaml
@@ -20,6 +20,8 @@ host: localhost:8448
 schemes:
   - https
 basePath: /_matrix/federation/v1
+consumes:
+  - application/json
 produces:
   - application/json
 paths:

--- a/api/server-server/transactions.yaml
+++ b/api/server-server/transactions.yaml
@@ -20,6 +20,8 @@ host: localhost:8448
 schemes:
   - https
 basePath: /_matrix/federation/v1
+consumes:
+  - application/json
 produces:
   - application/json
 paths:


### PR DESCRIPTION
This is purely for documentation purposes when/if we get around to having a swagger viewer for federation. Also helps people who plan on using swagger for things.