### PR TITLE
Document how typing notifications work over federation

### DIFF
--- a/api/server-server/definitions/event-schemas/m.typing.yaml
+++ b/api/server-server/definitions/event-schemas/m.typing.yaml
@@ -1,0 +1,45 @@
+# Copyright 2018 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: Typing Notification EDU
+description: A typing notification EDU for a user in a room.
+allOf:
+  - $ref: ../edu.yaml
+  - type: object
+    properties:
+      edu_type:
+        type: string
+        description: The string ``m.typing``
+        example: "m.typing"
+      content:
+        type: object
+        description: The typing notification.
+        title: Typing Notification
+        properties:
+          room_id:
+            type: string
+            description: |-
+              The room where the user's typing status has been updated.
+            example: "!somewhere:matrix.org"
+          user_id:
+            type: string
+            description: |-
+              The user ID that has had their typing status changed.
+            example: "@john:matrix.org"
+          typing:
+            type: boolean
+            description: Whether the user is typing in the room or not.
+            example: true
+        required: ['room_id', 'user_id', 'typing']

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -833,6 +833,16 @@ should be retrieved for.
 {{public_rooms_ss_http_api}}
 
 
+Typing Notifications
+--------------------
+
+When a server's users send typing notifications, those notifications need to
+be sent to other servers in the room so their users are aware of the same
+state. Receiving servers should verify that the user is in the room, and is
+a user belonging to the sending server.
+
+{{definition_ss_event_schemas_m_typing}}
+
 Presence
 --------
 The server API for presence is based entirely on exchange of the following


### PR DESCRIPTION
Rendered: see 'docs' commit status.

This PR is blocked on https://github.com/matrix-org/matrix-doc/pull/1463 as it makes use of the "definitions embedded in the spec" feature, and builds upon EDUs.

Blocked on:
* [x] https://github.com/matrix-org/matrix-doc/pull/1463

----

Relevant synapse code: https://github.com/matrix-org/synapse/blob/d69decd5c78c72abef50b597a689e2bc55a39702/synapse/handlers/typing.py#L221-L230