### PR TITLE
Fix minor spelling mistake in event retrieval endpoints

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -693,7 +693,7 @@ that requested by the requester in the ``v`` parameter).
   Specify (or remark that it is unspecified) how the server handles divergent
   history. DFS? BFS? Anything weirder?
 
-Retriving events
+Retrieving events
 ----------------
 
 In some circumstances, a homeserver may be missing a particular event or information


### PR DESCRIPTION
Correct me if I'm wrong, I was a little too late to metntion this directly in #1472. :wink: