### PR TITLE
Mention how the content repository works over federation

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -1020,6 +1020,20 @@ the following EDU::
         for the user
 
 
+Content Repository
+------------------
+
+Attachments to events (images, files, etc) are uploaded to a homeserver via the
+Content Repository described in the `Client-Server API`_. When a server wishes
+to serve content originating from a remote server, it needs to ask the remote
+server for the media.
+
+Servers should use the server described in the Matrix Content URI, which has the
+format ``mxc://{ServerName}/{MediaID}``. Servers should use the download endpoint
+described in the `Client-Server API`_, being sure to use the ``allow_remote``
+parameter (set to ``false``).
+
+
 Signing Events
 --------------
 

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -1182,7 +1182,7 @@ that are too long.
 
 .. _`Invitation storage`: ../identity_service/unstable.html#invitation-storage
 .. _`Identity Service API`: ../identity_service/unstable.html
-.. _`Client-Server API`: ../client_server/unstable.html#m-room-member
+.. _`Client-Server API`: ../client_server/unstable.html
 .. _`Inviting to a room`: #inviting-to-a-room
 .. _`Canonical JSON`: ../appendices.html#canonical-json
 .. _`Unpadded Base64`:  ../appendices.html#unpadded-base64


### PR DESCRIPTION
Rendered: see 'docs' commit status

----

We might want to consider promoting the media repo to it's own API, and maybe consider calling it the Media Repo rather than Content Repo.

Source of information: experience.