### PR TITLE
Add EDUs to appservice transactions

### DIFF
--- a/api/application-service/application_service.yaml
+++ b/api/application-service/application_service.yaml
@@ -73,16 +73,35 @@ paths:
                   "type": "m.room.message",
                   "user_id": "@bob:localhost"
                 }
+              ],
+              "edus": [
+                {
+                  "type": "m.typing",
+                  "room_id": "!TmaZBKYIFrIPVGoUYp:localhost",
+                  "content": {
+                    "user_ids": ["@alice:localhost"]
+                  }
+                }
               ]
             }
             description: "Transaction informations"
             properties:
               events:
                 type: array
-                description: A list of events
+                description: A list of events. May be empty.
                 items:
                   type: object
                   title: Event
+              edus:
+                  type: array
+                  description: |-
+                    A list of ephemeral events the application service may be
+                    interested in. These have the same format as the EDUs defined
+                    in the Client-Server API.
+                  items:
+                    type: object
+                    title: Ephemeral Event
+                    # TODO: Reference client schema for EDUs
             required: ["events"]
       responses:
         200:

--- a/api/application-service/application_service.yaml
+++ b/api/application-service/application_service.yaml
@@ -44,7 +44,7 @@ paths:
           x-example: "35"
         - in: body
           name: body
-          description: A list of events
+          description: A list of events.
           schema:
             type: object
             example: {
@@ -84,7 +84,7 @@ paths:
                 }
               ]
             }
-            description: "Transaction informations"
+            description: "Transaction Information"
             properties:
               events:
                 type: array


### PR DESCRIPTION
Rendered: see 'docs' commit status
Synapse PR: coming soon

----

Many bridges are interested in this information, and considering they can no longer sync themselves they need a way to get EDUs. Servers should send EDUs as per the rules for "interested events" defined elsewhere.

EDUs are a new top level key for backwards compatibility and sanity. Having EDUs in the events array would likely break appservices which are not EDU-aware due to missing fields and unknown event types. 

The events array is still required for backwards compatibility. The added condition of it may be empty has been added so that appservices which are not aware of EDUs don't break with a missing field. Appservices should be iterating over the list, so a zero-element list should be fine.

Fixes #1145 