### PR TITLE
Clarify how third party invites work

### DIFF
--- a/api/identity/pubkey.yaml
+++ b/api/identity/pubkey.yaml
@@ -56,7 +56,7 @@ paths:
     get:
       summary: Check whether a long-term public key is valid.
       description: |-
-        Check whether a long-term public key is valid.
+        Check whether a long-term public key is valid. The request must be idempotent.
       operationId: isPubKeyValid
       parameters:
         - in: query

--- a/api/identity/pubkey.yaml
+++ b/api/identity/pubkey.yaml
@@ -56,7 +56,8 @@ paths:
     get:
       summary: Check whether a long-term public key is valid.
       description: |-
-        Check whether a long-term public key is valid. The request must be idempotent.
+        Check whether a long-term public key is valid. The response should always
+        be the same, provided the key exists.
       operationId: isPubKeyValid
       parameters:
         - in: query

--- a/api/server-server/third_party_invite.yaml
+++ b/api/server-server/third_party_invite.yaml
@@ -190,3 +190,126 @@ paths:
             type: object
             description: An empty object
             example: {}
+  "/3pid/onbind":
+    put:
+      summary: |-
+        Notifies the server that a third party identifier has been bound to one
+        of its users.
+      description: |-
+        Used by Identity Servers to notify the homeserver that one of its users
+        has bound a third party identifier successfully, including any pending
+        room invites the Identity Server has been made aware of.
+      operationId: onBindThirdPartyIdentifier
+      parameters:
+        - in: body
+          name: body
+          type: object
+          required: true
+          schema:
+            type: object
+            properties:
+              medium:
+                type: string
+                description: |-
+                  The type of third party identifier. Currently only "email" is
+                  a possible value.
+                example: "email"
+              address:
+                type: string
+                description: |-
+                  The third party identifier itself. For example, an email address.
+                example: "alice@domain.com"
+              mxid:
+                type: string
+                description: The user that is now bound to the third party identifier.
+                example: "@alice:matrix.org"
+              invites:
+                type: array
+                description: |-
+                  A list of pending invites that the third party identifier has received.
+                items:
+                  type: object
+                  title: Third Party Invite
+                  properties:
+                    medium:
+                      type: string
+                      description: |-
+                        The type of third party invite issues. Currently only
+                        "email" is used.
+                      example: "email"
+                    address:
+                      type: string
+                      description: |-
+                        The third party identifier that received the invite.
+                      example: "alice@domain.com"
+                    mxid:
+                      type: string
+                      description: The now-bound user ID that received the invite.
+                      example: "@alice:matrix.org"
+                    room_id:
+                      type: string
+                      description: The room ID the invite is valid for.
+                      example: "!somewhere:example.org"
+                    sender:
+                      type: string
+                      description: The user ID that sent the invite.
+                      example: "@bob:matrix.org"
+                    # TODO (TravisR): Make this reusable when doing IS spec changes
+                    #   also make sure it isn't lying about anything, like the key version
+                    signed:
+                      type: object
+                      title: Identity Server Signatures
+                      description: |-
+                        Signature from the Identity Server using a long-term private
+                        key.
+                      properties:
+                        mxid:
+                          type: string
+                          description: |-
+                            The user ID that has been bound to the third party
+                            identifier.
+                          example: "@alice:matrix.org"
+                        token:
+                          type: string
+                          # TODO: What is this actually?
+                          description: A token.
+                          example: "Hello World"
+                        signatures:
+                          type: object
+                          title: Identity Server Signature
+                          description: |-
+                            The signature from the identity server. The ``string`` key
+                            is the identity server's domain name, such as vector.im
+                          additionalProperties:
+                            type: object
+                            title: Identity Server Domain Signature
+                            description: The signature for the identity server.
+                            properties:
+                              "ed25519:0":
+                                type: string
+                                description: The signature.
+                                example: "SomeSignatureGoesHere"
+                            required: ['ed25519:0']
+                          example: {
+                            "vector.im": {
+                              "ed25519:0": "SomeSignatureGoesHere"
+                            }
+                          }
+                      required: ['mxid', 'token', 'signatures']
+                  required:
+                    - medium
+                    - address
+                    - mxid
+                    - room_id
+                    - sender
+                    - signed
+            required: ['medium', 'address', 'mxid', 'invites']
+      responses:
+        200:
+          description: The homeserver has processed the notification.
+          examples:
+            application/json: {}
+          schema:
+            type: object
+            description: An empty object
+            example: {}

--- a/specification/identity_service_api.rst
+++ b/specification/identity_service_api.rst
@@ -80,9 +80,11 @@ in a scheme ``algorithm:identifier``, e.g. ``ed25519:0``. When signing an
 association, the Matrix standard JSON signing format is used, as specified in
 the server-server API specification under the heading "Signing Events".
 
-In the event of key compromise, the identity service may revoke any of its keys.
-An HTTP API is offered to get public keys, and check whether a particular key is
-valid.
+.. TODO: Actually allow identity services to revoke all keys
+         See: https://github.com/matrix-org/matrix-doc/issues/1633
+.. In the event of key compromise, the identity service may revoke any of its keys.
+   An HTTP API is offered to get public keys, and check whether a particular key is
+   valid.
 
 The identity server may also keep track of some short-term public-private
 keypairs, which may have different usage and lifetime characteristics than the

--- a/specification/modules/third_party_invites.rst
+++ b/specification/modules/third_party_invites.rst
@@ -190,10 +190,6 @@ H3 is attempting to join.
         |              |                     | (Federation) Emit m.room.member for invite     |                 |                            |
         |              |                     |----------------------------------------------->|                 |                            |
         |              |                     |                                                |                 |                            |
-        |              |                     |                                                | Accept event    |                            |
-        |              |                     |                                                |-------------    |                            |
-        |              |                     |                                                |            |    |                            |
-        |              |                     |                                                |<------------    |                            |
         |              |                     |                                                |                 |                            |
         |              |                     | (Federation) Emit the m.room.member event sent to H2             |                            |
         |              |                     |----------------------------------------------------------------->|                            |

--- a/specification/modules/third_party_invites.rst
+++ b/specification/modules/third_party_invites.rst
@@ -138,7 +138,7 @@ validate that the public key used for signing is still valid, by checking
 
 No other homeservers may reject the joining of the room on the basis of
 ``key_validity_url``, this is so that all homeservers have a consistent view of
-the room. They may, however, indicate to their clients that a member's'
+the room. They may, however, indicate to their clients that a member's
 membership is questionable.
 
 For example, given H1, H2, and H3 as homeservers, UserA as a user of H1, and an

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -734,6 +734,10 @@ event to other servers in the room.
 Third-party invites
 -------------------
 
+.. NOTE::
+   More information about third party invites is available in the `Client-Server API`_
+   under the Third Party Invites module.
+
 When an user wants to invite another user in a room but doesn't know the Matrix
 ID to invite, they can do so using a third-party identifier (e.g. an e-mail or a
 phone number).


### PR DESCRIPTION
Rendered: see 'docs' commit status. This is highly recommended given the large sequence diagrams in the client-server spec.

----

This adds several diagrams to the Client-Server API about how invites are handled, including what the server is expected to do. This helps implementors know what they are supposed to do in the common cases, and infer where needed to get the more complex cases correct.

Although lacking in some areas, this is how third party invites work today.

A link to the now-improved client-server documentation for third party invites has been added to the server-server specification, alongside some documentation on how the `/3pid/onbind` endpoint works.

Fixes #1366
Fixes https://github.com/matrix-org/matrix-doc/issues/1422