### PR TITLE
Document `validated_at`, `added_at`, and POST /3pid/delete

### DIFF
--- a/api/client-server/administrative_contact.yaml
+++ b/api/client-server/administrative_contact.yaml
@@ -180,6 +180,7 @@ paths:
             user.
           schema:
             type: object
+            properties: {}
       tags:
         - User data
   "/account/3pid/email/requestToken":

--- a/api/client-server/administrative_contact.yaml
+++ b/api/client-server/administrative_contact.yaml
@@ -148,6 +148,51 @@ paths:
             "$ref": "definitions/errors/error.yaml"
       tags:
         - User data
+  "/account/3pid/delete":
+    post:
+      summary: Deletes a third party identifier from the user's account
+      description: |-
+        Removes a third party identifier from the user's account. The homeserver
+        should attempt to unbind the identifier from the identity service, if the
+        homeserver is able to reasonably determine the identity service used.
+      operationId: delete3pidFromAccount
+      security:
+        - accessToken: []
+      parameters:
+        - in: body
+          name: body
+          schema:
+            type: object
+            properties:
+              medium:
+                type: string
+                description: The medium of the third party identifier being removed.
+                enum: ["email", "msisdn"]
+                example: "email"
+              address:
+                type: string
+                description: The third party address being removed.
+                example: "example@domain.com"
+            required: ['medium', 'address']
+      responses:
+        200:
+          description: |-
+            The homeserver has disassociated the third party identifier from the
+            user.
+          schema:
+            type: object
+            properties:
+              id_server_unbind_result:
+                type: string
+                description: |-
+                  The result of the homeserver's attempt to unbind the identifier from
+                  the identity service. ``success`` indicates that the homeserver was
+                  able to unbind the identifier while ``no-support`` means the homeserver
+                  was not able to unbind, likely due to the identity service not supporting
+                  the operation. Defaults to ``no-support``.
+                example: "success"
+      tags:
+        - User data
   "/account/3pid/email/requestToken":
     post:
       summary: Requests a validation token be sent to the given email address for the purpose of adding an email address to an account

--- a/api/client-server/administrative_contact.yaml
+++ b/api/client-server/administrative_contact.yaml
@@ -152,9 +152,8 @@ paths:
     post:
       summary: Deletes a third party identifier from the user's account
       description: |-
-        Removes a third party identifier from the user's account. The homeserver
-        should attempt to unbind the identifier from the identity service, if the
-        homeserver is able to reasonably determine the identity service used.
+        Removes a third party identifier from the user's account. This may not
+        cause an unbind of the identifier from the identity service.
       operationId: delete3pidFromAccount
       security:
         - accessToken: []
@@ -181,16 +180,6 @@ paths:
             user.
           schema:
             type: object
-            properties:
-              id_server_unbind_result:
-                type: string
-                description: |-
-                  The result of the homeserver's attempt to unbind the identifier from
-                  the identity service. ``success`` indicates that the homeserver was
-                  able to unbind the identifier while ``no-support`` means the homeserver
-                  was not able to unbind, likely due to the identity service not supporting
-                  the operation. Defaults to ``no-support``.
-                example: "success"
       tags:
         - User data
   "/account/3pid/email/requestToken":

--- a/api/client-server/administrative_contact.yaml
+++ b/api/client-server/administrative_contact.yaml
@@ -47,13 +47,15 @@ paths:
           description: The lookup was successful.
           examples:
             application/json: {
-                "threepids": [
-                  {
-                    "medium": "email",
-                    "address": "monkey@banana.island"
-                  }
-                ]
-              }
+              "threepids": [
+                {
+                  "medium": "email",
+                  "address": "monkey@banana.island",
+                  "validated_at": 1535176800000,
+                  "added_at": 1535336848756
+                }
+              ]
+            }
           schema:
             type: object
             properties:
@@ -70,6 +72,19 @@ paths:
                     address:
                       type: string
                       description: The third party identifier address.
+                    validated_at:
+                      type: integer
+                      format: int64
+                      description: |-
+                        The timestamp, in milliseconds, when the identifier was
+                        validated by the identity service.
+                    added_at:
+                      type: integer
+                      format: int64
+                      description:
+                        The timestamp, in milliseconds, when the homeserver
+                        associated the third party identifier with the user.
+                  required: ['medium', 'address', 'validated_at', 'added_at']
       tags:
         - User data
     post:

--- a/api/client-server/administrative_contact.yaml
+++ b/api/client-server/administrative_contact.yaml
@@ -152,7 +152,7 @@ paths:
     post:
       summary: Deletes a third party identifier from the user's account
       description: |-
-        Removes a third party identifier from the user's account. This may not
+        Removes a third party identifier from the user's account. This might not
         cause an unbind of the identifier from the identity service.
       operationId: delete3pidFromAccount
       security:

--- a/changelogs/client_server/newsfragments/1567.feature
+++ b/changelogs/client_server/newsfragments/1567.feature
@@ -1,0 +1,1 @@
+Document the ``validated_at`` and ``added_at`` fields on ``GET /acount/3pid``.

--- a/changelogs/client_server/newsfragments/1567.new
+++ b/changelogs/client_server/newsfragments/1567.new
@@ -1,0 +1,1 @@
+Add ``POST /account/3pid/delete``


### PR DESCRIPTION
Rendered: see 'docs' status check

----

Document `validated_at` and `added_at` on GET /3pid 
Fixes #661


Document POST /account/3pid/delete
Fixes #985
Includes documentation for matrix-org/synapse#3667
Raises #1566