### PR TITLE
Update filtering API documentation

### DIFF
--- a/api/client-server/definitions/event_filter.yaml
+++ b/api/client-server/definitions/event_filter.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-title: Filter
+title: EventFilter
 properties:
   limit:
     description: The maximum number of events to return.

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -31,5 +31,5 @@ allOf:
       type: array
     contains_url:
       type: boolean
-    description: If ``true``, includes only events with a url key in their content. If
-      ``false``, excludes those events.
+      description: If ``true``, includes only events with a ``url`` key in their content. If
+        ``false``, excludes those events. Defaults to ``false``.

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -13,23 +13,23 @@
 # limitations under the License.
 allOf:
 - $ref: event_filter.yaml
-title: RoomEventFilter
-properties:
-  not_rooms:
-    description: A list of room IDs to exclude. If this list is absent then no rooms
-      are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``
-      filter.
-    items:
-      type: string
-    type: array
-  rooms:
-    description: A list of room IDs to include. If this list is absent then all rooms
-      are included.
-    items:
-      type: string
-    type: array
-  contains_url:
-    type: boolean
+- type: object
+  title: RoomEventFilter
+  properties:
+    not_rooms:
+      description: A list of room IDs to exclude. If this list is absent then no rooms
+        are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``
+        filter.
+      items:
+        type: string
+      type: array
+    rooms:
+      description: A list of room IDs to include. If this list is absent then all rooms
+        are included.
+      items:
+        type: string
+      type: array
+    contains_url:
+      type: boolean
     description: If ``true``, includes only events with a url key in their content. If
       ``false``, excludes those events.
-type: object

--- a/api/client-server/definitions/sync_filter.yaml
+++ b/api/client-server/definitions/sync_filter.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+type: object
+title: Filter
 properties:
   event_fields:
     description: List of event fields to include. If this list is absent then all
@@ -40,6 +42,7 @@ properties:
   room:
     title: RoomFilter
     description: Filters to be applied to room data.
+    type: object
     properties:
       not_rooms:
         description: A list of room IDs to exclude. If this list is absent then no rooms
@@ -76,5 +79,3 @@ properties:
         allOf:
         - $ref: room_event_filter.yaml
         description: The per user account data to include for rooms.
-    type: object
-type: object

--- a/api/client-server/filter.yaml
+++ b/api/client-server/filter.yaml
@@ -91,7 +91,12 @@ paths:
               filter_id:
                 type: string
                 description: |-
-                  The ID of the filter that was created.
+                  The ID of the filter that was created. Cannot start
+                  with a ``{`` as this character is used to determine
+                  if the filter provided is inline JSON or a previously
+                  declared filter by homeservers on some APIs.
+                example: "66696p746572"
+            required: ['filter_id']
       tags:
         - Room participation
   "/user/{userId}/filter/{filterId}":

--- a/api/client-server/filter.yaml
+++ b/api/client-server/filter.yaml
@@ -54,37 +54,33 @@ paths:
             allOf:
               - $ref: "definitions/sync_filter.yaml"
             example: {
-                "room": {
-                  "state": {
-                    "types": ["m.room.*"],
-                    "not_rooms": ["!726s6s6q:example.com"]
-                  },
-                  "timeline": {
-                    "limit": 10,
-                    "types": ["m.room.message"],
-                    "not_rooms": ["!726s6s6q:example.com"],
-                    "not_senders": ["@spam:example.com"]
-                  },
-                  "ephemeral": {
-                    "types": ["m.receipt", "m.typing"],
-                    "not_rooms": ["!726s6s6q:example.com"],
-                    "not_senders": ["@spam:example.com"]
-                  }
+              "room": {
+                "state": {
+                  "types": ["m.room.*"],
+                  "not_rooms": ["!726s6s6q:example.com"]
                 },
-                "presence": {
-                  "types": ["m.presence"],
-                  "not_senders": ["@alice:example.com"]
+                "timeline": {
+                  "limit": 10,
+                  "types": ["m.room.message"],
+                  "not_rooms": ["!726s6s6q:example.com"],
+                  "not_senders": ["@spam:example.com"]
                 },
-                "event_format": "client",
-                "event_fields": ["type", "content", "sender"]
-              }
+                "ephemeral": {
+                  "types": ["m.receipt", "m.typing"],
+                  "not_rooms": ["!726s6s6q:example.com"],
+                  "not_senders": ["@spam:example.com"]
+                }
+              },
+              "presence": {
+                "types": ["m.presence"],
+                "not_senders": ["@alice:example.com"]
+              },
+              "event_format": "client",
+              "event_fields": ["type", "content", "sender"]
+            }
       responses:
         200:
           description: The filter was created.
-          examples:
-            application/json: {
-                "filter_id": "66696p746572"
-              }
           schema:
             type: object
             properties:

--- a/changelogs/client_server/newsfragments/1570.clarification
+++ b/changelogs/client_server/newsfragments/1570.clarification
@@ -1,0 +1,1 @@
+Clarify the object structures and defaults for Filters.


### PR DESCRIPTION
Rendered: see 'docs' status check

This PR may be best to review commit-by-commit.

----

Fix naming of the Filter schemas
EventFilter !== Filter
Fixes #1509

Update room_event_filter.yaml to use the OpenAPI allOf definition

Mark the filter_id in the response of POST /filter as required

Clean up examples in filter.yaml

Define the default for the contains_url filter param
Fixes #1553