### PR TITLE
Replace applicable types of 'number' to 'integer'

### DIFF
--- a/api/client-server/admin.yaml
+++ b/api/client-server/admin.yaml
@@ -105,7 +105,8 @@ paths:
                                   type: string
                                   description: Most recently seen IP address of the session.
                                 last_seen:
-                                  type: number
+                                  type: integer
+                                  format: int64
                                   description: Unix timestamp that the session was last active.
                                 user_agent:
                                   type: string

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -259,7 +259,8 @@ paths:
           description: "The URL to get a preview of"
           required: true
         - in: query
-          type: number
+          type: integer
+          format: int64
           x-example: 1510610716656
           name: ts
           description: |-
@@ -276,7 +277,8 @@ paths:
             type: object
             properties:
               "matrix:image:size":
-                type: number
+                type: integer
+                format: int64
                 description: |-
                   The byte-size of the image. Omitted if there is no image attached.
               "og:image":
@@ -324,7 +326,8 @@ paths:
             type: object
             properties:
               m.upload.size:
-                type: number
+                type: integer
+                format: int64
                 description: |- 
                   The maximum size an upload can be in bytes.
                   Clients SHOULD use this as a guide when uploading content.

--- a/api/client-server/definitions/public_rooms_response.yaml
+++ b/api/client-server/definitions/public_rooms_response.yaml
@@ -45,7 +45,7 @@ properties:
           description: |-
             The name of the room, if any.
         num_joined_members:
-          type: number
+          type: integer
           description: |-
             The number of members joined to the room.
         room_id:
@@ -82,7 +82,7 @@ properties:
       absence of this token means there are no results before this
       batch, i.e. this is the first batch.
   total_room_count_estimate:
-    type: number
+    type: integer
     description: |-
         An estimate on the total number of public rooms, if the
         server has an estimate.

--- a/api/client-server/list_public_rooms.yaml
+++ b/api/client-server/list_public_rooms.yaml
@@ -123,7 +123,7 @@ paths:
       parameters:
         - in: query
           name: limit
-          type: number
+          type: integer
           description: |-
             Limit the number of results returned.
         - in: query
@@ -173,7 +173,7 @@ paths:
             type: object
             properties:
               limit:
-                type: number
+                type: integer
                 description: |-
                   Limit the number of results returned.
               since:
@@ -233,7 +233,7 @@ paths:
                       description: |-
                         The name of the room, if any.
                     num_joined_members:
-                      type: number
+                      type: integer
                       description: |-
                         The number of members joined to the room.
                     room_id:
@@ -270,7 +270,7 @@ paths:
                   absence of this token means there are no results before this
                   batch, i.e. this is the first batch.
               total_room_count_estimate:
-                type: number
+                type: integer
                 description: |-
                    An estimate on the total number of public rooms, if the
                    server has an estimate.

--- a/api/client-server/notifications.yaml
+++ b/api/client-server/notifications.yaml
@@ -45,7 +45,7 @@ paths:
           required: false
           x-example: "xxxxx"
         - in: query
-          type: number
+          type: integer
           name: limit
           description: Limit on the number of events to return in this request.
           required: false

--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -218,7 +218,7 @@ paths:
                 description: The email address
                 example: "example@example.com"
               send_attempt:
-                type: number
+                type: integer
                 description: Used to distinguish protocol level retries from requests to re-send the email.
                 example: 1
             required: ["client_secret", "email", "send_attempt"]
@@ -283,7 +283,7 @@ paths:
                 description: The phone number.
                 example: "example@example.com"
               send_attempt:
-                type: number
+                type: integer
                 description: Used to distinguish protocol level retries from requests to re-send the SMS message.
                 example: 1
             required: ["client_secret", "country", "phone_number", "send_attempt"]

--- a/api/client-server/search.yaml
+++ b/api/client-server/search.yaml
@@ -179,7 +179,7 @@ paths:
                     description: Mapping of category name to search criteria.
                     properties:
                       count:
-                        type: number
+                        type: integer
                         description: An approximate count of the total number of results found.
                       highlights:
                         type: array
@@ -197,7 +197,7 @@ paths:
                           description: The result object.
                           properties:
                             rank:
-                              type: number
+                              type: integer
                               description: A number that describes how closely
                                 this result matches the search. Higher is
                                 closer.

--- a/api/client-server/users.yaml
+++ b/api/client-server/users.yaml
@@ -47,7 +47,7 @@ paths:
                 description: The term to search for
                 example: "foo"
               limit:
-                type: number
+                type: integer
                 description: The maximum number of results to return (Defaults to 10).
                 example: 10
             required: ["search_term"]

--- a/changelogs/client_server/newsfragments/1571.clarification
+++ b/changelogs/client_server/newsfragments/1571.clarification
@@ -1,0 +1,1 @@
+Clarify instances of ``type: number`` in the swagger/OpenAPI schema definitions.

--- a/event-schemas/schema/core-event-schema/room_event.yaml
+++ b/event-schemas/schema/core-event-schema/room_event.yaml
@@ -16,7 +16,8 @@ properties:
   origin_server_ts:
     description: Timestamp in milliseconds on originating homeserver
       when this event was sent.
-    type: number
+    type: integer
+    format: int64
   unsigned:
     description: Contains optional extra information about the event.
     properties:

--- a/event-schemas/schema/m.room.power_levels
+++ b/event-schemas/schema/m.room.power_levels
@@ -46,10 +46,10 @@ properties:
     properties:
       ban:
         description: The level required to ban a user. Defaults to 50 if unspecified.
-        type: number
+        type: integer
       events:
         additionalProperties:
-          type: number
+          type: integer
         description: The level required to send specific event types. This is a mapping from event type to power level required.
         title: Event power levels
         type: object
@@ -57,25 +57,25 @@ properties:
         description: |-
             The default level required to send message events. Can be
             overridden by the ``events`` key.  Defaults to 0 if unspecified.
-        type: number
+        type: integer
       invite:
         description: The level required to invite a user. Defaults to 50 if unspecified.
-        type: number
+        type: integer
       kick:
         description: The level required to kick a user. Defaults to 50 if unspecified.
-        type: number
+        type: integer
       redact:
         description: The level required to redact an event. Defaults to 50 if unspecified.
-        type: number
+        type: integer
       state_default:
         description: |-
             The default level required to send state events. Can be overridden
             by the ``events`` key. Defaults to 50 if unspecified, but 0 if
             there is no ``m.room.power_levels`` event at all.
-        type: number
+        type: integer
       users:
         additionalProperties:
-          type: number
+          type: integer
         description: The power levels for specific users. This is a mapping from ``user_id`` to power level for that user.
         title: User power levels
         type: object
@@ -84,7 +84,7 @@ properties:
             The default power level for every user in the room, unless their
             ``user_id`` is mentioned in the ``users`` key. Defaults to 0 if
             unspecified.
-        type: number
+        type: integer
     type: object
   state_key:
     description: A zero-length string.


### PR DESCRIPTION
Rendered: see 'docs' status check

----

`number` implies/represents a float where `integer` does not.

The only remaining `type: number` in the project appear on power levels: those have been left untouched pending clarification.

Fixes https://github.com/matrix-org/matrix-doc/issues/746