### PR TITLE
Fix server ACL schema: The type is a string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ workflows:
     jobs:
       - build-docs
       - build-swagger
+      - check-docs
 
 notify:
   webhooks:

--- a/event-schemas/schema/m.room.server_acl
+++ b/event-schemas/schema/m.room.server_acl
@@ -85,4 +85,4 @@ properties:
     type: string
   type:
     enum: ['m.room.server_acl']
-    type: enum
+    type: string


### PR DESCRIPTION
It cannot be an enum otherwise the build starts screaming.