### PR TITLE
The `rank` in search results is actually a floating point number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ checkexamples: &checkexamples
     source /env/bin/activate
     cd event-schemas
     ./check_examples.py
+    cd ../api
+    ./check_examples.py
 
 genmatrixassets: &genmatrixassets
   name: Generate/Verify matrix.org assets

--- a/api/client-server/search.yaml
+++ b/api/client-server/search.yaml
@@ -198,7 +198,7 @@ paths:
                           description: The result object.
                           properties:
                             rank:
-                              type: integer
+                              type: number
                               description: A number that describes how closely
                                 this result matches the search. Higher is
                                 closer.


### PR DESCRIPTION
This was accidentally changed in https://github.com/matrix-org/matrix-doc/pull/1571 and appears to be the only instance.