### PR TITLE
Update schemas and auth rules to cover the @ state key restriction

### DIFF
--- a/event-schemas/schema/core-event-schema/state_event.yaml
+++ b/event-schemas/schema/core-event-schema/state_event.yaml
@@ -11,7 +11,11 @@ properties:
   state_key:
     description: A unique key which defines the overwriting semantics for this piece
       of room state. This value is often a zero-length string. The presence of this
-      key makes this event a State Event. The key MUST NOT start with '_'.
+      key makes this event a State Event. 
+
+      State keys starting with an ``@`` are reserved for referencing user IDs, such
+      as room members. With the exception of a few events, state events set with a
+      given user's ID as the state key MUST only be set by that user.
     type: string
 required:
 - state_key

--- a/event-schemas/schema/m.room.member
+++ b/event-schemas/schema/m.room.member
@@ -105,7 +105,10 @@ properties:
     title: EventContent
     type: object
   state_key:
-    description: The ``user_id`` this membership event relates to.
+    description: |-
+      The ``user_id`` this membership event relates to. In all cases except for when ``membership`` is
+      ``join``, the user ID sending the event does not need to match the user ID in the ``state_key``,
+      unlike other events. Regular authorisation rules still apply.
     type: string
   type:
     enum:

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -450,7 +450,10 @@ The rules are as follows:
 
   #. Otherwise, reject.
 
-7. Otherwise, allow.
+7. If the ``state_key`` starts with ``@`` and the ``state_key`` does not match
+   the ``sender``, reject.
+
+8. Otherwise, allow.
 
 .. NOTE::
 

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -450,10 +450,7 @@ The rules are as follows:
 
   #. Otherwise, reject.
 
-7. If the ``state_key`` starts with ``@`` and the ``state_key`` does not match
-   the ``sender``, reject.
-
-8. Otherwise, allow.
+7. Otherwise, allow.
 
 .. NOTE::
 


### PR DESCRIPTION
Rendered: see 'docs' status check

----

Fixes some of https://github.com/matrix-org/matrix-doc/issues/1305

Also fixes an issue regarding the `_` being restricted previously, which is false.