### PR TITLE
Benpa/spec tables prettier

### DIFF
--- a/scripts/css/basic.css
+++ b/scripts/css/basic.css
@@ -342,6 +342,10 @@ table.colwidths-auto tr td:nth-child(3) {
     width: 70%;
 }
 
+table.colwidths-auto tr:nth-child(even) {
+    background-color: #f4f4f4;
+}
+
 /* -- other body styles ----------------------------------------------------- */
 
 ol.arabic {

--- a/scripts/css/basic.css
+++ b/scripts/css/basic.css
@@ -321,7 +321,7 @@ table.citation td {
 table.colwidths-auto caption {
     font-family: 'Inconsolata', monospace;
     font-weight: 800;
-    font-size: 110%;
+    font-size: 120%;
     padding: 5px;
     text-align: left;
     margin-bottom: 2px;

--- a/scripts/css/basic.css
+++ b/scripts/css/basic.css
@@ -320,8 +320,9 @@ table.citation td {
 
 table.colwidths-auto caption {
     font-family: monospace;
-    font-size: x-large;
+    font-size: large;
     padding: 2px;
+    text-align: left;
 }
 
 table.colwidths-auto {

--- a/scripts/css/basic.css
+++ b/scripts/css/basic.css
@@ -318,6 +318,29 @@ table.citation td {
     border-bottom: none;
 }
 
+table.colwidths-auto caption {
+    font-family: monospace;
+    font-size: x-large;
+    padding: 2px;
+}
+
+table.colwidths-auto {
+    width:100%;
+    margin-top: 20px;
+}
+
+table.colwidths-auto tr td:nth-child(1) {
+    width: 15%;
+}
+
+table.colwidths-auto tr td:nth-child(2) {
+    width: 15%;
+}
+
+table.colwidths-auto tr td:nth-child(3) {
+    width: 70%;
+}
+
 /* -- other body styles ----------------------------------------------------- */
 
 ol.arabic {

--- a/scripts/css/basic.css
+++ b/scripts/css/basic.css
@@ -319,10 +319,24 @@ table.citation td {
 }
 
 table.colwidths-auto caption {
-    font-family: monospace;
-    font-size: large;
-    padding: 2px;
+    font-family: 'Inconsolata', monospace;
+    font-weight: 800;
+    font-size: 110%;
+    padding: 5px;
     text-align: left;
+    margin-bottom: 2px;
+}
+
+ol, li {
+    margin: 0px 0px 0px 30px !important;
+}
+
+p.httpheaders {
+    font-weight: 800;
+    font-size: 120%;
+    padding: 5px;
+    text-align: left;
+    margin-bottom: 2px;
 }
 
 table.colwidths-auto {
@@ -336,15 +350,13 @@ table.colwidths-auto tr td:nth-child(1) {
 
 table.colwidths-auto tr td:nth-child(2) {
     width: 15%;
+    font-family: 'Inconsolata', monospace;
 }
 
 table.colwidths-auto tr td:nth-child(3) {
     width: 70%;
 }
 
-table.colwidths-auto tr:nth-child(even) {
-    background-color: #f4f4f4;
-}
 
 /* -- other body styles ----------------------------------------------------- */
 

--- a/scripts/css/nature.css
+++ b/scripts/css/nature.css
@@ -273,6 +273,7 @@ table {
 
 td[colspan]:not([colspan="1"]) {
     background: #eeeeee;
+    text-transform: capitalize;
 }
 
 thead {

--- a/scripts/templating/matrix_templates/templates/common-event-fields.tmpl
+++ b/scripts/templating/matrix_templates/templates/common-event-fields.tmpl
@@ -7,6 +7,6 @@
 
 {% for table in common_event.tables %}
 
-{{ tables.paramtable(table.rows, [(table.title or "") ~ " Key", "Type", "Description"]) }}
+{{ tables.paramtable(table.rows, ["Key", "Type", "Description"], (table.title or "")) }}
 
 {% endfor %}

--- a/scripts/templating/matrix_templates/templates/common-event-fields.tmpl
+++ b/scripts/templating/matrix_templates/templates/common-event-fields.tmpl
@@ -6,8 +6,7 @@
 {{common_event.desc}}
 
 {% for table in common_event.tables %}
-{{"``"+table.title+"``" if table.title else "" }}
 
-{{ tables.paramtable(table.rows, ["Key", "Type", "Description"]) }}
+{{ tables.paramtable(table.rows, [(table.title or "") ~ " Key", "Type", "Description"]) }}
 
 {% endfor %}

--- a/scripts/templating/matrix_templates/templates/events.tmpl
+++ b/scripts/templating/matrix_templates/templates/events.tmpl
@@ -13,7 +13,7 @@
 
 {% for table in event.content_fields %}
 
-{{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"]) }}
+{{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"], (table.title or "")) }}
 
 {% endfor %}
 Example{% if examples | length > 1 %}s{% endif %}:

--- a/scripts/templating/matrix_templates/templates/events.tmpl
+++ b/scripts/templating/matrix_templates/templates/events.tmpl
@@ -12,7 +12,6 @@
 {{event.desc}}
 
 {% for table in event.content_fields %}
-{{"``"+table.title+"``" if table.title else "" }}
 
 {{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"]) }}
 

--- a/scripts/templating/matrix_templates/templates/http-api.tmpl
+++ b/scripts/templating/matrix_templates/templates/http-api.tmpl
@@ -18,8 +18,8 @@ Request format:
 {{ tables.split_paramtable(endpoint.req_param_by_loc) }}
 {% if (endpoint.req_body_tables) %}
 {% for table in endpoint.req_body_tables -%}
-{{"``"+table.title+"``" if table.title else "" }}
-{{ tables.paramtable(table.rows) }}
+{{ tables.paramtable(table.rows, [(table.title or "") ~ " Parameter", "Type", "Description"] ) }}
+
 {% endfor -%}
 {% endif -%}
 
@@ -37,9 +37,9 @@ Response headers:
 Response format:
 
 {% for table in endpoint.res_tables -%}
-{{"``"+table.title+"``" if table.title else "" }}
 
-{{ tables.paramtable(table.rows) }}
+{{ tables.paramtable(table.rows, [(table.title or "") ~ " Parameter", "Type", "Description"] ) }}
+
 
 {% endfor %}
 {% endif -%}

--- a/scripts/templating/matrix_templates/templates/http-api.tmpl
+++ b/scripts/templating/matrix_templates/templates/http-api.tmpl
@@ -13,7 +13,10 @@
 {{":Rate-limited: Yes." if endpoint.rate_limited else "" }}
 {{":Requires auth: Yes." if endpoint.requires_auth else "" }}
 
-Request format:
+.. class:: httpheaders
+  
+  Request format:
+  
 {% if (endpoint.req_param_by_loc | length) %}
 {{ tables.split_paramtable(endpoint.req_param_by_loc) }}
 {% if (endpoint.req_body_tables) %}
@@ -28,13 +31,19 @@ Request format:
 {% endif %}
 
 {% if endpoint.res_headers is not none -%}
-Response headers:
+
+.. class:: httpheaders
+  
+  Response headers:
 
 {{ tables.paramtable(endpoint.res_headers.rows) }}
 {% endif -%}
 
 {% if endpoint.res_tables|length > 0 -%}
-Response format:
+
+.. class:: httpheaders
+  
+  Response format:
 
 {% for table in endpoint.res_tables -%}
 
@@ -44,14 +53,19 @@ Response format:
 {% endfor %}
 {% endif -%}
 
-Example request:
+.. class:: httpheaders
+  
+  Example request:
 
 .. code:: http
 
   {{endpoint.example.req | indent_block(2)}}
 
 {% if endpoint.responses|length > 0 -%}
-Response{{"s" if endpoint.responses|length > 1 else "" }}:
+
+.. class:: httpheaders
+  
+  Response{{"s" if endpoint.responses|length > 1 else "" }}:
 
 {% endif -%}
 
@@ -63,7 +77,9 @@ Response{{"s" if endpoint.responses|length > 1 else "" }}:
 
 {% if res["example"] -%}
 
-Example
+.. class:: httpheaders
+  
+  Example
 
 .. code:: json
 

--- a/scripts/templating/matrix_templates/templates/http-api.tmpl
+++ b/scripts/templating/matrix_templates/templates/http-api.tmpl
@@ -18,7 +18,7 @@ Request format:
 {{ tables.split_paramtable(endpoint.req_param_by_loc) }}
 {% if (endpoint.req_body_tables) %}
 {% for table in endpoint.req_body_tables -%}
-{{ tables.paramtable(table.rows, [(table.title or "") ~ " Parameter", "Type", "Description"] ) }}
+{{ tables.paramtable(table.rows, caption=(table.title or "")) }}
 
 {% endfor -%}
 {% endif -%}
@@ -38,7 +38,7 @@ Response format:
 
 {% for table in endpoint.res_tables -%}
 
-{{ tables.paramtable(table.rows, [(table.title or "") ~ " Parameter", "Type", "Description"] ) }}
+{{ tables.paramtable(table.rows, caption=(table.title or "")) }}
 
 
 {% endfor %}

--- a/scripts/templating/matrix_templates/templates/msgtypes.tmpl
+++ b/scripts/templating/matrix_templates/templates/msgtypes.tmpl
@@ -4,9 +4,14 @@
 {{(4 + event.msgtype | length) * title_kind}}
 {{event.desc | wrap(80)}}
 {% for table in event.content_fields -%}
-{{"``"+table.title+"``" if table.title else "" }}
 
-{{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"]) }}
+{% if table.title -%}
+{% set tabletitle = table.title -%}
+{% else -%}
+{% set tabletitle = "" -%}
+{% endif -%}
+
+{{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"] ) }}
 
 {% endfor %}
 Example:

--- a/scripts/templating/matrix_templates/templates/msgtypes.tmpl
+++ b/scripts/templating/matrix_templates/templates/msgtypes.tmpl
@@ -5,13 +5,7 @@
 {{event.desc | wrap(80)}}
 {% for table in event.content_fields -%}
 
-{% if table.title -%}
-{% set tabletitle = table.title -%}
-{% else -%}
-{% set tabletitle = "" -%}
-{% endif -%}
-
-{{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"] ) }}
+{{ tables.paramtable(table.rows, [(table.title or "Content") ~ " Key", "Type", "Description"], (table.title or "")) }}
 
 {% endfor %}
 Example:

--- a/scripts/templating/matrix_templates/templates/schema-definition.tmpl
+++ b/scripts/templating/matrix_templates/templates/schema-definition.tmpl
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% for table in definition.tables -%}
-{{"``"+table.title+"``" if table.title else "" }}
+{{"``7777"+table.title+"``" if table.title else "" }}
 {{ tables.paramtable(table.rows) }}
 {% endfor %}
 

--- a/scripts/templating/matrix_templates/templates/schema-definition.tmpl
+++ b/scripts/templating/matrix_templates/templates/schema-definition.tmpl
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% for table in definition.tables -%}
-{{"``7777"+table.title+"``" if table.title else "" }}
+{{"``"+table.title+"``" if table.title else "" }}
 {{ tables.paramtable(table.rows) }}
 {% endfor %}
 

--- a/scripts/templating/matrix_templates/templates/tables.tmpl
+++ b/scripts/templating/matrix_templates/templates/tables.tmpl
@@ -36,6 +36,14 @@
 {% set fieldwidths = (([titlerow] + flatrows) |
         fieldwidths(rowkeys[0:-1], [10, 10])) + [50] -%}
 
+{% set caption = titlerow['key'] | replace (' Key', '') | replace ('Parameter', '') -%}
+{% if caption == 'Content' -%}
+{% set caption = '' -%}
+{% endif -%}
+
+{{".. table:: "}}{{ caption }}
+{{"  :widths: auto"}}
+{{""}}
 {{ tableheader(fieldwidths) }}
 {{ tablerow(fieldwidths, titlerow, rowkeys) }}
 {{ tableheader(fieldwidths) }}
@@ -59,7 +67,7 @@
  # Write a table header row, for the given column widths
  #}
 {% macro tableheader(widths) -%}
-{% for arg in widths -%}
+{{"  "}}{% for arg in widths -%}
 {{"="*arg}} {% endfor -%}
 {% endmacro %}
 
@@ -71,7 +79,7 @@
  # attributes of 'row' to look up for values to put in the columns.
  #}
 {% macro tablerow(widths, row, keys) -%}
-{% for key in keys -%}
+{{"  "}}{% for key in keys -%}
 {% set value=row[key] -%}
 {% if not loop.last -%}
    {# the first few columns need space after them -#}
@@ -81,7 +89,7 @@
    the preceding columns, plus the number of preceding columns (for the
    separators)) -#}
    {{ value | wrap(widths[loop.index0]) |
-         indent_block(widths[0:-1]|sum + loop.index0) -}}
+         indent_block(widths[0:-1]|sum + loop.index0 + 2) -}}
 {% endif -%}
 {% endfor -%}
 {% endmacro %}
@@ -93,10 +101,10 @@
  # write a tablespan row. This is a single value which spans the entire table.
  #}
 {% macro tablespan(widths, value) -%}
-{{value}}
+{{"  "}}{{value}}
 {# we write a trailing space to stop the separator being misinterpreted
  # as a header line. -#}
-{{"-"*(widths|sum + widths|length -1)}} {% endmacro %}
+{{"  "}}{{"-"*(widths|sum + widths|length -1)}} {% endmacro %}
 
 
 

--- a/scripts/templating/matrix_templates/templates/tables.tmpl
+++ b/scripts/templating/matrix_templates/templates/tables.tmpl
@@ -8,8 +8,8 @@
  #
  # 'rows' is the list of parameters. Each row should be a TypeTableRow.
  #}
-{% macro paramtable(rows, titles=["Parameter", "Type", "Description"]) -%}
-{{ split_paramtable({None: rows}, titles) }}
+{% macro paramtable(rows, titles=["Parameter", "Type", "Description"], caption="") -%}
+{{ split_paramtable({None: rows}, titles, caption) }}
 {% endmacro %}
 
 
@@ -21,7 +21,7 @@
  # written for that location. This is used by the standard 'paramtable' macro.
  #}
 {% macro split_paramtable(rows_by_loc,
-      titles=["Parameter", "Type", "Description"]) -%}
+      titles=["Parameter", "Type", "Description"], caption="") -%}
 
 {% set rowkeys = ['key', 'title', 'desc'] %}
 {% set titlerow = {'key': titles[0], 'title': titles[1], 'desc': titles[2]} %}
@@ -35,11 +35,6 @@
  # column. -#}
 {% set fieldwidths = (([titlerow] + flatrows) |
         fieldwidths(rowkeys[0:-1], [10, 10])) + [50] -%}
-
-{% set caption = titlerow['key'] | replace (' Key', '') | replace ('Parameter', '') -%}
-{% if caption == 'Content' -%}
-{% set caption = '' -%}
-{% endif -%}
 
 {{".. table:: "}}{{ caption }}
 {{"  :widths: auto"}}


### PR DESCRIPTION
This change does two things:

* makes all the tables aligned the same
* moves the unclear titles of types to the caption of the correct tables