### PR TITLE
Add the other fields the server is expected to keep on events

### DIFF
--- a/changelogs/client_server/newsfragments/1602.clarification
+++ b/changelogs/client_server/newsfragments/1602.clarification
@@ -1,0 +1,1 @@
+Add the other keys that redactions are expected to preserve.

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1328,16 +1328,30 @@ the following list:
 - ``state_key``
 - ``prev_content``
 - ``content``
+- ``hashes``
+- ``signatures``
+- ``depth``
+- ``prev_events``
+- ``prev_state``
+- ``auth_events``
+- ``origin``
+- ``origin_server_ts``
+- ``membership``
+
+.. Note:
+   Some of the keys, such as ``hashes``, will appear on the federation-formatted
+   event and therefore the client may not be aware of them.
 
 The content object should also be stripped of all keys, unless it is one of
 one of the following event types:
 
-- ``m.room.member`` allows key ``membership``
-- ``m.room.create`` allows key ``creator``
-- ``m.room.join_rules`` allows key ``join_rule``
+- ``m.room.member`` allows key ``membership``.
+- ``m.room.create`` allows key ``creator``.
+- ``m.room.join_rules`` allows key ``join_rule``.
 - ``m.room.power_levels`` allows keys ``ban``, ``events``, ``events_default``,
   ``kick``, ``redact``, ``state_default``, ``users``, ``users_default``.
-- ``m.room.aliases`` allows key ``aliases``
+- ``m.room.aliases`` allows key ``aliases``.
+- ``m.room.history_visibility`` allows key ``history_visibility``.
 
 The server should add the event causing the redaction to the ``unsigned``
 property of the redacted event, under the ``redacted_because`` key. When a


### PR DESCRIPTION
Rendered: see 'docs' status check

----

Fixes https://github.com/matrix-org/matrix-doc/issues/839

Reference: https://github.com/matrix-org/synapse/blob/d69decd5c78c72abef50b597a689e2bc55a39702/synapse/events/utils.py#L44-L91