### PR TITLE
Remove references to initialSync from account data and receipts module

### DIFF
--- a/specification/modules/account_data.rst
+++ b/specification/modules/account_data.rst
@@ -31,7 +31,7 @@ The client recieves the account data as events in the ``account_data`` sections
 of a ``/sync``.
 
 These events can also be received in a ``/events`` response or in the
-``account_data`` section of a room in ``/initialSync``. ``m.tag``
+``account_data`` section of a room in ``/sync``. ``m.tag``
 events appearing in ``/events`` will have a ``room_id`` with the room
 the tags are for.
 

--- a/specification/modules/receipts.rst
+++ b/specification/modules/receipts.rst
@@ -38,11 +38,10 @@ single ``event_id``.
 Client behaviour
 ----------------
 
-In ``/initialSync``, receipts are listed in a separate top level ``receipts``
-key. In ``/sync``, receipts are contained in the ``ephemeral`` block for a
-room. New receipts that come down the event streams are deltas which update
-existing mappings. Clients should replace older receipt acknowledgements based
-on ``user_id`` and ``receipt_type`` pairs. For example::
+In ``/sync``, receipts are listed under the ``ephemeral`` array of events
+for a given room. New receipts that come down the event streams are deltas
+which update existing mappings. Clients should replace older receipt acknowledgements
+based on ``user_id`` and ``receipt_type`` pairs. For example::
 
   Client receives m.receipt:
     user = @alice:example.com


### PR DESCRIPTION
Rendered: see 'docs' status check

----

Fixes https://github.com/matrix-org/matrix-doc/issues/695

Note: This commit leaves the /join endpoints alone because they say "and /sync" rather than just initialSync