### PR TITLE
fix handling of multi-line state key descriptions

### DIFF
--- a/scripts/templating/matrix_templates/templates/events.tmpl
+++ b/scripts/templating/matrix_templates/templates/events.tmpl
@@ -5,7 +5,7 @@
 
 {% if (event.typeof | length) %}
 *{{event.typeof}}*
-    {{event.typeof_info}}
+    {{event.typeof_info | indent_block(4)}}
 
 {% endif -%}
 


### PR DESCRIPTION
fixes an issue exposed by the state key of m.room.member spanning multiple lines