### PR TITLE
Power levels always have a default of 50 for state_default

### DIFF
--- a/event-schemas/schema/m.room.power_levels
+++ b/event-schemas/schema/m.room.power_levels
@@ -70,8 +70,7 @@ properties:
       state_default:
         description: |-
             The default level required to send state events. Can be overridden
-            by the ``events`` key. Defaults to 50 if unspecified, but 0 if
-            there is no ``m.room.power_levels`` event at all.
+            by the ``events`` key. Defaults to 50 if unspecified.
         type: integer
       users:
         additionalProperties:


### PR DESCRIPTION
Rendered: see 'docs' status check

----

As per the proposal https://github.com/matrix-org/matrix-doc/issues/1304

Closes https://github.com/matrix-org/matrix-doc/issues/1304