### PR TITLE
Filling gaps

### DIFF
--- a/api/client-server/joining.yaml
+++ b/api/client-server/joining.yaml
@@ -101,6 +101,11 @@ paths:
               "room_id": "!d41d8cd:matrix.org"}
           schema:
             type: object
+            properties:
+              room_id:
+                type: string
+                description: The joined room id
+            required: ["room_id"]
         403:
           description: |-
             You do not have permission to join the room. A meaningful ``errcode`` and description error text will be returned. Example reasons for rejection are:
@@ -208,6 +213,11 @@ paths:
               "room_id": "!d41d8cd:matrix.org"}
           schema:
             type: object
+            properties:
+              room_id:
+                type: string
+                description: The joined room id
+            required: ["room_id"]
         403:
           description: |-
             You do not have permission to join the room. A meaningful ``errcode`` and description error text will be returned. Example reasons for rejection are:

--- a/api/client-server/rooms.yaml
+++ b/api/client-server/rooms.yaml
@@ -107,7 +107,8 @@ paths:
             application/json: {
               "name": "Example room name"}
           schema:
-            type: object
+            allOf:
+              - "$ref": "definitions/event-schemas/schema/core-event-schema/state_event.yaml"
         404:
           description: The room has no state with the given type or key.
         403:
@@ -149,7 +150,8 @@ paths:
             application/json: {
               "name": "Example room name"}
           schema:
-            type: object
+            allOf:
+              - "$ref": "definitions/event-schemas/schema/core-event-schema/state_event.yaml"
         404:
           description: The room has no state with the given type or key.
         403:


### PR DESCRIPTION
This PR adds definitions implied for a very long time now but not provided in the spec. QMatrixClient has been using these definitions to generate the API stubs for awhile.