### PR TITLE
joining.yaml: add missing response schema details

### DIFF
--- a/api/client-server/joining.yaml
+++ b/api/client-server/joining.yaml
@@ -104,7 +104,7 @@ paths:
             properties:
               room_id:
                 type: string
-                description: The joined room id
+                description: The joined room ID.
             required: ["room_id"]
         403:
           description: |-
@@ -216,7 +216,7 @@ paths:
             properties:
               room_id:
                 type: string
-                description: The joined room id
+                description: The joined room ID.
             required: ["room_id"]
         403:
           description: |-

--- a/api/client-server/joining.yaml
+++ b/api/client-server/joining.yaml
@@ -101,6 +101,11 @@ paths:
               "room_id": "!d41d8cd:matrix.org"}
           schema:
             type: object
+            properties:
+              room_id:
+                type: string
+                description: The joined room id
+            required: ["room_id"]
         403:
           description: |-
             You do not have permission to join the room. A meaningful ``errcode`` and description error text will be returned. Example reasons for rejection are:
@@ -208,6 +213,11 @@ paths:
               "room_id": "!d41d8cd:matrix.org"}
           schema:
             type: object
+            properties:
+              room_id:
+                type: string
+                description: The joined room id
+            required: ["room_id"]
         403:
           description: |-
             You do not have permission to join the room. A meaningful ``errcode`` and description error text will be returned. Example reasons for rejection are:


### PR DESCRIPTION
This PR adds definitions implied for a very long time now but not provided in the spec.