### PR TITLE
Add 'sandbox' to recommended CSP header

### DIFF
--- a/specification/modules/content_repo.rst
+++ b/specification/modules/content_repo.rst
@@ -34,8 +34,9 @@ origin homeserver using the same API (unless the origin and destination
 homeservers are the same).
 
 When serving content, the server SHOULD provide a ``Content-Security-Policy``
-header. The recommended policy is ``default-src 'none'; script-src 'none';
-plugin-types application/pdf; style-src 'unsafe-inline'; object-src 'self';``.
+header. The recommended policy is ``sandbox; default-src 'none'; script-src
+'none'; plugin-types application/pdf; style-src 'unsafe-inline'; object-src
+'self';``.
 
 Client behaviour
 ----------------


### PR DESCRIPTION
The sandbox attribute exists now and offers much better protection in that anything served from the media repo will have a unique origin.

Impls:
 * https://github.com/matrix-org/synapse/pull/4284
 * https://github.com/turt2live/matrix-media-repo/commit/3194e82c592c0600b1ffe3bd6085b7dacf8192c7
