### PR TITLE
Add missing status_msg to m.presence schema and example

### DIFF
--- a/changelogs/client_server/newsfragments/1744.clarification
+++ b/changelogs/client_server/newsfragments/1744.clarification
@@ -1,0 +1,1 @@
+Add missing status_msg to m.presence schema

--- a/event-schemas/examples/m.presence
+++ b/event-schemas/examples/m.presence
@@ -6,6 +6,7 @@
     "avatar_url": "mxc://localhost:wefuiwegh8742w",
     "last_active_ago": 2478593,
     "presence": "online",
-    "currently_active": false
+    "currently_active": false,
+    "status_msg": "Making cupcakes"
   }
 }

--- a/event-schemas/schema/m.presence
+++ b/event-schemas/schema/m.presence
@@ -29,6 +29,10 @@
                 "currently_active": {
                     "type": boolean,
                     "description": "Whether the user is currently active"
+                },
+                "status_msg": {
+                    "type": "string",
+                    "description": "An optional description to accompany the presence."
                 }
             },
             "required": ["presence"]


### PR DESCRIPTION
The APIs to change presence have this listed, but it is not included on the schema itself.