### PR TITLE
Document the checks made for incoming PDUs

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -334,8 +334,22 @@ Authorization of PDUs
 ~~~~~~~~~~~~~~~~~~~~~
 
 Whenever a server receives an event from a remote server, the receiving server
-must check that the event is allowed by the authorization rules. These rules
-depend on the state of the room at that event.
+must ensure that the event:
+
+1. Is a valid event, otherwise it is dropped
+2. Passes signature checks, otherwise it is dropped.
+3. Passes hash checks, otherwise it is redacted before being processed
+   further.
+4. Passes authorization rules based on the event's auth events, otherwise it
+   is rejected.
+5. Passes authorization rules based on the state at the event, otherwise it
+   is rejected.
+6. Passes auth rules based on the current state of the room, otherwise it
+   is "soft failed".
+
+Further details of these checks, and how to handle failures, are described
+below.
+
 
 Definitions
 +++++++++++

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -330,8 +330,8 @@ following subset of the room state:
 
 {{definition_ss_pdu}}
 
-Authorization of PDUs
-~~~~~~~~~~~~~~~~~~~~~
+Checks performed on receipt of a PDU
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Whenever a server receives an event from a remote server, the receiving server
 must ensure that the event:
@@ -371,8 +371,8 @@ Target User
 
 .. _`authorization rules`:
 
-Rules
-+++++
+Authorization rules
++++++++++++++++++++
 
 The rules governing whether an event is authorized depend solely on the
 state of the room at the point in the room graph at which the new event is to

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -374,9 +374,9 @@ Target User
 Authorization rules
 +++++++++++++++++++
 
-The rules governing whether an event is authorized depend solely on the
-state of the room at the point in the room graph at which the new event is to
-be inserted. The types of state events that affect authorization are:
+The rules governing whether an event is authorized depends on a set of state. A
+given event is checked multiple times against different sets of state, as
+specified above. The types of state events that affect authorization are:
 
 - ``m.room.create``
 - ``m.room.member``

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -336,7 +336,7 @@ Authorization of PDUs
 Whenever a server receives an event from a remote server, the receiving server
 must ensure that the event:
 
-1. Is a valid event, otherwise it is dropped
+1. Is a valid event, otherwise it is dropped.
 2. Passes signature checks, otherwise it is dropped.
 3. Passes hash checks, otherwise it is redacted before being processed
    further.
@@ -344,7 +344,7 @@ must ensure that the event:
    is rejected.
 5. Passes authorization rules based on the state at the event, otherwise it
    is rejected.
-6. Passes auth rules based on the current state of the room, otherwise it
+6. Passes authorization rules based on the current state of the room, otherwise it
    is "soft failed".
 
 Further details of these checks, and how to handle failures, are described

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -350,6 +350,10 @@ must ensure that the event:
 Further details of these checks, and how to handle failures, are described
 below.
 
+.. TODO:
+  Flesh this out a bit more, and probably change the doc to group the various
+  checks in one place, rather than have them spread out.
+
 
 Definitions
 +++++++++++


### PR DESCRIPTION
This is meant as a small clarification to make it easier in MSCs to talk about the different types of checks and rejections that can happen when processing an event. This needs to be expanded on more fully in the future, most likely