### PR TITLE
Room v2 proposal

### DIFF
--- a/proposals/1759-rooms-v2.md
+++ b/proposals/1759-rooms-v2.md
@@ -1,0 +1,14 @@
+# MSC 1759 - Rooms V2
+
+This MSC proposes creating a new room version to allow servers and users to opt
+in to using the new state resolution algorithm.
+
+
+## Proposal
+
+The new room version is called "2". The only difference between v2 and v1 is
+that v2 rooms use the v2 state resolution algorithm, as defined in MSC 1442 and
+MSC 1693.
+
+It is not proposed that servers change the default room version used when
+creating new rooms.


### PR DESCRIPTION
This MSC proposes adding a new room version to allow servers and users to opt into using the new state resolution algorithm. Given that this does ***not*** propose making the new room version the default, nor prompting users to upgrade existing rooms, I'm hoping that this should be relatively uncontroversial.

We do not propose to make this a new default as there are several other incompatible changes to rooms we wish to make, and so its probably best to wait for those to land before changing the default and prompting people to upgrade existing rooms.

This assumes that MSC #1693 lands.

[Rendered](https://github.com/matrix-org/matrix-doc/blob/erikj/rooms_v2/proposals/1759-rooms-v2.md)