### PR TITLE
Require Content-Type for /upload

### DIFF
--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -40,6 +40,7 @@ paths:
         - in: header
           name: Content-Type
           type: string
+          required: true
           description: The content type of the file being uploaded
           x-example: "Content-Type: audio/mpeg"
         - in: query


### PR DESCRIPTION
Because this is what the error message from the server says if I omit Content-Type. There might be other endpoints with the same bug - feel free to indicate and I'll add them to the PR.