### PR TITLE
Add support for unstable feature advertising via /versions

### DIFF
--- a/api/client-server/versions.yaml
+++ b/api/client-server/versions.yaml
@@ -39,9 +39,12 @@ paths:
         may optionally include version information within their name if desired.
         Features listed here are not for optionally toggling parts of the Matrix
         specification and should only be used to advertise support for a feature
-        which has not yet landed in the spec. For example, an accepted proposal
-        for a feature needing implementation would advertise itself here with
-        the intention of being removed from this list once the spec changes land.
+        which has not yet landed in the spec. For example, a feature currently
+        undergoing the proposal process may appear here and eventually be taken
+        off this list once the feature lands in the spec and the server deems it
+        reasonable to do so. Servers may wish to keep advertising features here
+        after they've been released into the spec to give clients a chance to
+        upgrade appropriately.
       operationId: getVersions
       responses:
         200:

--- a/api/client-server/versions.yaml
+++ b/api/client-server/versions.yaml
@@ -44,7 +44,8 @@ paths:
         off this list once the feature lands in the spec and the server deems it
         reasonable to do so. Servers may wish to keep advertising features here
         after they've been released into the spec to give clients a chance to
-        upgrade appropriately.
+        upgrade appropriately. Additionally, clients should avoid using unstable
+        features in their stable releases.
       operationId: getVersions
       responses:
         200:

--- a/api/client-server/versions.yaml
+++ b/api/client-server/versions.yaml
@@ -33,13 +33,25 @@ paths:
 
         Only the latest ``Z`` value will be reported for each supported ``X.Y`` value.
         i.e. if the server implements ``r0.0.0``, ``r0.0.1``, and ``r1.2.0``, it will report ``r0.0.1`` and ``r1.2.0``.
+
+        The server may additionally advertise experimental features it supports
+        through ``unstable_features``. These features should be namespaced and
+        may optionally include version information within their name if desired.
+        Features listed here are not for optionally toggling parts of the Matrix
+        specification and should only be used to advertise support for a feature
+        which has not yet landed in the spec. For example, an accepted proposal
+        for a feature needing implementation would advertise itself here with
+        the intention of being removed from this list once the spec changes land.
       operationId: getVersions
       responses:
         200:
           description: The versions supported by the server.
           examples:
             application/json: {
-                "versions": ["r0.0.1"]
+                "versions": ["r0.0.1"],
+                "unstable_features": {
+                  "org.example.my_feature": true
+                }
               }
           schema:
             type: object
@@ -50,5 +62,15 @@ paths:
                 items:
                   type: string
                   description: The supported versions
+              unstable_features:
+                type: object
+                description: |-
+                  Experimental features the server supports. Features not listed here,
+                  or the lack of this property all together, indicate that a feature is
+                  not supported.
+                additionalProperties:
+                  type: boolean
+                  description: Whether or not the namespaced feature is supported.
+            required: ['versions']
       tags:
         - Server administration

--- a/changelogs/client_server/newsfragments/1786.feature
+++ b/changelogs/client_server/newsfragments/1786.feature
@@ -1,0 +1,1 @@
+Add support for advertising experimental features to clients.


### PR DESCRIPTION
Rendered: see 'docs' status check
Proposal: https://github.com/matrix-org/matrix-doc/issues/1497

----

The only potential change (it is unclear in the proposal) is that the spec doesn't define the features that can be listed here. The rationale being that people can be courteous to each other and not pick identifiers which collide with other people's implementation where possible.