### PR TITLE
Fix sticky headers so they don't hide behind header bar on desktop

### DIFF
--- a/scripts/css/basic.css
+++ b/scripts/css/basic.css
@@ -465,11 +465,23 @@ dl.glossary dt {
 /* -- proposals page -------------------------------------------------------- */
 
 #tables-of-tracked-proposals h2 {
-  margin-top: 7px;
-  padding-left: 10px;
-  position: -webkit-sticky;
-  position: sticky;
-  top: 0px;
+    padding-left: 10px;
+    position: -webkit-sticky;
+    position: sticky;
+}
+
+/* Move sticky headers below header bar on desktop */
+@media all and (min-width:980px) {
+    #tables-of-tracked-proposals h2 {
+        top: 52px;
+    }
+}
+
+/* Sticky headers stick to the top on mobile */
+@media all and (min-width:0px) and (max-width: 980px) {
+    #tables-of-tracked-proposals h2 {
+        top: 0px;
+    }
 }
 
 /* -- code displays --------------------------------------------------------- */


### PR DESCRIPTION
Looked fine on mobile, but on Desktop on matrix.org we have the header bar.

This accounts for it.