### PR TITLE
Specify .well-known s2s discovery and X.509 validation

### DIFF
--- a/api/server-server/definitions/keys.yaml
+++ b/api/server-server/definitions/keys.yaml
@@ -25,9 +25,9 @@ properties:
   verify_keys:
     type: object
     description: |-
-      Public keys of the homeserver for verifying digital signatures. 
-      
-      The object's key is the algorithm and version combined (``ed25519`` being the 
+      Public keys of the homeserver for verifying digital signatures.
+
+      The object's key is the algorithm and version combined (``ed25519`` being the
       algorithm and ``abc123`` being the version in the example below). Together,
       this forms the Key ID. The version must have characters matching the regular
       expression ``[a-zA-Z0-9_]``.
@@ -49,9 +49,9 @@ properties:
   old_verify_keys:
     type: object
     description: |-
-      The public keys that the server used to use and when it stopped using them. 
-      
-      The object's key is the algorithm and version combined (``ed25519`` being the 
+      The public keys that the server used to use and when it stopped using them.
+
+      The object's key is the algorithm and version combined (``ed25519`` being the
       algorithm and ``0ldK3y`` being the version in the example below). Together,
       this forms the Key ID. The version must have characters matching the regular
       expression ``[a-zA-Z0-9_]``.
@@ -90,17 +90,6 @@ properties:
       additionalProperties:
         type: string
         name: Encoded Signature Verification Key
-  tls_fingerprints:
-    type: array
-    description: Hashes of X.509 TLS certificates used by this server.
-    items:
-      type: object
-      title: TLS Fingerprint
-      properties:
-        sha256:
-          type: string
-          description: The `Unpadded Base64`_ encoded fingerprint.
-          example: "VGhpcyBpcyBoYXNoIHdoaWNoIHNob3VsZCBiZSBieXRlcw"
   valid_until_ts:
     type: integer
     format: int64

--- a/api/server-server/examples/server_key.json
+++ b/api/server-server/examples/server_key.json
@@ -16,8 +16,5 @@
             "ed25519:auto2": "VGhpcyBzaG91bGQgYWN0dWFsbHkgYmUgYSBzaWduYXR1cmU"
         }
     },
-    "tls_fingerprints": [{
-        "sha256": "VGhpcyBpcyBoYXNoIHdoaWNoIHNob3VsZCBiZSBieXRlcw"
-    }],
     "valid_until_ts": 1652262000000
 }

--- a/api/server-server/wellknown.yaml
+++ b/api/server-server/wellknown.yaml
@@ -1,0 +1,53 @@
+# Copyright 2019 New Vector Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+swagger: '2.0'
+info:
+  title: "Matrix Federation Server Discovery API"
+  version: "1.0.0"
+host: localhost:443
+schemes:
+  - https
+basePath: /.well-known
+produces:
+  - application/json
+paths:
+  "/matrix/server":
+    get:
+      summary: Gets information about the delegated server for server-server communication.
+      description: |-
+        Gets information about the delegated server for server-server communication
+        between Matrix homeservers. Servers should follow 30x redirects, carefully
+        avoiding redirect loops, and use normal X.509 certificate validation.
+      responses:
+        200:
+          description:
+            The delegated server information. The ``Content-Type`` for this response SHOULD
+            be ``application/json``, however servers parsing the response should assume that
+            the body is JSON regardless of type. Failures parsing the JSON or invalid data
+            provided in the resulting parsed JSON must result in server discovery failure (no
+            attempts should be made to continue finding an IP address/port number to connect
+            to).
+          examples:
+            application/json: {
+              "m.server": "delegated.example.com:1234"
+            }
+          schema:
+            type: object
+            properties:
+              "m.server":
+                type: string
+                description: |-
+                  The server name to delegate server-server communciations to, with optional
+                  port. The delegated server name uses the same grammar as
+                  `server names in the appendices <../appendices.html#server-name>`_.

--- a/proposals/1708-well-known-for-federation.md
+++ b/proposals/1708-well-known-for-federation.md
@@ -44,8 +44,8 @@ redirect loops). If the request does not return a 200, continue to step 4,
 otherwise:
 
 The response must be valid JSON which follows the structure documented
-below. Otherwise, the request is aborted. It is NOT necessary for the response
-to have a `Content-Type` of `application/json`.
+below. Otherwise, continue to the next step in the discovery process. It is
+NOT necessary for the response to have a `Content-Type` of `application/json`.
 
 If the response is valid, the `m.server` property is parsed as
 `<delegated_server_name>[:<delegated_port>]`, and processed as follows:

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -112,14 +112,7 @@ The process overall is as follows:
    IP address on all requests. Requests must be made with a ``Host``
    header containing the IP address, without port.
 
-2. If the hostname is not an IP literal, a server is found by resolving
-   an SRV record for ``_matrix._tcp.<hostname>``. This may result in
-   a hostname (to be resolved using AAAA or A records) and port. Requests
-   are made to the resolved IP address and port, using 8448 as a default
-   port, with a ``Host`` header of ``<hostname>``. A valid TLS certificate
-   for ``<hostname>`` must be provided by the target server on all requests.
-
-3. If the SRV record yielded no results, a ``/.well-known`` request is
+2. If the hostname is not an IP literal, a ``/.well-known`` request is
    made to the hostname (using port 443 exclusively, ignoring the port
    provided in the server name). The target must present a valid TLS
    certificate for the hostname, and a ``Host`` header containing the
@@ -156,12 +149,19 @@ The process overall is as follows:
         A valid TLS certificate for ``<delegated_server_name>`` must be
         provided by the target server.
 
-4. If the `/.well-known` request was invalid or returned an error response,
-   and the SRV record was not found, an IP address is resolved using AAAA
-   and A records. Requests are made to the resolved IP address using port
-   8448 and a ``Host`` header containing the ``<hostname>``. A valid TLS
-   certificate for ``<hostname>`` must be provided by the target server
-   on all requests.
+3. If the `/.well-known` request returned an error response, a server is
+   found by resolving an SRV record for ``_matrix._tcp.<hostname>``. This
+   may result in a hostname (to be resolved using AAAA or A records) and
+   port. Requests are made to the resolved IP address and port, using 8448
+   as a default port, with a ``Host`` header of ``<hostname>``. A valid TLS
+   certificate for ``<hostname>`` must be provided by the target server on
+   all requests.
+
+4. If the `/.well-known` request returned an error response, and the SRV
+   record was not found, an IP address is resolved using AAAA and A records.
+   Requests are made to the resolved IP address using port 8448 and a ``Host``
+   header containing the ``<hostname>``. A valid TLS certificate for
+   ``<hostname>`` must be provided by the target server on all requests.
 
 
 The TLS certificate provided by the target server must be present on all

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -112,7 +112,7 @@ The process overall is as follows:
    Requests must be made with a ``Host`` header containing the IP address,
    without port.
 
-2. If the hostname is not an IP literal, and has an explicit port given,
+2. If the hostname is not an IP literal, and the server name includes an explicit port,
    resolve the IP address using AAAA or A records. Requests are made to
    the resolved IP address and given port with a ``Host`` header of the
    original hostname (with port). The target server must present a valid

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -122,12 +122,19 @@ The process overall is as follows:
    made to the hostname (using port 443 exclusively, ignoring the port
    provided in the server name). This is done as a plain HTTPS request
    which follows 30x redirects, being careful to avoid redirect loops.
-   The schema of the ``/.well-known`` request is later in this section.
-   If the response is invalid (bad JSON, missing properties, etc),
-   attempts to connect to the target server are aborted - no connections
-   should be attempted. If the response is valid, the ``m.server`` property
-   is parsed as ``<delegated_server_name>[:<delegated_port>]`` and processed
-   as follows:
+   Responses (successful or otherwise) to the ``/.well-known`` endpoint
+   should be cached by the requesting server. Servers should respect
+   the cache control headers present on the response, or use a sensible
+   default when headers are not present. The recommended sensible default
+   is 24 hours. Servers should additionally impose a maximum cache time
+   for responses: 48 hours is recommended. Errors are recommended to be
+   cached for up to an hour, and servers are encouraged to exponentially
+   back off for repeated failures. The schema of the ``/.well-known``
+   request is later in this section. If the response is invalid (bad JSON,
+   missing properties, etc), attempts to connect to the target server are
+   aborted - no connections should be attempted. If the response is valid,
+   the ``m.server`` property is parsed as ``<delegated_server_name>[:<delegated_port>]``
+   and processed as follows:
 
    * If ``<delegated_server_name>`` is an IP literal, then that IP address
      should be used together with the ``<delegated_port>`` or 8448 if no

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -109,14 +109,14 @@ The process overall is as follows:
 1. If the hostname is an IP literal, then that IP address should be used,
    together with the given port number, or 8448 if no port is given. The
    target server must present a valid certificate for the IP address.
-   Requests must be made with a ``Host`` header containing the IP address,
-   without port.
+   The ``Host`` header in the request should be set to the server name,
+   including the port if the server name included one.
 
-2. If the hostname is not an IP literal, and the server name includes an explicit port,
-   resolve the IP address using AAAA or A records. Requests are made to
-   the resolved IP address and given port with a ``Host`` header of the
-   original hostname (with port). The target server must present a valid
-   certificate for the hostname.
+2. If the hostname is not an IP literal, and the server name includes an
+   explicit port, resolve the IP address using AAAA or A records. Requests
+   are made to the resolved IP address and given port with a ``Host`` header
+   of the original server name (with port). The target server must present a
+   valid certificate for the hostname.
 
 3. If the hostname is not an IP literal, a regular HTTPS request is made
    to ``https://<hostname>/.well-known/matrix/server``, expecting the
@@ -130,39 +130,38 @@ The process overall is as follows:
    recommended. Errors are recommended to be cached for up to an hour,
    and servers are encouraged to exponentially back off for repeated
    failures. The schema of the ``/.well-known`` request is later in this
-   section. If the response is invalid (bad JSON, missing properties, etc),
-   attempts to connect to the target server are aborted - no connections
-   should be attempted. If the response is valid, the ``m.server`` property
-   is parsed as ``<delegated_server_name>[:<delegated_port>]`` and processed
-   as follows:
+   section. If the response is invalid (bad JSON, missing properties, non-200
+   response, etc), skip to step 4. If the response is valid, the ``m.server``
+   property is parsed as ``<delegated_hostname>[:<delegated_port>]`` and
+   processed as follows:
 
-   * If ``<delegated_server_name>`` is an IP literal, then that IP address
+   * If ``<delegated_hostname>`` is an IP literal, then that IP address
      should be used together with the ``<delegated_port>`` or 8448 if no
      port is provided. The target server must present a valid TLS certificate
      for the IP address. Requests must be made with a ``Host`` header containing
-     the IP address, with port.
+     the IP address, including the port if one was provided.
 
-   * If ``<delegated_server_name>`` is not an IP literal, and ``<delegated_port>``
+   * If ``<delegated_hostname>`` is not an IP literal, and ``<delegated_port>``
      is present, an IP address is disovered by looking up an AAAA or A
-     record for ``<delegated_server_name>``. The resulting IP address is
-     used, alongside the ``<delegated_port>``, to make requests with a
-     ``Host`` header of ``<delegated_server_name>:<delegated_port>``. The
-     target server must present a valid certificate for ``<delegated_server_name>``.
+     record for ``<delegated_hostname>``. The resulting IP address is
+     used, alongside the ``<delegated_port>``. Requests must be made with a
+     ``Host`` header of ``<delegated_hostname>:<delegated_port>``. The
+     target server must present a valid certificate for ``<delegated_hostname>``.
 
-   * If ``<delegated_server_name>`` is not an IP literal and no
+   * If ``<delegated_hostname>`` is not an IP literal and no
      ``<delegated_port>`` is present, an SRV record is looked up for
-     ``_matrix._tcp.<delegated_server_name>``. This may result in another
+     ``_matrix._tcp.<delegated_hostname>``. This may result in another
      hostname (to be resolved using AAAA or A records) and port. Requests
      should be made to the resolved IP address and port with a ``Host``
-     header containing the ``<delegated_server_name>``. The target server
-     must present a valid certificate for ``<delegated_server_name>``.
+     header containing the ``<delegated_hostname>``. The target server
+     must present a valid certificate for ``<delegated_hostname>``.
 
    * If no SRV record is found, an IP address is resolved using AAAA
      or A records. Requests are then made to the resolve IP address
-     and a port of 8448, using a ``Host`` header of ``<delegated_server_name>``.
-     The target server must present a valid certificate for ``<delegated_server_name>``.
+     and a port of 8448, using a ``Host`` header of ``<delegated_hostname>``.
+     The target server must present a valid certificate for ``<delegated_hostname>``.
 
-4. If the `/.well-known` request did not result in a 200 response, a server
+4. If the `/.well-known` request resulted in an error response, a server
    is found by resolving an SRV record for ``_matrix._tcp.<hostname>``. This
    may result in a hostname (to be resolved using AAAA or A records) and
    port. Requests are made to the resolved IP address and port, using 8448


### PR DESCRIPTION
Rendered: see 'docs' status check

**Note to reviewers**: This now includes MSC1831, which means this cannot land until the FCP has cleared.

----

Original proposals:
* https://github.com/matrix-org/matrix-doc/pull/1708 (note: the JSON requirements were softened by https://github.com/matrix-org/matrix-doc/pull/1824)
* https://github.com/matrix-org/matrix-doc/pull/1711
* https://github.com/matrix-org/matrix-doc/pull/1831

Implementation proofs:
* https://github.com/matrix-org/synapse/pull/4489
* MSC1711 is expected to be enforced by Synapse *after* the r0 spec release: https://github.com/matrix-org/synapse/issues/4366
* https://github.com/matrix-org/synapse/pull/4539

There are no intentional changes which differ from the proposals in this commit, however the author has relied upon various historical conversations outside of the proposals to gain the required context. Inaccuracies introduced by the author are purely accidental.