### PR TITLE
Remove wrong references to TLS fingerprints

### DIFF
--- a/api/server-server/keys_server.yaml
+++ b/api/server-server/keys_server.yaml
@@ -27,7 +27,7 @@ paths:
     get:
       summary: Get the homeserver's public key(s)
       description: |-
-        Gets the homeserver's published TLS fingerprints and signing keys.
+        Gets the homeserver's published signing keys.
         The homeserver may have any number of active keys and may have a
         number of old keys.
 
@@ -49,7 +49,7 @@ paths:
           type: string
           description: |-
             **Deprecated**. Servers should not use this parameter and instead
-            opt to return all keys, not just the requested one. The key ID to 
+            opt to return all keys, not just the requested one. The key ID to
             look up.
           required: false
           x-example: "ed25519:abc123"

--- a/changelogs/server_server/newsfragments/1844.clarification
+++ b/changelogs/server_server/newsfragments/1844.clarification
@@ -1,0 +1,1 @@
+Remove legacy references to TLS fingerprints.

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -157,14 +157,14 @@ The process overall is as follows:
      and a port of 8448, using a ``Host`` header of ``<delegated_hostname>``.
      The target server must present a valid certificate for ``<delegated_hostname>``.
 
-4. If the `/.well-known` request resulted in an error response, a server
+4. If the ``/.well-known`` request resulted in an error response, a server
    is found by resolving an SRV record for ``_matrix._tcp.<hostname>``. This
    may result in a hostname (to be resolved using AAAA or A records) and
    port. Requests are made to the resolved IP address and port, using 8448
    as a default port, with a ``Host`` header of ``<hostname>``. The target
    server must present a valid certificate for ``<hostname>``.
 
-5. If the `/.well-known` request returned an error response, and the SRV
+5. If the ``/.well-known`` request returned an error response, and the SRV
    record was not found, an IP address is resolved using AAAA and A records.
    Requests are made to the resolved IP address using port 8448 and a ``Host``
    header containing the ``<hostname>``. The target server must present a
@@ -220,12 +220,11 @@ server by querying other servers.
 Publishing Keys
 +++++++++++++++
 
-Homeservers publish the allowed TLS fingerprints and signing keys in a JSON
+Homeservers publish their signing keys in a JSON
 object at ``/_matrix/key/v2/server/{key_id}``. The response contains a list of
 ``verify_keys`` that are valid for signing federation requests made by the
 homeserver and for signing events. It contains a list of ``old_verify_keys`` which
-are only valid for signing events. Finally the response contains a list of TLS
-certificate fingerprints to validate any connection made to the homeserver.
+are only valid for signing events.
 
 {{keys_server_ss_http_api}}
 


### PR DESCRIPTION
Also fix some styling in the server discovery section - this didn't feel like it needed its own commit.

Fixes https://github.com/matrix-org/matrix-doc/issues/1842