### PR TITLE
Add the "please use latest.html" warning to the s2s spec

### DIFF
--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -16,6 +16,8 @@
 Federation API
 ==============
 
+{{unstable_warning_block_SERVER_RELEASE_LABEL}}
+
 Matrix homeservers use the Federation APIs (also known as server-server APIs)
 to communicate with each other. Homeservers use these APIs to push messages to
 each other in real-time, to retrieve historic messages from each other, and to


### PR DESCRIPTION
Now that we have a release, we should be warning people who try and use the unstable spec as fact.