### PR TITLE
Fix spelling mistake: endponts -> endpoints

### DIFF
--- a/changelogs/client_server/newsfragments/1838.clarification
+++ b/changelogs/client_server/newsfragments/1838.clarification
@@ -1,0 +1,1 @@
+Fix various spelling mistakes throughout the specification.

--- a/changelogs/client_server/newsfragments/1860.clarification
+++ b/changelogs/client_server/newsfragments/1860.clarification
@@ -1,0 +1,1 @@
+Fix various spelling mistakes throughout the specification.

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -73,7 +73,7 @@ MUST be encoded as UTF-8. Clients are authenticated using opaque
 ``access_token`` strings (see `Client Authentication`_ for details), passed as a
 query string parameter on all requests.
 
-The names of the API endponts for the HTTP transport follow a convention of
+The names of the API endpoints for the HTTP transport follow a convention of
 using underscores to separate words (for example ``/delete_devices``). The key
 names in JSON objects passed over the API also follow this convention.
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1677

This includes a changelog entry for https://github.com/matrix-org/matrix-doc/pull/1838 as it was previously missed.