### PR TITLE
Add a table of contents to each room version spec

### DIFF
--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -18,6 +18,9 @@ Room Version 1
 This room version is the first ever version for rooms, and contains the building
 blocks for other room versions.
 
+.. contents:: Table of Contents
+.. sectnum::
+
 Server implementation components
 --------------------------------
 

--- a/specification/rooms/v2.rst
+++ b/specification/rooms/v2.rst
@@ -18,6 +18,9 @@ Room Version 2
 This room version builds off of `version 1 <v1.html>`_ with an improved state
 resolution algorithm.
 
+.. contents:: Table of Contents
+.. sectnum::
+
 Server implementation components
 --------------------------------
 

--- a/specification/rooms/v3.rst
+++ b/specification/rooms/v3.rst
@@ -24,6 +24,9 @@ This room version builds on `version 2 <v2.html>`_ with an improved event format
    where the contextual room of the request is using this room version. Rooms using
    other room versions should not be affected by these sweeping requirements.
 
+.. contents:: Table of Contents
+.. sectnum::
+
 
 Client considerations
 ---------------------


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1852

We get clickable headers for free by doing this.