### PR TITLE
Correctly nest the capabilities response object

### DIFF
--- a/api/client-server/capabilities.yaml
+++ b/api/client-server/capabilities.yaml
@@ -62,44 +62,48 @@ paths:
           schema:
             type: object
             required: ["capabilities"]
-            additionalProperties:
-              type: object
-              description: |-
-                The custom capabilities the server supports, using the
-                Java package naming convention.
             properties:
-              "m.change_password":
+              capabilities:
                 type: object
+                title: Capabilities
                 description: |-
-                  Capability to indicate if the user can change their password.
-                title: ChangePasswordCapability
+                    The custom capabilities the server supports, using the
+                    Java package naming convention.
+                additionalProperties:
+                  type: object
                 properties:
-                  enabled:
-                    type: boolean
-                    description: |-
-                      True if the user can change their password, false otherwise.
-                    example: false
-                required: ['enabled']
-              "m.room_versions":
-                type: object
-                description: The room versions the server supports.
-                title: RoomVersionsCapability
-                properties:
-                  default:
-                    type: string
-                    description: |-
-                      The default room version the server is using for new rooms.
-                    example: "1"
-                  available:
+                  "m.change_password":
                     type: object
                     description: |-
-                      A detailed description of the room versions the server supports.
-                    additionalProperties:
-                      type: string
-                      title: RoomVersionStability
-                      enum: [stable, unstable]
-                      description: The stability of the room version.
-                required: ['default', 'available']
+                      Capability to indicate if the user can change their password.
+                    title: ChangePasswordCapability
+                    properties:
+                      enabled:
+                        type: boolean
+                        description: |-
+                          True if the user can change their password, false otherwise.
+                        example: false
+                    required: ['enabled']
+                  "m.room_versions":
+                    type: object
+                    description: The room versions the server supports.
+                    title: RoomVersionsCapability
+                    properties:
+                      default:
+                        type: string
+                        description: |-
+                          The default room version the server is using for new rooms.
+                        example: "1"
+                      available:
+                        type: object
+                        description: |-
+                          A detailed description of the room versions the server supports.
+                        additionalProperties:
+                          type: string
+                          title: RoomVersionStability
+                          enum: [stable, unstable]
+                          description: The stability of the room version.
+                    required: ['default', 'available']
         429:
           description: This request was rate-limited.
           schema:

--- a/changelogs/client_server/newsfragments/1879.feature
+++ b/changelogs/client_server/newsfragments/1879.feature
@@ -1,0 +1,1 @@
+Support optional features by having clients query for capabilities.


### PR DESCRIPTION
Everything is contained in a "capabilities" property, which is not represented by the schema. The example was correct.