### PR TITLE
Restrict identifier port numbers to 5 digits.

### DIFF
--- a/specification/appendices/identifier_grammar.rst
+++ b/specification/appendices/identifier_grammar.rst
@@ -34,7 +34,7 @@ following grammar::
 
     server_name = hostname [ ":" port ]
 
-    port        = *DIGIT
+    port        = 1*5DIGIT
 
     hostname    = IPv4address / "[" IPv6address "]" / dns-name
 


### PR DESCRIPTION
Currently the port number can be anything between 0 and 250 characters. It doesn't look like synapse accepts empty port numbers anyway.