### PR TITLE
E2E typo fix in spec

### DIFF
--- a/changelogs/client_server/newsfragments/1933.clarification
+++ b/changelogs/client_server/newsfragments/1933.clarification
@@ -1,0 +1,1 @@
+Fix various spelling mistakes throughout the specification.

--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -291,8 +291,8 @@ v         string           **Required.** Version of the encrypted attachments
 ========= ========= ============================================================
 Parameter Type      Description
 ========= ========= ============================================================
-key       string    **Required.** Key type. Must be ``oct``.
-key_opts  [string]  **Required.** Key operations. Must at least contain
+kty       string    **Required.** Key type. Must be ``oct``.
+key_ops  [string]   **Required.** Key operations. Must at least contain
                     ``encrypt`` and ``decrypt``.
 alg       string    **Required.** Algorithm. Must be ``A256CTR``.
 k         string    **Required.** The key, encoded as urlsafe unpadded base64.

--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -292,7 +292,7 @@ v         string           **Required.** Version of the encrypted attachments
 Parameter Type      Description
 ========= ========= ============================================================
 kty       string    **Required.** Key type. Must be ``oct``.
-key_ops  [string]   **Required.** Key operations. Must at least contain
+key_ops   [string]  **Required.** Key operations. Must at least contain
                     ``encrypt`` and ``decrypt``.
 alg       string    **Required.** Algorithm. Must be ``A256CTR``.
 k         string    **Required.** The key, encoded as urlsafe unpadded base64.


### PR DESCRIPTION
#1932 fixed.

https://matrix.org/_matrix/media/v1/download/matrix.org/OxzykAeqwlnBEsRhBjtDZfQj

Signed-off-by: Eryk Skalinski <e22rico@gmail.com>
