### PR TITLE
fix some errors in key export format

### DIFF
--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -496,17 +496,8 @@ passphrase, and is created as follows:
 Key export format
 <<<<<<<<<<<<<<<<<
 
-The exported sessions are formatted as a JSON object of type ``ExportData``
+The exported sessions are formatted as a JSON array of ``SessionData`` objects
 described as follows:
-
-``ExportData``
-
-=============== ================= ==============================================
-Parameter       Type              Description
-=============== ================= ==============================================
-sessions        ``[SessionData]`` Required. The sessions that are being
-                                  exported.
-=============== ================= ==============================================
 
 ``SessionData``
 
@@ -529,7 +520,7 @@ sessions        ``[SessionData]`` Required. The sessions that are being
                                                device which initiated the session
                                                originally.
    sender_claimed_keys             {string:    Required. The Ed25519 key of the
-                                   integer}    device which initiated the session
+                                   string}     device which initiated the session
                                                originally.
    session_id                      string      Required. The ID of the session.
    session_key                     string      Required. The key for the session.


### PR DESCRIPTION
- empirically, we don't actually wrap the array in an object
- fix an incorrect type

(note: no changelog because this section is only in the unstable release)

fixes #1936 

requesting review from @richvdh because that probably makes most sense