### PR TITLE
Replace /bind with /3pid/bind

### DIFF
--- a/api/identity/associations.yaml
+++ b/api/identity/associations.yaml
@@ -90,7 +90,7 @@ paths:
             }
           schema:
             $ref: "../client-server/definitions/errors/error.yaml"
-  "/bind":
+  "/3pid/bind":
     post:
       summary: Publish an association between a session and a Matrix user ID.
       description: |-

--- a/proposals/1915-unbind-identity-server-param.md
+++ b/proposals/1915-unbind-identity-server-param.md
@@ -55,12 +55,12 @@ from the given identity server.
 
 ### Identity Server 3PID Unbind API
 
-Add `POST /_matrix/identity/api/v1/unbind` with `mxid` and `threepid` fields.
+Add `POST /_matrix/identity/api/v1/3pid/unbind` with `mxid` and `threepid` fields.
 The `mxid` is the user's `user_id` and `threepid` is a dict with the usual
 `medium` and `address` fields.
 
 If the server returns a 400, 404 or 501 HTTP error code then the homeserver
-should assume that the identity server doesn't support the `/unbind` API, unless
+should assume that the identity server doesn't support the `/3pid/unbind` API, unless
 it returns a specific matrix error response (i.e. the body is a JSON object with
 `error` and `errcode` fields).
 
@@ -73,7 +73,7 @@ The identity server should authenticate the request in one of two ways:
 Example:
 
 ```
-POST /_matrix/identity/api/v1/unbind HTTP/1.1
+POST /_matrix/identity/api/v1/3pid/unbind HTTP/1.1
 
 {
     "mxid": "@foobar:example.com",


### PR DESCRIPTION
Sydent implements /3pid/bind instead of /bind. So I have changed the specification to document what is actually implemented.

I have also changed the /unbind endpoint in MSC 1915 in a similar fashion, since this also seems to be a mistake.
