### PR TITLE
Add missing punctuation

### DIFF
--- a/api/client-server/keys.yaml
+++ b/api/client-server/keys.yaml
@@ -253,7 +253,7 @@ paths:
       responses:
         200:
           description:
-            The claimed keys
+            The claimed keys.
           schema:
             type: object
             properties:

--- a/api/server-server/user_keys.yaml
+++ b/api/server-server/user_keys.yaml
@@ -63,7 +63,7 @@ paths:
               - one_time_keys
       responses:
         200:
-          description: The claimed keys
+          description: The claimed keys.
           schema:
             type: object
             properties:

--- a/changelogs/client_server/newsfragments/1991.clarification
+++ b/changelogs/client_server/newsfragments/1991.clarification
@@ -1,0 +1,1 @@
+Fix various spelling mistakes throughout the specification.

--- a/changelogs/server_server/newsfragments/1991.clarification
+++ b/changelogs/server_server/newsfragments/1991.clarification
@@ -1,0 +1,1 @@
+Fix various spelling mistakes throughout the specification.


### PR DESCRIPTION
Other small sentences are postfixed with a period. Add period to keep consistency.