### PR TITLE
Fix body formatting

### DIFF
--- a/event-schemas/examples/m.room.message#m.emote
+++ b/event-schemas/examples/m.room.message#m.emote
@@ -2,9 +2,9 @@
   "$ref": "core/room_event.json",
   "type": "m.room.message",
   "content": {
-    "body": "thinks this is an example emote",
+    "body": "thinks **this** is an example emote",
     "msgtype": "m.emote",
     "format": "org.matrix.custom.html",
-    "formatted_body": "thinks <b>this</b> is an example emote"
+    "formatted_body": "thinks <strong>this</strong> is an example emote"
   }
 }


### PR DESCRIPTION
* `body` and `formatted_body` were inconsistent
* the current markdown translation is to a strong tag, not b