### PR TITLE
Add missing changelogs and make existing ones match conventions

### DIFF
--- a/changelogs/application_service/newsfragments/1650.clarification
+++ b/changelogs/application_service/newsfragments/1650.clarification
@@ -1,0 +1,1 @@
+Change examples to use example.org instead of a real domain.

--- a/changelogs/client_server/newsfragments/1650.clarification
+++ b/changelogs/client_server/newsfragments/1650.clarification
@@ -1,0 +1,1 @@
+Change examples to use example.org instead of a real domain.

--- a/changelogs/client_server/newsfragments/1656.clarification
+++ b/changelogs/client_server/newsfragments/1656.clarification
@@ -1,0 +1,1 @@
+Clarify that ``state_default`` in ``m.room.power_levels`` always defaults to 50.

--- a/changelogs/client_server/newsfragments/1701.feature
+++ b/changelogs/client_server/newsfragments/1701.feature
@@ -1,1 +1,1 @@
-Documented megolm session export format.
+Add megolm session export format.

--- a/changelogs/client_server/newsfragments/1744.clarification
+++ b/changelogs/client_server/newsfragments/1744.clarification
@@ -1,1 +1,1 @@
-Add missing status_msg to m.presence schema.
+Add missing ``status_msg`` to ``m.presence`` schema.

--- a/changelogs/client_server/newsfragments/1889.clarification
+++ b/changelogs/client_server/newsfragments/1889.clarification
@@ -1,1 +1,1 @@
-Add the missing `m.push_rules` event schema.
+Add the missing ``m.push_rules`` event schema.

--- a/changelogs/client_server/newsfragments/1891.clarification
+++ b/changelogs/client_server/newsfragments/1891.clarification
@@ -1,0 +1,1 @@
+Clarify how modern day local echo is meant to be solved by clients.

--- a/changelogs/client_server/newsfragments/1969.clarification
+++ b/changelogs/client_server/newsfragments/1969.clarification
@@ -1,0 +1,1 @@
+Fix various spelling mistakes throughout the specification.

--- a/changelogs/client_server/newsfragments/1975.clarification
+++ b/changelogs/client_server/newsfragments/1975.clarification
@@ -1,1 +1,1 @@
-Clarify that ``width`` and ``height`` are required parameters on ``/_matrix/media/r0/thumbnail/{serverName}/{mediaId}``. It is somewhat meaningless to request a thumbnail without specifying a desired size, and Synapse has never permitted such requests.
+Clarify that ``width`` and ``height`` are required parameters on ``/_matrix/media/r0/thumbnail/{serverName}/{mediaId}``.

--- a/changelogs/client_server/newsfragments/1999.clarification
+++ b/changelogs/client_server/newsfragments/1999.clarification
@@ -1,0 +1,1 @@
+Clarify how ``m.login.dummy`` can be used to disambiguate login flows.

--- a/changelogs/identity_service/newsfragments/1967.clarification
+++ b/changelogs/identity_service/newsfragments/1967.clarification
@@ -1,0 +1,1 @@
+Fix route for ``/3pid/bind``.

--- a/changelogs/server_server/newsfragments/1650.clarification
+++ b/changelogs/server_server/newsfragments/1650.clarification
@@ -1,0 +1,1 @@
+Change examples to use example.org instead of a real domain.


### PR DESCRIPTION
The conventions are not set in stone, however the changelog should not be a mixed bag of voices.