### PR TITLE
Remove prev_content from the redaction essential keys list

### DIFF
--- a/changelogs/client_server/newsfragments/2016.clarification
+++ b/changelogs/client_server/newsfragments/2016.clarification
@@ -1,0 +1,1 @@
+Remove ``prev_content`` from the redaction algorithm's essential keys list.

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1500,7 +1500,6 @@ the following list:
 - ``room_id``
 - ``sender``
 - ``state_key``
-- ``prev_content``
 - ``content``
 - ``hashes``
 - ``signatures``


### PR DESCRIPTION
As per [MSC1954](https://github.com/matrix-org/matrix-doc/pull/1954)

No known changes since the proposal was accepted.