### PR TITLE
Spec MSISDN UIA support

### DIFF
--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -94,6 +94,12 @@ paths:
                   If true, the server binds the email used for authentication to
                   the Matrix ID with the identity server.
                 example: false
+              bind_msisdn:
+                type: boolean
+                description: |-
+                  If true, the server binds the phone number used for authentication
+                  to the Matrix ID with the identity server.
+                example: false
               username:
                 type: string
                 description: |-

--- a/changelogs/client_server/newsfragments/2030.feature
+++ b/changelogs/client_server/newsfragments/2030.feature
@@ -1,0 +1,1 @@
+Add MSISDN (phone number) support to User-Interactive Authentication.

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -618,6 +618,7 @@ This specification defines the following auth types:
  - ``m.login.recaptcha``
  - ``m.login.oauth2``
  - ``m.login.email.identity``
+ - ``m.login.msisdn``
  - ``m.login.token``
  - ``m.login.dummy``
 
@@ -772,6 +773,34 @@ To use this authentication type, clients should submit an auth dict as follows:
 
   {
     "type": "m.login.email.identity",
+    "threepidCreds": [
+      {
+        "sid": "<identity server session id>",
+        "client_secret": "<identity server client secret>",
+        "id_server": "<url of identity server authed with, e.g. 'matrix.org:8090'>"
+      }
+    ],
+    "session": "<session ID>"
+  }
+
+Phone number/MSISDN-based (identity server)
+<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+:Type:
+  ``m.login.msisdn``
+:Description:
+  Authentication is supported by authorising a phone number with an identity
+  server.
+
+Prior to submitting this, the client should authenticate with an identity
+server. After authenticating, the session information should be submitted to
+the homeserver.
+
+To use this authentication type, clients should submit an auth dict as follows:
+
+.. code:: json
+
+  {
+    "type": "m.login.msisdn",
     "threepidCreds": [
       {
         "sid": "<identity server session id>",


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1702

1702 describes the lack of `bind_msisdn` parameter, however the whole login type was missing from UIA.