### PR TITLE
Spec lazy-loading room members

### DIFF
--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -30,7 +30,12 @@ allOf:
         ``include_redundant_members`` to change this behaviour).
 
         Only applicable when filtering state events, such as the
-        ``state`` section of a ``/sync`` or ``/messages`` response.
+        ``state`` section of a lazy-loading aware endpoint.
+
+        The endpoints which support lazy-loading are:
+        `/sync <#get-matrix-client-%CLIENT_RELEASE_LABEL%-sync>`_,
+        `/messages <#get-matrix-client-%CLIENT_RELEASE_LABEL%-rooms-roomid-messages>`_,
+        and `/context <#get-matrix-client-%CLIENT_RELEASE_LABEL%-rooms-roomid-context-eventid>`_.
     include_redundant_members:
       type: boolean
       description: |-
@@ -45,7 +50,7 @@ allOf:
         is ``false`` this field is ignored.
 
         Only applicable when filtering state events, such as the
-        ``state`` section of a ``/sync`` or ``/messages`` response.
+        ``state`` section of a lazy-loading aware endpoint.
     not_rooms:
       description: A list of room IDs to exclude. If this list is absent then no rooms
         are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -25,7 +25,7 @@ allOf:
     include_redundant_members:
       type: boolean
       description: |-
-        If ``true``, enables redudant membership events. Does not
+        If ``true``, enables redundant membership events. Does not
         apply unless ``lazy_load_members`` is ``true``. See
         `Lazy-loading room members <#lazy-loading-room-members>`_
         for more information. Defaults to ``false``.

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -16,6 +16,31 @@ allOf:
 - type: object
   title: RoomEventFilter
   properties:
+    lazy_load_members:
+      type: boolean
+      description: |-
+        If ``true``, the only ``m.room.member`` events returned in
+        the ``state`` section of the ``/sync`` response are those
+        which are definitely necessary for a client to display
+        the ``sender`` of the timeline events in that response.
+        If ``false``, ``m.room.member`` events are not filtered.
+        By default, servers should suppress duplicate redundant
+        lazy-loaded ``m.room.member`` events from being sent to a given
+        client across multiple calls to ``/sync``, given that most clients
+        cache membership events (see ``include_redundant_members``
+        to change this behaviour).
+    include_redundant_members:
+      type: boolean
+      description: |-
+        If ``true``, the ``state`` section of the ``/sync`` response will
+        always contain the ``m.room.member`` events required to display
+        the ``sender`` of the timeline events in that response, assuming
+        ``lazy_load_members`` is enabled. This means that redundant
+        duplicate member events may be returned across multiple calls to
+        ``/sync``. This is useful for naive clients who never track
+        membership data. If ``false``, duplicate ``m.room.member`` events
+        may be suppressed by the server across multiple calls to ``/sync``.
+        If ``lazy_load_members`` is ``false`` this field is ignored.
     not_rooms:
       description: A list of room IDs to exclude. If this list is absent then no rooms
         are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -24,27 +24,28 @@ allOf:
         display the ``sender`` of the timeline events in the response.
         If ``false``, ``m.room.member`` events are not filtered.
         By default, servers should suppress duplicate redundant
-        lazy-loaded ``m.room.member`` events from being sent to a given
-        client across multiple calls, given that most clients
-        cache membership events (see ``include_redundant_members``
-        to change this behaviour).
+        lazy-loaded ``m.room.member`` events from being sent to a
+        given client in a previous request using the same filter,
+        given that most clients cache membership events (see
+        ``include_redundant_members`` to change this behaviour).
 
         Only applicable when filtering state events, such as the
-        ``state`` section of a ``/sync`` or ``/messages``.
+        ``state`` section of a ``/sync`` or ``/messages`` response.
     include_redundant_members:
       type: boolean
       description: |-
         If ``true``, response will always contain the ``m.room.member``
         events required to display the ``sender`` of the timeline events
-        in that response, assuming ``lazy_load_members`` is enabled. This
-        means that redundant duplicate member events may be returned across
-        multiple calls to. This is useful for naive clients who never track
-        membership data. If ``false``, duplicate ``m.room.member`` events
-        may be suppressed by the server across multiple calls. If
-        ``lazy_load_members`` is ``false`` this field is ignored.
+        in that response, assuming ``lazy_load_members`` is enabled.
+        This means that redundant duplicate member events will be returned
+        across multiple calls using the same filter. This is useful for
+        naive clients who never track membership data. If ``false`` or
+        not provided, duplicate ``m.room.member`` events should be
+        suppressed by the server across multiple calls. If ``lazy_load_members``
+        is ``false`` this field is ignored.
 
         Only applicable when filtering state events, such as the
-        ``state`` section of a ``/sync`` or ``/messages``.
+        ``state`` section of a ``/sync`` or ``/messages`` response.
     not_rooms:
       description: A list of room IDs to exclude. If this list is absent then no rooms
         are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -19,28 +19,32 @@ allOf:
     lazy_load_members:
       type: boolean
       description: |-
-        If ``true``, the only ``m.room.member`` events returned in
-        the ``state`` section of the ``/sync`` response are those
-        which are definitely necessary for a client to display
-        the ``sender`` of the timeline events in that response.
+        If ``true``, the only ``m.room.member`` events returned
+        are those which are definitely necessary for a client to
+        display the ``sender`` of the timeline events in the response.
         If ``false``, ``m.room.member`` events are not filtered.
         By default, servers should suppress duplicate redundant
         lazy-loaded ``m.room.member`` events from being sent to a given
-        client across multiple calls to ``/sync``, given that most clients
+        client across multiple calls, given that most clients
         cache membership events (see ``include_redundant_members``
         to change this behaviour).
+
+        Only applicable when filtering state events, such as the
+        ``state`` section of a ``/sync`` or ``/messages``.
     include_redundant_members:
       type: boolean
       description: |-
-        If ``true``, the ``state`` section of the ``/sync`` response will
-        always contain the ``m.room.member`` events required to display
-        the ``sender`` of the timeline events in that response, assuming
-        ``lazy_load_members`` is enabled. This means that redundant
-        duplicate member events may be returned across multiple calls to
-        ``/sync``. This is useful for naive clients who never track
+        If ``true``, response will always contain the ``m.room.member``
+        events required to display the ``sender`` of the timeline events
+        in that response, assuming ``lazy_load_members`` is enabled. This
+        means that redundant duplicate member events may be returned across
+        multiple calls to. This is useful for naive clients who never track
         membership data. If ``false``, duplicate ``m.room.member`` events
-        may be suppressed by the server across multiple calls to ``/sync``.
-        If ``lazy_load_members`` is ``false`` this field is ignored.
+        may be suppressed by the server across multiple calls. If
+        ``lazy_load_members`` is ``false`` this field is ignored.
+
+        Only applicable when filtering state events, such as the
+        ``state`` section of a ``/sync`` or ``/messages``.
     not_rooms:
       description: A list of room IDs to exclude. If this list is absent then no rooms
         are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``

--- a/api/client-server/definitions/room_event_filter.yaml
+++ b/api/client-server/definitions/room_event_filter.yaml
@@ -19,38 +19,16 @@ allOf:
     lazy_load_members:
       type: boolean
       description: |-
-        If ``true``, the only ``m.room.member`` events returned
-        are those which are definitely necessary for a client to
-        display the ``sender`` of the timeline events in the response.
-        If ``false``, ``m.room.member`` events are not filtered.
-        By default, servers should suppress duplicate redundant
-        lazy-loaded ``m.room.member`` events from being sent to a
-        given client in a previous request using the same filter,
-        given that most clients cache membership events (see
-        ``include_redundant_members`` to change this behaviour).
-
-        Only applicable when filtering state events, such as the
-        ``state`` section of a lazy-loading aware endpoint.
-
-        The endpoints which support lazy-loading are:
-        `/sync <#get-matrix-client-%CLIENT_RELEASE_LABEL%-sync>`_,
-        `/messages <#get-matrix-client-%CLIENT_RELEASE_LABEL%-rooms-roomid-messages>`_,
-        and `/context <#get-matrix-client-%CLIENT_RELEASE_LABEL%-rooms-roomid-context-eventid>`_.
+        If ``true``, enables lazy-loading of membership events. See
+        `Lazy-loading room members <#lazy-loading-room-members>`_
+        for more information. Defaults to ``false``.
     include_redundant_members:
       type: boolean
       description: |-
-        If ``true``, response will always contain the ``m.room.member``
-        events required to display the ``sender`` of the timeline events
-        in that response, assuming ``lazy_load_members`` is enabled.
-        This means that redundant duplicate member events will be returned
-        across multiple calls using the same filter. This is useful for
-        naive clients who never track membership data. If ``false`` or
-        not provided, duplicate ``m.room.member`` events should be
-        suppressed by the server across multiple calls. If ``lazy_load_members``
-        is ``false`` this field is ignored.
-
-        Only applicable when filtering state events, such as the
-        ``state`` section of a lazy-loading aware endpoint.
+        If ``true``, enables redudant membership events. Does not
+        apply unless ``lazy_load_members`` is ``true``. See
+        `Lazy-loading room members <#lazy-loading-room-members>`_
+        for more information. Defaults to ``false``.
     not_rooms:
       description: A list of room IDs to exclude. If this list is absent then no rooms
         are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``

--- a/api/client-server/definitions/sync_filter.yaml
+++ b/api/client-server/definitions/sync_filter.yaml
@@ -47,7 +47,7 @@ properties:
       not_rooms:
         description: A list of room IDs to exclude. If this list is absent then no rooms
           are excluded. A matching room will be excluded even if it is listed in the ``'rooms'``
-          filter. This filter is applied before the filters in ``ephemeral``, 
+          filter. This filter is applied before the filters in ``ephemeral``,
           ``state``, ``timeline`` or ``account_data``
         items:
           type: string
@@ -73,33 +73,6 @@ properties:
         allOf:
         - $ref: room_event_filter.yaml
         description: The state events to include for rooms.
-        properties:
-          lazy_load_members:
-            type: boolean
-            description: |-
-              If ``true``, the only ``m.room.member`` events returned in
-              the ``state`` section of the ``/sync`` response are those
-              which are definitely necessary for a client to display
-              the ``sender`` of the timeline events in that response.
-              If ``false``, ``m.room.member`` events are not filtered.
-              By default, servers should suppress duplicate redundant
-              lazy-loaded ``m.room.member`` events from being sent to a given
-              client across multiple calls to ``/sync``, given that most clients
-              cache membership events (see ``include_redundant_members``
-              to change this behaviour).
-          include_redundant_members:
-            type: boolean
-            description: |-
-              If ``true``, the ``state`` section of the ``/sync`` response will
-              always contain the ``m.room.member`` events required to display
-              the ``sender`` of the timeline events in that response, assuming
-              ``lazy_load_members`` is enabled. This means that redundant
-              duplicate member events may be returned across multiple calls to
-              ``/sync``. This is useful for naive clients who never track
-              membership data. If ``false``, duplicate ``m.room.member`` events
-              may be suppressed by the server across multiple calls to ``/sync``.
-              If ``lazy_load_members`` is ``false`` this field is ignored.
-
       timeline:
         allOf:
         - $ref: room_event_filter.yaml

--- a/api/client-server/event_context.yaml
+++ b/api/client-server/event_context.yaml
@@ -35,7 +35,7 @@ paths:
         after the specified event. This allows clients to get the context
         surrounding an event.
 
-        *Note*: This endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        *Note*: This endpoint supports lazy-loading of room member events. See `Filtering <#lazy-loading-room-members>`_
         for more information.
       operationId: getEventContext
       security:

--- a/api/client-server/event_context.yaml
+++ b/api/client-server/event_context.yaml
@@ -35,7 +35,7 @@ paths:
         after the specified event. This allows clients to get the context
         surrounding an event.
 
-        *Note*: this endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        *Note*: This endpoint supports lazy-loading. See `Filtering <#filtering>`_
         for more information.
       operationId: getEventContext
       security:

--- a/api/client-server/event_context.yaml
+++ b/api/client-server/event_context.yaml
@@ -34,6 +34,9 @@ paths:
         This API returns a number of events that happened just before and
         after the specified event. This allows clients to get the context
         surrounding an event.
+
+        *Note*: this endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        for more information.
       operationId: getEventContext
       security:
         - accessToken: []

--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -33,6 +33,9 @@ paths:
       description: |-
         This API returns a list of message and state events for a room. It uses
         pagination query parameters to paginate history in the room.
+
+        *Note*: this endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        for more information.
       operationId: getRoomEvents
       security:
         - accessToken: []
@@ -120,7 +123,7 @@ paths:
 
                   Unless ``include_redundant_members`` is ``true``, the server should remove
                   redundant members which would have already been sent to clients in prior calls
-                  to ``/messages`` or ``/sync`` with the same filter.
+                  to lazy-loading aware endpoints with the same filter.
                 items:
                   type: object
                   title: RoomStateEvent

--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -34,7 +34,7 @@ paths:
         This API returns a list of message and state events for a room. It uses
         pagination query parameters to paginate history in the room.
 
-        *Note*: This endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        *Note*: This endpoint supports lazy-loading of room member events. See `Filtering <#lazy-loading-room-members>`_
         for more information.
       operationId: getRoomEvents
       security:

--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -34,7 +34,7 @@ paths:
         This API returns a list of message and state events for a room. It uses
         pagination query parameters to paginate history in the room.
 
-        *Note*: this endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        *Note*: This endpoint supports lazy-loading. See `Filtering <#filtering>`_
         for more information.
       operationId: getRoomEvents
       security:

--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -115,14 +115,14 @@ paths:
                 type: array
                 description: |-
                   A list of state events relevant to showing the ``chunk``. For example, if
-                  lazy-loading members is enabled in the filter then this will contain any
-                  applicable membership events. Servers should be careful to not exclude
+                  ``lazy_load_members`` is enabled in the filter then this will contain any
+                  the membership events for the the senders of events in the ``chunk``. Servers should be careful to not exclude
                   membership events which are older than ones already sent to the client.
                   Likewise, clients should be cautious and avoid using older membership
                   events as the current membership event when paginating backwards.
 
                   Unless ``include_redundant_members`` is ``true``, the server should remove
-                  redundant members which would have already been sent to clients in prior calls
+                  membership events which would have already been sent to clients in prior calls
                   to lazy-loading aware endpoints with the same filter.
                 items:
                   type: object

--- a/api/client-server/message_pagination.yaml
+++ b/api/client-server/message_pagination.yaml
@@ -108,6 +108,23 @@ paths:
                   type: object
                   title: RoomEvent
                   "$ref": "definitions/event-schemas/schema/core-event-schema/room_event.yaml"
+              state:
+                type: array
+                description: |-
+                  A list of state events relevant to showing the ``chunk``. For example, if
+                  lazy-loading members is enabled in the filter then this will contain any
+                  applicable membership events. Servers should be careful to not exclude
+                  membership events which are older than ones already sent to the client.
+                  Likewise, clients should be cautious and avoid using older membership
+                  events as the current membership event when paginating backwards.
+
+                  Unless ``include_redundant_members`` is ``true``, the server should remove
+                  redundant members which would have already been sent to clients in prior calls
+                  to ``/messages`` or ``/sync`` with the same filter.
+                items:
+                  type: object
+                  title: RoomStateEvent
+                  $ref: "definitions/event-schemas/schema/core-event-schema/state_event.yaml"
           examples:
             application/json: {
                 "start": "t47429-4392820_219380_26003_2265",

--- a/api/client-server/rooms.yaml
+++ b/api/client-server/rooms.yaml
@@ -288,6 +288,44 @@ paths:
           description: The room to get the member events for.
           required: true
           x-example: "!636q39766251:example.com"
+        - in: query
+          name: at
+          type: string
+          description: |-
+            The point in time (pagination token) to return members for in the room.
+            This token can be obtained from a ``prev_batch`` token returned for
+            each room by the sync API. Defaults to the current state of the room,
+            as determined by the server.
+          x-example: "YWxsCgpOb25lLDM1ODcwOA"
+        # XXX: As mentioned in MSC1227, replacing `[not_]membership` with a JSON
+        # filter might be a better alternative.
+        # See https://github.com/matrix-org/matrix-doc/issues/1337
+        - in: query
+          name: membership
+          type: string
+          enum:
+            - join
+            - invite
+            - leave
+            - ban
+          description: |-
+            The kind of membership to filter for. Defaults to no filtering if
+            unspecified. When specified alongside ``not_membership``, the two
+            parameters create an 'or' condition: either the membership *is*
+            the same as ``membership`` **or** *is not* the same as ``not_membership``.
+          x-example: "join"
+        - in: query
+          name: not_membership
+          type: string
+          enum:
+            - join
+            - invite
+            - leave
+            - ban
+          description: |-
+            The kind of membership to exclude from the results. Defaults to no
+            filtering if unspecified.
+          x-example: leave
       security:
         - accessToken: []
       responses:

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -53,6 +53,8 @@ paths:
             requests. Creating a filter using the filter API is recommended for
             clients that reuse the same filter multiple times, for example in
             long poll requests.
+
+            See `Filtering <#filtering>`_ for more information.
           x-example: "66696p746572"
         - in: query
           name: since

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -36,7 +36,8 @@ paths:
         incremental deltas to the state, and to receive new messages.
 
         *Note*: this endpoint supports lazy-loading. See `Filtering <#filtering>`_
-        for more information.
+        for more information. Lazy-loading members is only supported on a ``StateFilter``
+        for this endpoint.
       operationId: sync
       security:
         - accessToken: []

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -40,10 +40,11 @@ paths:
         for this endpoint. When lazy-loading is enabled, servers MUST include the
         syncing user's own membership event when they join a room, or when the
         full state of rooms is requested. The user's own membership event is eligible
-        for being considered redudant by the server. When a sync is ``limited``,
-        the server MUST return membership events for the timeline, even if the
-        applicable events are not in the response, regardless as to whether or not
-        they are redundant.
+        for being considered redundant by the server. When a sync is ``limited``,
+        the server MUST return membership events for events in the gap (from ``since``),
+        even if the applicable events are not in the response, regardless as to whether
+        or not they are redundant. ``include_redundant_members`` is ignored for limited
+        syncs.
       operationId: sync
       security:
         - accessToken: []

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -34,6 +34,9 @@ paths:
         Clients use this API when they first log in to get an initial snapshot
         of the state on the server, and then continue to call this API to get
         incremental deltas to the state, and to receive new messages.
+
+        *Note*: this endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        for more information.
       operationId: sync
       security:
         - accessToken: []

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -129,6 +129,50 @@ paths:
                       title: Joined Room
                       type: object
                       properties:
+                        summary:
+                          title: RoomSummary
+                          type: object
+                          description: |-
+                            Information about the room which clients may need to
+                            correctly render it to users.
+                          properties:
+                            "m.heroes":
+                              type: array
+                              description: |-
+                                The users which can be used to generate a room name
+                                if the room does not have one. Required if the room
+                                does not have a ``m.room.name`` or ``m.room.canonical_alias``
+                                state event with non-empty content.
+
+                                This should be the first 5 members of the room, ordered
+                                by stream ordering, which are joined or invited. The
+                                list must never include the client's own user ID. When
+                                no joined or invited members are available, this should
+                                consist of the banned and left users. More than 5 members
+                                may be provided, however less than 5 should only be provided
+                                when there are less than 5 members to represent.
+
+                                When lazy-loading room members is enabled, the membership
+                                events for the heroes MUST be included in the ``state``,
+                                unless they are redundant. When the list of users changes,
+                                the server notifies the client by sending a fresh list of
+                                heroes. If there are no changes since the last sync, this
+                                field may be omitted.
+                              items:
+                                type: string
+                            "m.joined_member_count":
+                              type: integer
+                              description: |-
+                                 The number of users with ``membership`` of ``join``,
+                                 including the client's own user ID. If this field has
+                                 not changed since the last sync, it may be omitted.
+                                 Required otherwise.
+                            "m.invited_member_count":
+                              type: integer
+                              description: |-
+                                 The number of users with ``membership`` of ``invite``.
+                                 If this field has not changed since the last sync, it
+                                 may be omitted. Required otherwise.
                         state:
                           title: State
                           type: object
@@ -334,6 +378,14 @@ paths:
                 "rooms": {
                   "join": {
                     "!726s6s6q:example.com": {
+                      "summary": {
+                        "m.heroes": [
+                          "@alice:example.com",
+                          "@bob:example.com"
+                        ],
+                        "m.joined_member_count": 2,
+                        "m.invited_member_count": 0
+                      },
                       "state": {
                         "events": [
                           {

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -41,8 +41,8 @@ paths:
         syncing user's own membership event when they join a room, or when the
         full state of rooms is requested. The user's own membership event is eligible
         for being considered redundant by the server. When a sync is ``limited``,
-        the server MUST return membership events for events in the gap (from ``since``),
-        even if the applicable events are not in the response, regardless as to whether
+        the server MUST return membership events for events in the gap (between ``since`` and the start of the returned timeline),
+        regardless as to whether
         or not they are redundant. ``include_redundant_members`` is ignored for limited
         syncs.
       operationId: sync

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -35,7 +35,7 @@ paths:
         of the state on the server, and then continue to call this API to get
         incremental deltas to the state, and to receive new messages.
 
-        *Note*: this endpoint supports lazy-loading. See `Filtering <#filtering>`_
+        *Note*: This endpoint supports lazy-loading. See `Filtering <#filtering>`_
         for more information. Lazy-loading members is only supported on a ``StateFilter``
         for this endpoint.
       operationId: sync

--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -37,7 +37,13 @@ paths:
 
         *Note*: This endpoint supports lazy-loading. See `Filtering <#filtering>`_
         for more information. Lazy-loading members is only supported on a ``StateFilter``
-        for this endpoint.
+        for this endpoint. When lazy-loading is enabled, servers MUST include the
+        syncing user's own membership event when they join a room, or when the
+        full state of rooms is requested. The user's own membership event is eligible
+        for being considered redudant by the server. When a sync is ``limited``,
+        the server MUST return membership events for the timeline, even if the
+        applicable events are not in the response, regardless as to whether or not
+        they are redundant.
       operationId: sync
       security:
         - accessToken: []

--- a/changelogs/client_server/newsfragments/2035.feature
+++ b/changelogs/client_server/newsfragments/2035.feature
@@ -1,0 +1,1 @@
+Add the option to lazy-load room members for increased client performance.

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1268,6 +1268,39 @@ Filters can be created on the server and can be passed as as a parameter to APIs
 which return events. These filters alter the data returned from those APIs.
 Not all APIs accept filters.
 
+Lazy-loading room members
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Membership events often take significant resources for clients to track. In an
+effort to reduce the number of resources used, clients can enable "lazy-loading"
+for room members. By doing this, servers will only ever send membership events
+which are relevant to the client.
+
+In terms of filters, this means enabling ``lazy_load_members`` on a ``StateFilter``
+or ``RoomEventFilter``. When enabled, lazy-loading aware endpoints (see below)
+will only include membership events for the ``sender`` of events being included
+in the response. For example, if a client makes a ``/sync`` request with lazy-loading
+enabled, the server will only return membership events for the ``sender`` of events
+in the timeline, not all members of a room.
+
+Repeated calls to lazy-loading aware endpoints will result in redundant membership
+events being excluded by default. Clients often track which membership events they
+already have, therefore making the extra information not as useful to the client.
+Clients can always request redundant members by setting ``include_redundant_members``
+to true in the filter.
+
+Servers should be cautious about which events they consider redundant. Membership
+events can change over time, and should be included as relevant to maintain the
+historical record. Likewise, clients should be cautious about treating an older event
+as the current membership event for a user.
+
+.. Note::
+   Repeated calls using the same filter to *any* lazy-loading aware endpoint may
+   result in redundant members being excluded from future calls. For example, a
+   request to ``/sync`` followed by a request to ``/messages`` may result in a
+   future call to ``/sync`` excluding members included by the ``/messages`` call.
+
+
 {{filter_cs_http_api}}
 
 Events

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1300,6 +1300,11 @@ as the current membership event for a user.
    request to ``/sync`` followed by a request to ``/messages`` may result in a
    future call to ``/sync`` excluding members included by the ``/messages`` call.
 
+The current endpoints which support lazy-loading room members are:
+
+* |/sync|_
+* |/rooms/<room_id>/messages|_
+* |/rooms/{roomId}/context/{eventId}|_
 
 {{filter_cs_http_api}}
 

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1286,7 +1286,7 @@ for the ``sender`` of events in the timeline, not all members of a room.
 Repeated calls to lazy-loading aware endpoints will result in redundant membership
 events being excluded by default. Clients often track which membership events they
 already have, therefore making the extra information not as useful to the client.
-Clients can always request redundant members by setting ``include_redundant_members``
+Clients can always request redundant membership events by setting ``include_redundant_members``
 to true in the filter.
 
 Servers should be cautious about which events they consider redundant. Membership
@@ -1296,9 +1296,9 @@ as the current membership event for a user.
 
 .. Note::
    Repeated calls using the same filter to *any* lazy-loading aware endpoint may
-   result in redundant members being excluded from future calls. For example, a
+   result in redundant membership events being excluded from future calls. For example, a
    request to ``/sync`` followed by a request to ``/messages`` may result in a
-   future call to ``/sync`` excluding members included by the ``/messages`` call.
+   future call to ``/sync`` excluding membership events returned by the ``/messages`` call.
 
 The current endpoints which support lazy-loading room members are:
 

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1276,12 +1276,12 @@ effort to reduce the number of resources used, clients can enable "lazy-loading"
 for room members. By doing this, servers will only ever send membership events
 which are relevant to the client.
 
-In terms of filters, this means enabling ``lazy_load_members`` on a ``StateFilter``
-or ``RoomEventFilter``. When enabled, lazy-loading aware endpoints (see below)
-will only include membership events for the ``sender`` of events being included
-in the response. For example, if a client makes a ``/sync`` request with lazy-loading
-enabled, the server will only return membership events for the ``sender`` of events
-in the timeline, not all members of a room.
+In terms of filters, this means enabling ``lazy_load_members`` on a ``RoomEventFilter``
+(or a ``StateFilter`` in the case of ``/sync`` only). When enabled, lazy-loading
+aware endpoints (see below) will only include membership events for the ``sender``
+of events being included in the response. For example, if a client makes a ``/sync``
+request with lazy-loading enabled, the server will only return membership events
+for the ``sender`` of events in the timeline, not all members of a room.
 
 Repeated calls to lazy-loading aware endpoints will result in redundant membership
 events being excluded by default. Clients often track which membership events they

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1306,6 +1306,9 @@ The current endpoints which support lazy-loading room members are:
 * |/rooms/<room_id>/messages|_
 * |/rooms/{roomId}/context/{eventId}|_
 
+API endpoints
+~~~~~~~~~~~~~
+
 {{filter_cs_http_api}}
 
 Events

--- a/specification/modules/instant_messaging.rst
+++ b/specification/modules/instant_messaging.rst
@@ -293,7 +293,7 @@ choose a name:
       users (`disambiguating them if required`_) and concatenating them. For
       example, the client may choose to show "Alice, Bob, and Charlie
       (@charlie:example.org)" as the room name. The client may optionally
-      limit the number
+      limit the number of users it uses to generate a room name.
 
    #. If there are fewer heroes than ``m.joined_member_count + m.invited_member_count
       - 1``, and ``m.joined_member_count + m.invited_member_count`` is greater

--- a/specification/modules/instant_messaging.rst
+++ b/specification/modules/instant_messaging.rst
@@ -278,70 +278,42 @@ choose a name:
 #. If the room has an `m.room.canonical_alias`_ state event with a non-empty
    ``alias`` field, use the alias given by that field as the name.
 
-#. If neither of the above conditions are met, a name should be composed based
+#. If neither of the above conditions are met, the client can optionally guess
+   an alias from the ``m.room.alias`` events in the room. This is a temporary
+   measure while clients do not promote canonical aliases as prominently. This
+   step may be removed in a future version of the specification.
+
+#. If none of the above conditions are met, a name should be composed based
    on the members of the room. Clients should consider `m.room.member`_ events
-   for users other than the logged-in user, with ``membership: join`` or
-   ``membership: invite``.
+   for users other than the logged-in user, as defined below.
 
-   .. _active_members:
+   i. If the ``m.heroes`` for the room are greater or equal to
+      ``m.joined_member_count + m.invited_member_count - 1``, then use the
+      membership events for the heroes to calculate display names for the
+      users (`disambiguating them if required`_) and concatenating them. For
+      example, the client may choose to show "Alice, Bob, and Charlie
+      (@charlie:example.org)" as the room name. The client may optionally
+      limit the number
 
-   i. If there is only one such event, the display name for the room should be
-      the `disambiguated display name`_ of the corresponding user.
+   #. If there are fewer heroes than ``m.joined_member_count + m.invited_member_count
+      - 1``, and ``m.joined_member_count + m.invited_member_count`` is greater
+      than 1, the client should use the heroes to calculate display names for
+      the users (`disambiguating them if required`_) and concatenating them
+      alongside a count of the remaining users. For example, "Alice, Bob, and
+      1234 others".
 
-   #. If there are two such events, they should be lexicographically sorted by
-      their ``state_key`` (i.e. the corresponding user IDs), and the display
-      name for the room should be the  `disambiguated display name`_ of both
-      users: "<user1> and <user2>", or a localised variant thereof.
+   #. If ``m.joined_member_count + m.invited_member_count`` is less than or
+      equal to 1 (indicating the member is alone), the client should use the
+      rules above to indicate that the room was empty. For example, "Empty
+      Room (was Alice)", "Empty Room (was Alice and 1234 others)", or
+      "Empty Room" if there are no heroes.
 
-   #. If there are three or more such events, the display name for the room
-      should be based on the disambiguated display name of the user
-      corresponding to the first such event, under a lexicographical sorting
-      according to their ``state_key``. The display name should be in the
-      format "<user1> and <N> others" (or a localised variant thereof), where N
-      is the number of `m.room.member`_ events with ``membership: join`` or
-      ``membership: invite``, excluding the logged-in user and "user1".
+Clients SHOULD internationalise the room name to the user's language when using
+the ``m.heroes`` to calculate the name. Clients SHOULD use minimum 5 heroes to
+calculate room names where possible, but may use more or less to fit better with
+their user experience.
 
-      For example, if Alice joins a room, where Bob (whose user id is
-      ``@superuser:example.com``), Carol (user id ``@carol:example.com``) and
-      Dan (user id ``@dan:matrix.org``) are in conversation, Alice's
-      client should show the room name as "Carol and 2 others".
-
-   .. TODO-spec
-     Sorting by user_id certainly isn't ideal, as IDs at the start of the
-     alphabet will end up dominating room names: they will all be called
-     "Arathorn and 15 others". Furthermore - user_ids are not necessarily
-     ASCII, which means we need to either specify a collation order, or specify
-     how to choose one.
-
-     Ideally we might sort by the time when the user was first invited to, or
-     first joined the room. But we don't have this information.
-
-     See https://matrix.org/jira/browse/SPEC-267 for further discussion.
-
-#. If the room has no valid ``m.room.name`` or ``m.room.canonical_alias``
-   event, and no active members other than the current user, clients should
-   consider ``m.room.member`` events with ``membership: leave``. If such events
-   exist, a display name such as "Empty room (was <user1> and <N> others)" (or
-   a localised variant thereof) should be used, following similar rules as for
-   active members (see `above <active_members_>`_).
-
-#. A complete absence of room name, canonical alias, and room members is likely
-   to indicate a problem with creating the room or synchronising the state
-   table; however clients should still handle this situation. A display name
-   such as "Empty room" (or a localised variant thereof) should be used in this
-   situation.
-
-.. _`disambiguated display name`: `Calculating the display name for a user`_
-
-Clients SHOULD NOT use `m.room.aliases`_ events as a source for room names, as
-it is difficult for clients to agree on the best alias to use, and aliases can
-change unexpectedly.
-
-.. TODO-spec
-  How can we make this less painful for clients to implement, without forcing
-  an English-language implementation on them all? See
-  https://matrix.org/jira/browse/SPEC-425.
-
+.. _`disambiguating them if required`: `Calculating the display name for a user`_
 
 Forming relationships between events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Reviewers**: Although this has team review requested, I would appreciate particular review from @ara4n as the proposal author and @KitsuneRal as having gone through the gauntlet. Feedback in addition is more than appreciated.

**Disclaimer**: Although the implementation is lacking in areas (see below), it is believed by the spec core team that lazy-loading has enough benefits to be added to the spec, as per the MSC guidelines.

----

Implementation references:
* https://github.com/matrix-org/synapse/pull/3574 - Room summary API impl
* https://github.com/matrix-org/synapse/pull/3568 - `/members` additions
* https://github.com/matrix-org/synapse/pull/3567 - `/context` becoming aware of LL
* https://github.com/matrix-org/synapse/pull/2970 - lazy-loading filters + `/sync` & `/messages` behaviour

Notable lacks of implementation:
* Lack of pagination token support on `/members` - https://github.com/matrix-org/synapse/blob/e26e6b3230f0b55376f0f3bf823dd789ac7064d0/synapse/rest/client/v1/room.py#L394
* Synapse always returns redundant members on filtered endpoints - https://github.com/matrix-org/synapse/issues/5393
* Synapse does not return left/banned users in `m.heroes` - https://github.com/matrix-org/synapse/issues/4926
* Synapse does not deduplicate redundant members when paginating `/messages` - https://github.com/matrix-org/synapse/blob/b54b03f9e1abc1964fe5f00115a165a2b8e10df5/synapse/handlers/pagination.py#L262
 * Synapse maintains its redundant membership event cache globally but should be per event stream - https://github.com/matrix-org/synapse/issues/5421

Spec references:
* https://github.com/matrix-org/matrix-doc/pull/1758 - Original spec
* Fixes https://github.com/matrix-org/matrix-doc/issues/1868
* Fixes https://github.com/matrix-org/matrix-doc/issues/1945
* [MSC1227](https://github.com/matrix-org/matrix-doc/issues/1227) - Lazy loading members
* [MSC688](https://github.com/matrix-org/matrix-doc/issues/688) - Room summaries (in a lazy loaded world)

Alterations from the proposals:
* The MSCs are unclear of what scope "redundant" is defined under. Written as "across any of the supported endpoints".
* Clarification that servers and clients should be careful when dealing with historical data. Unsure how Synapse/Riot handle this, if at all.
* Unclear if `summary` should be required. The implementation only does so when lazy-loading is active, however this seems like a bug. Written as required so that clients can use `m.heroes` to name the room.

(*note*: due to these proposals being older Google Doc MSCs, they have had the alterations described here represented in the applicable threaded comments instead of the body of the proposal. This is to hopefully more clearly represent the changes.)