### PR TITLE
Clarify how homeservers are meant to auth themselves to appservices

### DIFF
--- a/changelogs/application_service/newsfragments/2037.clarification
+++ b/changelogs/application_service/newsfragments/2037.clarification
@@ -1,0 +1,1 @@
+Add missing definition for how appservices verify requests came from a homeserver.

--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -187,6 +187,14 @@ An example registration file for an IRC-bridging application service is below:
 Homeserver -> Application Service API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Authorization
++++++++++++++
+
+Homeservers MUST include a query parameter named ``access_token`` containing the
+``hs_token`` from the application service's registration when making requests to
+the application service. Application services MUST verify the provided ``access_token``
+matches their known ``hs_token``, failing the request with a ``M_FORBIDDEN`` error.
+
 Legacy routes
 +++++++++++++
 

--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -193,7 +193,8 @@ Authorization
 Homeservers MUST include a query parameter named ``access_token`` containing the
 ``hs_token`` from the application service's registration when making requests to
 the application service. Application services MUST verify the provided ``access_token``
-matches their known ``hs_token``, failing the request with a ``M_FORBIDDEN`` error.
+matches their known ``hs_token``, failing the request with a ``M_FORBIDDEN`` error
+if it does not match.
 
 Legacy routes
 +++++++++++++


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1765

Note that the swagger definitions already say that authorization is required. It just wasn't mentioned in the spec.