### PR TITLE
Clarify that login flows must be completed in order

### DIFF
--- a/changelogs/client_server/newsfragments/2042.clarification
+++ b/changelogs/client_server/newsfragments/2042.clarification
@@ -1,0 +1,1 @@
+Clarify that login flows are meant to be completed in order.

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -407,8 +407,9 @@ an additional stage. This exchange continues until the final success.
 For each endpoint, a server offers one or more 'flows' that the client can use
 to authenticate itself. Each flow comprises a series of stages, as described
 above. The client is free to choose which flow it follows, however the flow's
-stages must be completed in order. When all stages in a flow are complete,
-authentication is complete and the API call succeeds.
+stages must be completed in order. Failing to follow the flows in order must
+result in an HTTP 401 response, as defined below. When all stages in a flow
+are complete, authentication is complete and the API call succeeds.
 
 User-interactive API in the REST API
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -406,8 +406,9 @@ an additional stage. This exchange continues until the final success.
 
 For each endpoint, a server offers one or more 'flows' that the client can use
 to authenticate itself. Each flow comprises a series of stages, as described
-above. The client is free to choose which flow it follows. When all stages in a
-flow are complete, authentication is complete and the API call succeeds.
+above. The client is free to choose which flow it follows, however the flow's
+stages must be completed in order. When all stages in a flow are complete,
+authentication is complete and the API call succeeds.
 
 User-interactive API in the REST API
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1134

Evidence of this being the case is shown here: https://github.com/matrix-org/synapse/pull/5174