### PR TITLE
Clarify that clients should not ack their own messages

### DIFF
--- a/changelogs/client_server/newsfragments/2043.clarification
+++ b/changelogs/client_server/newsfragments/2043.clarification
@@ -1,0 +1,1 @@
+Clarify that clients should not send read receipts for their own messages.

--- a/specification/modules/receipts.rst
+++ b/specification/modules/receipts.rst
@@ -60,7 +60,8 @@ Clients should send read receipts when there is some certainty that the event in
 question has been **displayed** to the user. Simply receiving an event does not
 provide enough certainty that the user has seen the event. The user SHOULD need
 to *take some action* such as viewing the room that the event was sent to or
-dismissing a notification in order for the event to count as "read".
+dismissing a notification in order for the event to count as "read". Clients
+SHOULD NOT send read receipts for events sent by their own user.
 
 A client can update the markers for its user by interacting with the following
 HTTP APIs.
@@ -94,4 +95,3 @@ Security considerations
 
 As receipts are sent outside the context of the event graph, there are no
 integrity checks performed on the contents of ``m.receipt`` events.
-


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/567