### PR TITLE
Fix test vectors with invalid JSON and signature

### DIFF
--- a/specification/appendices/test_vectors.rst
+++ b/specification/appendices/test_vectors.rst
@@ -114,7 +114,7 @@ The event signing algorithm should emit the following signed event:
         "origin_server_ts": 1000000,
         "signatures": {
             "domain": {
-                "ed25519:1": "2Wptgo4CwmLo/Y8B8qinxApKaCkBG2fjTWB7AbP5Uy+aIbygsSdLOFzvdDjww8zUVKCmI02eP9xtyJxc/cLiBA"
+                "ed25519:1": "JV2dlZUASAefSdywnyCxzykHlyr7xkKGK7IRir1cF8eYsnONrCSb+GRn7aXXstr1UHKvzYjRXPx0001+boD1Ag"
             }
         },
         "type": "X",
@@ -129,7 +129,7 @@ Given the following event containing redactable content:
 
     {
         "content": {
-            "body": "Here is the message content",
+            "body": "Here is the message content"
         },
         "event_id": "$0:domain",
         "origin": "domain",
@@ -149,7 +149,7 @@ The event signing algorithm should emit the following signed event:
 
     {
         "content": {
-            "body": "Here is the message content",
+            "body": "Here is the message content"
         },
         "event_id": "$0:domain",
         "hashes": {
@@ -162,7 +162,7 @@ The event signing algorithm should emit the following signed event:
         "sender": "@u:domain",
         "signatures": {
             "domain": {
-                "ed25519:1": "Wm+VzmOUOz08Ds+0NTWb1d4CZrVsJSikkeRxh6aCcUwu6pNC78FunoD7KNWzqFn241eYHYMGCA5McEiVPdhzBA"
+                "ed25519:1": "4zc79tH2cU6Y+eg4YbbF7KiDOrnwEDjlhTqIKiH4k7L9zD9XCiomD7x9odL9eEwnyy1144QyMBe8O3HK++GHBg"
             }
         },
         "unsigned": {

--- a/specification/appendices/test_vectors.rst
+++ b/specification/appendices/test_vectors.rst
@@ -91,11 +91,22 @@ Given the following minimally-sized event:
 .. code:: json
 
     {
+        "room_id": "!x:domain",
+        "sender": "@a:domain",
         "event_id": "$0:domain",
         "origin": "domain",
         "origin_server_ts": 1000000,
         "signatures": {},
+        "hashes": {},
         "type": "X",
+        "content": {},
+        "prev_events": [
+            ["$1:domain", "ExampleHash"]
+        ],
+        "auth_events": [
+            ["$2", "ExampleHash2"]
+        ],
+        "depth": 3,
         "unsigned": {
             "age_ts": 1000000
         }
@@ -106,15 +117,25 @@ The event signing algorithm should emit the following signed event:
 .. code:: json
 
     {
+        "auth_events": [
+            ["$2", "6tJjLpXtggfke8UxFhAKg82QVkJzvKOVOOSjUDK4ZSI"]
+        ],
+        "content": {},
+        "depth": 3,
         "event_id": "$0:domain",
         "hashes": {
-            "sha256": "6tJjLpXtggfke8UxFhAKg82QVkJzvKOVOOSjUDK4ZSI"
+            "sha256": "6AaJICN1NJURTtaomDYfJlCPMIU+0gtkwg7qzd8FiJM"
         },
         "origin": "domain",
         "origin_server_ts": 1000000,
+        "prev_events": [
+            ["$1:domain", "onLKD1bGljeBWQhWZ1kaP9SorVmRQNdN5aM2JYU2n/g"]
+        ],
+        "room_id": "!x:domain",
+        "sender": "@a:domain",
         "signatures": {
             "domain": {
-                "ed25519:1": "JV2dlZUASAefSdywnyCxzykHlyr7xkKGK7IRir1cF8eYsnONrCSb+GRn7aXXstr1UHKvzYjRXPx0001+boD1Ag"
+                "ed25519:1": "51U0wpKYsaNLTQRbha2v5EGO2cVA6pCtnAKEXguu3j3efCLlmq/53vEfWhsk3tY6gnLsV0YM4Lx2NGZkzmV2Ag"
             }
         },
         "type": "X",

--- a/specification/appendices/test_vectors.rst
+++ b/specification/appendices/test_vectors.rst
@@ -162,7 +162,7 @@ The event signing algorithm should emit the following signed event:
         "sender": "@u:domain",
         "signatures": {
             "domain": {
-                "ed25519:1": "4zc79tH2cU6Y+eg4YbbF7KiDOrnwEDjlhTqIKiH4k7L9zD9XCiomD7x9odL9eEwnyy1144QyMBe8O3HK++GHBg"
+                "ed25519:1": "Wm+VzmOUOz08Ds+0NTWb1d4CZrVsJSikkeRxh6aCcUwu6pNC78FunoD7KNWzqFn241eYHYMGCA5McEiVPdhzBA"
             }
         },
         "unsigned": {

--- a/specification/appendices/test_vectors.rst
+++ b/specification/appendices/test_vectors.rst
@@ -93,19 +93,14 @@ Given the following minimally-sized event:
     {
         "room_id": "!x:domain",
         "sender": "@a:domain",
-        "event_id": "$0:domain",
         "origin": "domain",
         "origin_server_ts": 1000000,
         "signatures": {},
         "hashes": {},
         "type": "X",
         "content": {},
-        "prev_events": [
-            ["$1:domain", "ExampleHash"]
-        ],
-        "auth_events": [
-            ["$2", "ExampleHash2"]
-        ],
+        "prev_events": [],
+        "auth_events": [],
         "depth": 3,
         "unsigned": {
             "age_ts": 1000000
@@ -117,25 +112,20 @@ The event signing algorithm should emit the following signed event:
 .. code:: json
 
     {
-        "auth_events": [
-            ["$2", "6tJjLpXtggfke8UxFhAKg82QVkJzvKOVOOSjUDK4ZSI"]
-        ],
+        "auth_events": [],
         "content": {},
         "depth": 3,
-        "event_id": "$0:domain",
         "hashes": {
-            "sha256": "6AaJICN1NJURTtaomDYfJlCPMIU+0gtkwg7qzd8FiJM"
+            "sha256": "5jM4wQpv6lnBo7CLIghJuHdW+s2CMBJPUOGOC89ncos"
         },
         "origin": "domain",
         "origin_server_ts": 1000000,
-        "prev_events": [
-            ["$1:domain", "onLKD1bGljeBWQhWZ1kaP9SorVmRQNdN5aM2JYU2n/g"]
-        ],
+        "prev_events": [],
         "room_id": "!x:domain",
         "sender": "@a:domain",
         "signatures": {
             "domain": {
-                "ed25519:1": "51U0wpKYsaNLTQRbha2v5EGO2cVA6pCtnAKEXguu3j3efCLlmq/53vEfWhsk3tY6gnLsV0YM4Lx2NGZkzmV2Ag"
+                "ed25519:1": "KxwGjPSDEtvnFgU00fwFz+l6d2pJM6XBIaMEn81SXPTRl16AqLAYqfIReFGZlHi5KLjAWbOoMszkwsQma+lYAg"
             }
         },
         "type": "X",


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2023

The content hashes appear correct, however applying the algorithm defined in the spec never resulted in the signatures previously demonstrated.

**Disclaimer**: This should be reviewed by someone who is extremely comfortable with verifying the signatures in this PR. Although I feel moderately confident in them being wrong, I would rather someone definitively say so (and prove why or why not).