### PR TITLE
Make url required for m.file-like messages

### DIFF
--- a/changelogs/client_server/newsfragments/2053.clarification
+++ b/changelogs/client_server/newsfragments/2053.clarification
@@ -1,0 +1,1 @@
+Clarify the required fields on ``m.file`` (and similar) messages.

--- a/event-schemas/schema/m.room.message#m.audio
+++ b/event-schemas/schema/m.room.message#m.audio
@@ -38,6 +38,7 @@ properties:
     required:
       - msgtype
       - body
+      - url
     type: object
   type:
     enum:

--- a/event-schemas/schema/m.room.message#m.file
+++ b/event-schemas/schema/m.room.message#m.file
@@ -53,7 +53,7 @@ properties:
     required:
       - msgtype
       - body
-      - filename
+      - url
     type: object
   type:
     enum:

--- a/event-schemas/schema/m.room.message#m.image
+++ b/event-schemas/schema/m.room.message#m.image
@@ -28,6 +28,7 @@ properties:
     required:
       - msgtype
       - body
+      - url
     type: object
   type:
     enum:

--- a/event-schemas/schema/m.room.message#m.video
+++ b/event-schemas/schema/m.room.message#m.video
@@ -59,6 +59,7 @@ properties:
     required:
       - msgtype
       - body
+      - url
     type: object
   type:
     enum:


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2008

This also removes `filename` from `m.file` because it has never been used in practice.