### PR TITLE
Make v4 the "default" room version

### DIFF
--- a/specification/index.rst
+++ b/specification/index.rst
@@ -485,7 +485,7 @@ some other reason. Versions can switch between stable and unstable periodically
 for a variety of reasons, including discovered security vulnerabilities and age.
 
 Clients should not ask room administrators to upgrade their rooms if the room is
-running a stable version. Servers SHOULD use room version 1 as the default room
+running a stable version. Servers SHOULD use room version 4 as the default room
 version when creating new rooms.
 
 The available room versions are:


### PR DESCRIPTION
As per [MSC2002](https://github.com/matrix-org/matrix-doc/pull/2002). This was missed in https://github.com/matrix-org/matrix-doc/pull/2019

Fixes https://github.com/matrix-org/matrix-doc/issues/2071