### PR TITLE
Clarify that the default s2s transport is JSON over HTTP

### DIFF
--- a/changelogs/identity_service/newsfragments/2086.clarification
+++ b/changelogs/identity_service/newsfragments/2086.clarification
@@ -1,0 +1,1 @@
+Clarify that the default transport is JSON over HTTP.

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -57,6 +57,8 @@ The following other versions are also available, in reverse chronological order:
 API Standards
 -------------
 
+.. TODO: Move a lot of this to a common area for all specs.
+
 .. TODO
   Need to specify any HMAC or access_token lifetime/ratcheting tricks
   We need to specify capability negotiation for extensible transports
@@ -81,7 +83,6 @@ names in JSON objects passed over the API also follow this convention.
    There are a few historical exceptions to this rule, such as
    ``/createRoom``. A future version of this specification will address the
    inconsistency.
-
 
 Any errors which occur at the Matrix API level MUST return a "standard error
 response". This is a JSON object which looks like:

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -83,6 +83,17 @@ The following other versions are also available, in reverse chronological order:
 - `r0.1.1 <https://matrix.org/docs/spec/server_server/r0.1.1.html>`_
 - `r0.1.0 <https://matrix.org/docs/spec/server_server/r0.1.0.html>`_
 
+
+API standards
+-------------
+
+The mandatory baseline for client-server communication in Matrix is exchanging
+JSON objects over HTTP APIs. More efficient optional transports will in future
+be supported as optional extensions - e.g. a packed binary encoding over
+stream-cipher encrypted TCP socket for low-bandwidth/low-roundtrip mobile usage.
+For the default HTTP transport, all API calls use a Content-Type of
+``application/json``.  In addition, all strings MUST be encoded as UTF-8.
+
 Server discovery
 ----------------
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/1713