### PR TITLE
Merge GET/PUT /state/:event_type endpoints

### DIFF
--- a/api/client-server/room_state.yaml
+++ b/api/client-server/room_state.yaml
@@ -31,6 +31,9 @@ paths:
     put:
       summary: Send a state event to the given room.
       description: |
+        .. For backwards compatibility with older links...
+        .. _`put-matrix-client-%CLIENT_MAJOR_VERSION%-rooms-roomid-state-eventtype`:
+
         State events can be sent using this endpoint.  These events will be
         overwritten if ``<room id>``, ``<event type>`` and ``<state key>`` all
         match.
@@ -61,7 +64,9 @@ paths:
         - in: path
           type: string
           name: stateKey
-          description: The state_key for the state to send. Defaults to the empty string.
+          description: |-
+            The state_key for the state to send. Defaults to the empty string. When
+            an empty string, the trailing slash on this endpoint is optional.
           required: true
           x-example: "@alice:example.com"
         - in: body
@@ -72,71 +77,6 @@ paths:
                 "membership": "join",
                 "avatar_url": "mxc://localhost/SEsfnsuifSDFSSEF#auto",
                 "displayname": "Alice Margatroid"
-              }
-      responses:
-        200:
-          description: "An ID for the sent event."
-          examples:
-            application/json: {
-                  "event_id": "$YUwRidLecu:example.com"
-              }
-          schema:
-            type: object
-            properties:
-              event_id:
-                type: string
-                description: |-
-                  A unique identifier for the event.
-        403:
-          description: |-
-            The sender doesn't have permission to send the event into the room.
-          schema:
-            $ref: "definitions/errors/error.yaml"
-          examples:
-            application/json: {
-              "errcode": "M_FORBIDDEN",
-              "error": "You do not have permission to send the event."
-            }
-      tags:
-        - Room participation
-  "/rooms/{roomId}/state/{eventType}":
-    put:
-      summary: Send a state event to the given room.
-      description: |
-        State events can be sent using this endpoint. This endpoint is
-        equivalent to calling `/rooms/{roomId}/state/{eventType}/{stateKey}`
-        with an empty `stateKey`. Previous state events with matching
-        `<roomId>` and `<eventType>`, and empty `<stateKey>`, will be overwritten.
-
-        Requests to this endpoint **cannot use transaction IDs**
-        like other ``PUT`` paths because they cannot be differentiated from the
-        ``state_key``. Furthermore, ``POST`` is unsupported on state paths.
-
-        The body of the request should be the content object of the event; the
-        fields in this object will vary depending on the type of event. See
-        `Room Events`_ for the ``m.`` event specification.
-      operationId: setRoomState
-      security:
-        - accessToken: []
-      parameters:
-        - in: path
-          type: string
-          name: roomId
-          description: The room to set the state in
-          required: true
-          x-example: "!636q39766251:example.com"
-        - in: path
-          type: string
-          name: eventType
-          description: The type of event to send.
-          required: true
-          x-example: "m.room.name"
-        - in: body
-          name: body
-          schema:
-            type: object
-            example: {
-                  "name": "New name for the room"
               }
       responses:
         200:

--- a/api/client-server/rooms.yaml
+++ b/api/client-server/rooms.yaml
@@ -68,6 +68,9 @@ paths:
     get:
       summary: Get the state identified by the type and key.
       description: |-
+        .. For backwards compatibility with older links...
+        .. _`get-matrix-client-%CLIENT_MAJOR_VERSION%-rooms-roomid-state-eventtype`:
+
         Looks up the contents of a state event in a room. If the user is
         joined to the room then the state is taken from the current
         state of the room. If the user has left the room then the state is
@@ -91,51 +94,11 @@ paths:
         - in: path
           type: string
           name: stateKey
-          description: The key of the state to look up.
+          description: |-
+            The key of the state to look up. Defaults to an empty string. When
+            an empty string, the trailing slash on this endpoint is optional.
           required: true
           x-example: ""
-      responses:
-        200:
-          description: The content of the state event.
-          examples:
-            application/json: {
-              "name": "Example room name"}
-          schema:
-            type: object
-        404:
-          description: The room has no state with the given type or key.
-        403:
-          description: >
-            You aren't a member of the room and weren't previously a
-            member of the room.
-      tags:
-        - Room participation
-  "/rooms/{roomId}/state/{eventType}":
-    get:
-      summary: Get the state identified by the type, with the empty state key.
-      description: |-
-        Looks up the contents of a state event in a room. If the user is
-        joined to the room then the state is taken from the current
-        state of the room. If the user has left the room then the state is
-        taken from the state of the room when they left.
-
-        This looks up the state event with the empty state key.
-      operationId: getRoomStateByType
-      security:
-        - accessToken: []
-      parameters:
-        - in: path
-          type: string
-          name: roomId
-          description: The room to look up the state in.
-          required: true
-          x-example: "!636q39766251:example.com"
-        - in: path
-          type: string
-          name: eventType
-          description: The type of state to look up.
-          required: true
-          x-example: "m.room.name"
       responses:
         200:
           description: The content of the state event.

--- a/changelogs/client_server/newsfragments/2088.clarification
+++ b/changelogs/client_server/newsfragments/2088.clarification
@@ -1,0 +1,1 @@
+De-duplicate ``/state/<event_type>`` endpoints, clarifying that the ``<state_key>`` is optional.


### PR DESCRIPTION
Clarifying that the state key is optional, and how that works.

Fixes https://github.com/matrix-org/matrix-doc/issues/1182