### PR TITLE
Clarify that the user ID state key restriction doesn't grant send rights

### DIFF
--- a/changelogs/client_server/newsfragments/2092.clarification
+++ b/changelogs/client_server/newsfragments/2092.clarification
@@ -1,0 +1,1 @@
+Clarify that the ``user_id`` restriction on a ``state_key`` does not automatically grant permission to send state events.

--- a/event-schemas/schema/core-event-schema/sync_state_event.yaml
+++ b/event-schemas/schema/core-event-schema/sync_state_event.yaml
@@ -31,7 +31,9 @@ properties:
 
       State keys starting with an ``@`` are reserved for referencing user IDs, such
       as room members. With the exception of a few events, state events set with a
-      given user's ID as the state key MUST only be set by that user.
+      given user's ID as the state key MUST only be set by that user, however this
+      restriction MUST NOT permit the user to send state events without the appropriate
+      permissions.
     type: string
 required:
 - state_key


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2022