### PR TITLE
Fix 404s in links from room v1 spec

### DIFF
--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -293,5 +293,5 @@ Events in version 1 rooms have the following structure:
 {{definition_ss_pdu}}
 
 
-.. _`auth events selection`: ../../server_server/r0.1.1.html#auth-events-selection
-.. _`Signing Events`: ../../server_server/r0.1.1.html#signing-events
+.. _`auth events selection`: ../server_server/r0.1.1.html#auth-events-selection
+.. _`Signing Events`: ../server_server/r0.1.1.html#signing-events


### PR DESCRIPTION
Both links currently point to `/docs/server_server/...` instead of `/docs/spec/server_server/...`