### PR TITLE
Clarify that the common identifier format can be broken

### DIFF
--- a/specification/appendices/identifier_grammar.rst
+++ b/specification/appendices/identifier_grammar.rst
@@ -88,8 +88,8 @@ Common Identifier Format
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Matrix protocol uses a common format to assign unique identifiers to a
-number of entities, including users, events and rooms. Each identifier takes
-the form::
+number of entities, including users, events and rooms. Each identifier typically
+takes the form::
 
   &localpart:domain
 
@@ -106,7 +106,9 @@ The sigil characters are as follows:
 * ``#``: Room alias
 
 The precise grammar defining the allowable format of an identifier depends on
-the type of identifier.
+the type of identifier. For example, event IDs can be represented without a
+``domain`` component under some conditions - see the `Event IDs <#room-ids-and-event-ids>`_
+section below for more information.
 
 User Identifiers
 ++++++++++++++++

--- a/specification/appendices/identifier_grammar.rst
+++ b/specification/appendices/identifier_grammar.rst
@@ -88,14 +88,13 @@ Common Identifier Format
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Matrix protocol uses a common format to assign unique identifiers to a
-number of entities, including users, events and rooms. Each identifier typically
-takes the form::
+number of entities, including users, events and rooms. Each identifier takes
+the form::
 
-  &localpart:domain
+  &string
 
-where ``&`` represents a 'sigil' character; ``domain`` is the `server name`_ of
-the homeserver which allocated the identifier, and ``localpart`` is an
-identifier allocated by that homeserver.
+where ``&`` represents a 'sigil' character; ``string`` is the string which makes
+up the identifier.
 
 The sigil characters are as follows:
 
@@ -105,9 +104,16 @@ The sigil characters are as follows:
 * ``+``: Group ID
 * ``#``: Room alias
 
+User IDs, group IDs, room IDs, room aliases, and sometimes event IDs take the form::
+
+  &localpart:domain
+
+where ``domain`` is the `server name`_ of the homeserver which allocated the
+identifier, and ``localpart`` is an identifier allocated by that homeserver.
+
 The precise grammar defining the allowable format of an identifier depends on
-the type of identifier. For example, event IDs can be represented without a
-``domain`` component under some conditions - see the `Event IDs <#room-ids-and-event-ids>`_
+the type of identifier. For example, event IDs can sometimes be represented with
+a ``domain`` component under some conditions - see the `Event IDs <#room-ids-and-event-ids>`_
 section below for more information.
 
 User Identifiers


### PR DESCRIPTION
We already reference in the Event IDs section that the format depends on the room version, so we just need to link there.

Fixes https://github.com/matrix-org/matrix-doc/issues/2103