### PR TITLE
Fix changelog generation

### DIFF
--- a/scripts/templating/matrix_templates/units.py
+++ b/scripts/templating/matrix_templates/units.py
@@ -962,6 +962,9 @@ class MatrixUnits(Units):
                 if re.match("^[=]{3,}$", line.strip()):
                     # the last line was a header - use that as our new title_part
                     title_part = prev_line.strip()
+                    # take off the last line from the changelog_body_lines because it's the title
+                    if len(changelog_body_lines) > 0:
+                        changelog_body_lines = changelog_body_lines[:len(changelog_body_lines) - 1]
                     continue
                 if re.match("^[-]{3,}$", line.strip()):
                     # the last line is a subheading - drop this line because it's the underline
@@ -975,6 +978,7 @@ class MatrixUnits(Units):
                     # that it renders correctly in the section. We also add newlines so that there's
                     # intentionally blank lines that make rst2html happy.
                     changelog_body_lines.append("    " + line + '\n')
+                prev_line = line
 
             if len(changelog_body_lines) > 0:
                 changelogs[api_name] = "".join(changelog_body_lines)

--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -36,7 +36,7 @@ Changelog
 ---------
 
 
-.. topic:: Version: unstable
+.. topic:: Version: %APPSERVICE_RELEASE_LABEL%
 {{application_service_changelog}}
 
 This version of the specification is generated from


### PR DESCRIPTION
Only include the target version, not all versions. Additionally, make sure the appservice spec isn't hardcoded as "unstable".

Fixes https://github.com/matrix-org/matrix-doc/issues/2115
Fixes https://github.com/matrix-org/matrix-doc/issues/2114