### PR TITLE
Add missing format fields to m.room.message$m.notice schema.

### DIFF
--- a/changelogs/client_server/newsfragments/2125.clarification
+++ b/changelogs/client_server/newsfragments/2125.clarification
@@ -1,0 +1,1 @@
+Add missing format fields to ``m.room.message$m.notice`` schema.

--- a/event-schemas/schema/m.room.message$m.notice
+++ b/event-schemas/schema/m.room.message$m.notice
@@ -12,6 +12,16 @@ properties:
         enum:
           - m.notice
         type: string
+      format:
+        description: |-
+          The format used in the ``formatted_body``. Currently only
+          ``org.matrix.custom.html`` is supported.
+        type: string
+      formatted_body:
+        description: |-
+          The formatted version of the ``body``. This is required if ``format``
+          is specified.
+        type: string
     required:
       - msgtype
       - body


### PR DESCRIPTION
The example event shows the `format` and `formatted_body` fields like the `m.text` message type, but these fields do not appear in the schema shown above the example.