### PR TITLE
Remove the "required" designation from the `url` field of certain m.room.message msgtypes.

### DIFF
--- a/changelogs/client_server/newsfragments/2129.clarification
+++ b/changelogs/client_server/newsfragments/2129.clarification
@@ -1,0 +1,1 @@
+Remove "required" designation from the ``url`` field of certain ``m`.room.message` msgtypes.

--- a/event-schemas/schema/m.room.message$m.audio
+++ b/event-schemas/schema/m.room.message$m.audio
@@ -28,7 +28,7 @@ properties:
         type: string
       url:
         description: |-
-          Required if the file is not encrypted. The URL (typically `MXC URI`_)
+          Required if the file is unencrypted. The URL (typically `MXC URI`_)
           to the audio clip.
         type: string
       file:
@@ -40,7 +40,6 @@ properties:
     required:
       - msgtype
       - body
-      - url
     type: object
   type:
     enum:

--- a/event-schemas/schema/m.room.message$m.file
+++ b/event-schemas/schema/m.room.message$m.file
@@ -55,7 +55,6 @@ properties:
     required:
       - msgtype
       - body
-      - url
     type: object
   type:
     enum:

--- a/event-schemas/schema/m.room.message$m.image
+++ b/event-schemas/schema/m.room.message$m.image
@@ -30,7 +30,6 @@ properties:
     required:
       - msgtype
       - body
-      - url
     type: object
   type:
     enum:

--- a/event-schemas/schema/m.room.message$m.video
+++ b/event-schemas/schema/m.room.message$m.video
@@ -61,7 +61,6 @@ properties:
     required:
       - msgtype
       - body
-      - url
     type: object
   type:
     enum:


### PR DESCRIPTION
Now that content referenced by the *m.audio*, *m.file*, *m.image*, and *m.video* message types can be encrypted, the `url` field is required *only* if the content is unencrypted. The "required" designation in the event schemas (which prefixes the field description with "Required" in bold in the generated HTML) is used to indicate fields which must always be present, and this is no longer the case.

Signed-off-by: Jimmy Cuadra <jimmy@jimmycuadra.com>