### PR TITLE
Fix typo in key verification framework section.

### DIFF
--- a/changelogs/client_server/newsfragments/2131.clarification
+++ b/changelogs/client_server/newsfragments/2131.clarification
@@ -1,0 +1,1 @@
+Fix typo in key verification framework section.

--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -419,7 +419,7 @@ Key verification framework
 
 Verifying keys manually by reading out the Ed25519 key is not very user friendly,
 and can lead to errors. In order to help mitigate errors, and to make the process
-eaiser for users, some verification methods are supported by the specification.
+easier for users, some verification methods are supported by the specification.
 The methods all use a common framework for negotiating the key verification.
 
 To use this framework, Alice's client would send ``m.key.verification.request``


### PR DESCRIPTION
A simple typo fix.

Signed-off-by: Jimmy Cuadra <jimmy@jimmycuadra.com>