### PR TITLE
Fix Push Gateway API example: Field renamed to event_id

### DIFF
--- a/api/push-gateway/push_notifier.yaml
+++ b/api/push-gateway/push_notifier.yaml
@@ -57,7 +57,7 @@ paths:
             type: object
             example: {
               "notification": {
-                "id": "$3957tyerfgewrf384",
+                "event_id": "$3957tyerfgewrf384",
                 "room_id": "!slw48wfj34rtnrf:example.com",
                 "type": "m.room.message",
                 "sender": "@exampleuser:matrix.org",


### PR DESCRIPTION
I believe this was forgotten in:
71cb646541ed2611e8f623fc28fac55b3aa73fbb