### PR TITLE
Clarify `.m.rule.room_one_to_one` push rule

### DIFF
--- a/api/client-server/pushrules.yaml
+++ b/api/client-server/pushrules.yaml
@@ -159,8 +159,13 @@ paths:
                             ],
                             "conditions": [
                                 {
-                                    "is": "2",
-                                    "kind": "room_member_count"
+                                    "kind": "room_member_count",
+                                    "is": "2"
+                                },
+                                {
+                                    "kind": "event_match",
+                                    "key": "type",
+                                    "pattern": "m.room.message"
                                 }
                             ],
                             "default": true,

--- a/changelogs/client_server/newsfragments/2152.clarification
+++ b/changelogs/client_server/newsfragments/2152.clarification
@@ -1,0 +1,1 @@
+Clarify the conditions for the ``.m.rule.room_one_to_one`` push rule.

--- a/event-schemas/examples/m.push_rules
+++ b/event-schemas/examples/m.push_rules
@@ -107,8 +107,13 @@
           ],
           "conditions": [
             {
-              "is": "2",
-              "kind": "room_member_count"
+              "kind": "room_member_count",
+              "is": "2"
+            },
+            {
+              "kind": "event_match",
+              "key": "type",
+              "pattern": "m.room.message"
             }
           ],
           "default": true,

--- a/specification/modules/push.rst
+++ b/specification/modules/push.rst
@@ -563,6 +563,11 @@ Definition:
             {
                 "kind": "room_member_count",
                 "is": "2"
+            },
+            {
+                "kind": "event_match",
+                "key": "type",
+                "pattern": "m.room.message"
             }
         ],
         "actions": [


### PR DESCRIPTION
This clarifies the `.m.rule.room_one_to_one` push rule by adding a condition on
event type. Some parts of the spec already had this info, while others were
missing it. Synapse has had this behaviour since the push rule appeared.

Fixes https://github.com/matrix-org/matrix-doc/issues/2150