### PR TITLE
Clarify the purpose of reference hashes.

### DIFF
--- a/changelogs/server_server/newsfragments/2159.clarification
+++ b/changelogs/server_server/newsfragments/2159.clarification
@@ -1,0 +1,1 @@
+Clarify the purpose of reference hashes.

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -1134,8 +1134,9 @@ Calculating the reference hash for an event
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The *reference hash* of an event covers the essential fields of an event,
-including content hashes. It is used for event identifiers in room versions 3 and
-higher. It is calculated as follows.
+including content hashes. It is used for event identifiers in some room versions.
+See the `room version specification`_ for more information. It is calculated as
+follows.
 
 1. The event is put through the redaction algorithm.
 

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -1134,7 +1134,8 @@ Calculating the reference hash for an event
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The *reference hash* of an event covers the essential fields of an event,
-including content hashes. It is calculated as follows.
+including content hashes. It is used for event identifiers in room versions 3 and
+higher. It is calculated as follows.
 
 1. The event is put through the redaction algorithm.
 


### PR DESCRIPTION
The server-server specification describes a "reference hash" of an event and how to calculate it, but is otherwise not mentioned anywhere else in the document. This change adds a sentence to explain that they are used for event identifiers in later room versions, which are described in other documents.

Signed-off-by: Jimmy Cuadra <jimmy@jimmycuadra.com>