### PR TITLE
Less confusing wording on Application Service's Legacy Routes

### DIFF
--- a/changelogs/application_service/newsfragments/2160.clarification
+++ b/changelogs/application_service/newsfragments/2160.clarification
@@ -1,0 +1,1 @@
+Clearer wording for the legacy routes section.

--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -213,14 +213,14 @@ should fall back to the older endpoints for the application service.
 The older endpoints have the exact same request body and response format, they
 just belong at a different path. The equivalent path for each is as follows:
 
-* ``/_matrix/app/v1/transactions/{txnId}`` becomes ``/transactions/{txnId}``
-* ``/_matrix/app/v1/users/{userId}`` becomes ``/users/{userId}``
-* ``/_matrix/app/v1/rooms/{roomAlias}`` becomes ``/rooms/{roomAlias}``
-* ``/_matrix/app/v1/thirdparty/protocol/{protocol}`` becomes ``/_matrix/app/unstable/thirdparty/protocol/{protocol}``
-* ``/_matrix/app/v1/thirdparty/user/{user}`` becomes ``/_matrix/app/unstable/thirdparty/user/{user}``
-* ``/_matrix/app/v1/thirdparty/location/{location}`` becomes ``/_matrix/app/unstable/thirdparty/location/{location}``
-* ``/_matrix/app/v1/thirdparty/user`` becomes ``/_matrix/app/unstable/thirdparty/user``
-* ``/_matrix/app/v1/thirdparty/location`` becomes ``/_matrix/app/unstable/thirdparty/location``
+* ``/_matrix/app/v1/transactions/{txnId}`` should fallback to ``/transactions/{txnId}``
+* ``/_matrix/app/v1/users/{userId}`` should fallback to ``/users/{userId}``
+* ``/_matrix/app/v1/rooms/{roomAlias}`` should fallback to ``/rooms/{roomAlias}``
+* ``/_matrix/app/v1/thirdparty/protocol/{protocol}`` should fallback to ``/_matrix/app/unstable/thirdparty/protocol/{protocol}``
+* ``/_matrix/app/v1/thirdparty/user/{user}`` should fallback to ``/_matrix/app/unstable/thirdparty/user/{user}``
+* ``/_matrix/app/v1/thirdparty/location/{location}`` should fallback to ``/_matrix/app/unstable/thirdparty/location/{location}``
+* ``/_matrix/app/v1/thirdparty/user`` should fallback to ``/_matrix/app/unstable/thirdparty/user``
+* ``/_matrix/app/v1/thirdparty/location`` should fallback to ``/_matrix/app/unstable/thirdparty/location``
 
 Homeservers should periodically try again for the newer endpoints because the
 application service may have been updated.

--- a/specification/application_service_api.rst
+++ b/specification/application_service_api.rst
@@ -213,14 +213,14 @@ should fall back to the older endpoints for the application service.
 The older endpoints have the exact same request body and response format, they
 just belong at a different path. The equivalent path for each is as follows:
 
-* ``/_matrix/app/v1/transactions/{txnId}`` should fallback to ``/transactions/{txnId}``
-* ``/_matrix/app/v1/users/{userId}`` should fallback to ``/users/{userId}``
-* ``/_matrix/app/v1/rooms/{roomAlias}`` should fallback to ``/rooms/{roomAlias}``
-* ``/_matrix/app/v1/thirdparty/protocol/{protocol}`` should fallback to ``/_matrix/app/unstable/thirdparty/protocol/{protocol}``
-* ``/_matrix/app/v1/thirdparty/user/{user}`` should fallback to ``/_matrix/app/unstable/thirdparty/user/{user}``
-* ``/_matrix/app/v1/thirdparty/location/{location}`` should fallback to ``/_matrix/app/unstable/thirdparty/location/{location}``
-* ``/_matrix/app/v1/thirdparty/user`` should fallback to ``/_matrix/app/unstable/thirdparty/user``
-* ``/_matrix/app/v1/thirdparty/location`` should fallback to ``/_matrix/app/unstable/thirdparty/location``
+* ``/_matrix/app/v1/transactions/{txnId}`` should fall back to ``/transactions/{txnId}``
+* ``/_matrix/app/v1/users/{userId}`` should fall back to ``/users/{userId}``
+* ``/_matrix/app/v1/rooms/{roomAlias}`` should fall back to ``/rooms/{roomAlias}``
+* ``/_matrix/app/v1/thirdparty/protocol/{protocol}`` should fall back to ``/_matrix/app/unstable/thirdparty/protocol/{protocol}``
+* ``/_matrix/app/v1/thirdparty/user/{user}`` should fall back to ``/_matrix/app/unstable/thirdparty/user/{user}``
+* ``/_matrix/app/v1/thirdparty/location/{location}`` should fall back to ``/_matrix/app/unstable/thirdparty/location/{location}``
+* ``/_matrix/app/v1/thirdparty/user`` should fall back to ``/_matrix/app/unstable/thirdparty/user``
+* ``/_matrix/app/v1/thirdparty/location`` should fall back to ``/_matrix/app/unstable/thirdparty/location``
 
 Homeservers should periodically try again for the newer endpoints because the
 application service may have been updated.


### PR DESCRIPTION
https://matrix.org/docs/spec/application_service/r0.1.1#legacy-routes

The "becomes" wording made it a little bit confusing for which was the new route and which was the old.