### PR TITLE
Spec clarification regarding authorisation rules in v1

### DIFF
--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -243,14 +243,15 @@ The rules are as follows:
 
    #. If there is no previous ``m.room.power_levels`` event in the room, allow.
 
-   #. For each of the keys ``users_default``, ``events_default``,
-      ``state_default``, ``ban``, ``redact``, ``kick``, ``invite``, as well as
-      each entry being changed under the ``events`` or ``users`` keys:
+   #. For the keys ``users_default``, ``events_default``,
+      ``state_default``, ``ban``, ``redact``, ``kick``, ``invite`` check if they were changed. 
+      For each of the changed keys, as well as
+      each entry being added, changed or removed under the ``events`` or ``users`` keys:
 
-      i. If the current value is higher than the ``sender``'s current power level,
+      i. If the current value is present and higher than the ``sender``'s current power level,
          reject.
 
-      #. If the new value is higher than the ``sender``'s current power level,
+      #. If the new value is present and higher than the ``sender``'s current power level,
          reject.
 
    #. For each entry being changed under the ``users`` key, other than the

--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -244,8 +244,8 @@ The rules are as follows:
    #. If there is no previous ``m.room.power_levels`` event in the room, allow.
 
    #. For the keys ``users_default``, ``events_default``,
-      ``state_default``, ``ban``, ``redact``, ``kick``, ``invite`` check if they were changed. 
-      For each of the changed keys:
+      ``state_default``, ``ban``, ``redact``, ``kick``, ``invite`` check if they 
+      were added, changed or removed. For each found alteration:
 
       i. If the current value is higher than the ``sender``'s current power level,
          reject.
@@ -253,15 +253,14 @@ The rules are as follows:
       #. If the new value is higher than the ``sender``'s current power level,
          reject.
          
-   #. For each entry being added, changed or removed in both the ``events`` and ``users`` keys:
+   #. For each entry being added, changed or removed in both the ``events`` and 
+      ``users`` keys:
       
       i. If the current value is higher than the ``sender``'s current power level,
          reject.
          
       #. If the new value is higher than the ``sender``'s current power level,
          reject.
-         
-      #. (Note: current/new value can also denote the inferred value from either ``users_default``, ``events_default`` or  ``state_default``)
 
    #. For each entry being changed under the ``users`` key, other than the
       ``sender``'s own entry:
@@ -285,15 +284,19 @@ The rules are as follows:
 
 .. NOTE::
 
-  Some consequences of these rules:
+   * Some consequences of these rules:
 
-  * Unless you are a member of the room, the only permitted operations (apart
-    from the initial create/join) are: joining a public room; accepting or
-    rejecting an invitation to a room.
+       * Unless you are a member of the room, the only permitted operations (apart
+         from the initial create/join) are: joining a public room; accepting or
+         rejecting an invitation to a room.
 
-  * To unban somebody, you must have power level greater than or equal to both
-    the kick *and* ban levels, *and* greater than the target user's power
-    level.
+       * To unban somebody, you must have power level greater than or equal to both
+         the kick *and* ban levels, *and* greater than the target user's power
+         level.
+         
+   * Power levels may also be inferred from defaults. So, mentions of, for example,
+     the ``sender``'s power level might also refer to a default power level that is
+     applied. The same holds true for events.
 
 Event format
 ~~~~~~~~~~~~

--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -292,7 +292,7 @@ The rules are as follows:
 
   Some consequences of these rules:
 
-  *  Unless you are a member of the room, the only permitted operations (apart
+  * Unless you are a member of the room, the only permitted operations (apart
     from the initial create/join) are: joining a public room; accepting or
     rejecting an invitation to a room.
 

--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -109,6 +109,8 @@ The types of state events that affect authorization are:
 - ``m.room.power_levels``
 - ``m.room.third_party_invite``
 
+**Note:** Power levels are inferred from defaults when not explicitly supplied. For example, mentions of the ``sender``'s power level can also refer to the default power level for users in the room.
+
 The rules are as follows:
 
 1. If type is ``m.room.create``:
@@ -282,21 +284,17 @@ The rules are as follows:
 
 #. Otherwise, allow.
 
-.. NOTE::
 
-   * Some consequences of these rules:
 
-       * Unless you are a member of the room, the only permitted operations (apart
-         from the initial create/join) are: joining a public room; accepting or
-         rejecting an invitation to a room.
+  **Note:** Some consequences of these rules:
 
-       * To unban somebody, you must have power level greater than or equal to both
-         the kick *and* ban levels, *and* greater than the target user's power
-         level.
-         
-   * Power levels may also be inferred from defaults. So, mentions of, for example,
-     the ``sender``'s power level might also refer to a default power level that is
-     applied. The same holds true for events.
+  * Unless you are a member of the room, the only permitted operations (apart
+    from the initial create/join) are: joining a public room; accepting or
+    rejecting an invitation to a room.
+
+  * To unban somebody, you must have power level greater than or equal to both
+    the kick *and* ban levels, *and* greater than the target user's power
+    level.
 
 Event format
 ~~~~~~~~~~~~

--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -245,14 +245,23 @@ The rules are as follows:
 
    #. For the keys ``users_default``, ``events_default``,
       ``state_default``, ``ban``, ``redact``, ``kick``, ``invite`` check if they were changed. 
-      For each of the changed keys, as well as
-      each entry being added, changed or removed under the ``events`` or ``users`` keys:
+      For each of the changed keys:
 
-      i. If the current value is present and higher than the ``sender``'s current power level,
+      i. If the current value is higher than the ``sender``'s current power level,
          reject.
 
-      #. If the new value is present and higher than the ``sender``'s current power level,
+      #. If the new value is higher than the ``sender``'s current power level,
          reject.
+         
+   #. For each entry being added, changed or removed in both the ``events`` and ``users`` keys:
+      
+      i. If the current value is higher than the ``sender``'s current power level,
+         reject.
+         
+      #. If the new value is higher than the ``sender``'s current power level,
+         reject.
+         
+      #. (Note: current/new value can also denote the inferred value from either ``users_default``, ``events_default`` or  ``state_default``)
 
    #. For each entry being changed under the ``users`` key, other than the
       ``sender``'s own entry:

--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -109,7 +109,11 @@ The types of state events that affect authorization are:
 - ``m.room.power_levels``
 - ``m.room.third_party_invite``
 
-**Note:** Power levels are inferred from defaults when not explicitly supplied. For example, mentions of the ``sender``'s power level can also refer to the default power level for users in the room.
+.. NOTE::
+
+  Power levels are inferred from defaults when not explicitly supplied.
+  For example, mentions of the ``sender``'s power level can also refer 
+  to the default power level for users in the room.
 
 The rules are as follows:
 
@@ -284,11 +288,11 @@ The rules are as follows:
 
 #. Otherwise, allow.
 
+.. NOTE::
 
+  Some consequences of these rules:
 
-  **Note:** Some consequences of these rules:
-
-  * Unless you are a member of the room, the only permitted operations (apart
+  *  Unless you are a member of the room, the only permitted operations (apart
     from the initial create/join) are: joining a public room; accepting or
     rejecting an invitation to a room.
 


### PR DESCRIPTION
The authorisation rules in room version 1 under 10c can be misinterpreted. This commit changes the wording to make it clear, that both the always present keys, such as kick and ban, as well as the keys in the dictionaries users and events are taken into consideration if and only if they were changed and that unchanged values are ignored.

Additionally, it is also clarified that entries in the two dictionaries that are being added or removed, are also taken into consideration and not just entries where the value was altered.

Signed-off-by: Luca Becker luca.becker@me.com