### PR TITLE
Clarify that /rooms/{roomId}/event/{eventId}'s 404 should be M_NOT_FOUND

### DIFF
--- a/api/client-server/rooms.yaml
+++ b/api/client-server/rooms.yaml
@@ -62,6 +62,13 @@ paths:
               - "$ref": "definitions/event-schemas/schema/core-event-schema/event.yaml"
         404:
           description: The event was not found or you do not have permission to read this event.
+          examples:
+            application/json: {
+                "errcode": "M_NOT_FOUND",
+                "error": "Event not found."
+              }
+          schema:
+            "$ref": "definitions/errors/error.yaml"
       tags:
         - Room participation
   "/rooms/{roomId}/state/{eventType}/{stateKey}":


### PR DESCRIPTION
No error code is specified for this endpoint's 404. State that it should be an `M_NOT_FOUND`.