### PR TITLE
Check for a state_key on the tombstone push rule

### DIFF
--- a/changelogs/client_server/newsfragments/2223.clarification
+++ b/changelogs/client_server/newsfragments/2223.clarification
@@ -1,0 +1,1 @@
+Add a missing ``state_key`` check on ``.m.rule.tombstone``.

--- a/proposals/1930-tombstone-notifications.md
+++ b/proposals/1930-tombstone-notifications.md
@@ -19,6 +19,11 @@ A new default override rule is to be added which is similar to `@room` notificat
             "kind": "event_match",
             "key": "type",
             "pattern": "m.room.tombstone"
+        },
+        {
+            "kind": "event_match",
+            "key": "state_key",
+            "pattern": ""
         }
     ],
     "actions": [

--- a/specification/modules/push.rst
+++ b/specification/modules/push.rst
@@ -382,7 +382,7 @@ Definition:
 
 ``.m.rule.tombstone``
 `````````````````````
-Matches any event whose type is ``m.room.tombstone``. This is intended
+Matches any state event whose type is ``m.room.tombstone``. This is intended
 to notify users of a room when it is upgraded, similar to what an
 ``@room`` notification would accomplish.
 
@@ -399,6 +399,11 @@ Definition:
                 "kind": "event_match",
                 "key": "type",
                 "pattern": "m.room.tombstone"
+            },
+            {
+                "kind": "event_match",
+                "key": "state_key",
+                "pattern": ""
             }
         ],
         "actions": [


### PR DESCRIPTION
This is an oversight from the proposal: https://github.com/matrix-org/matrix-doc/pull/1930