### PR TITLE
fix oapi3'ism in identity service

### DIFF
--- a/api/identity/email_associations.yaml
+++ b/api/identity/email_associations.yaml
@@ -164,11 +164,11 @@ paths:
       responses:
         "200":
           description: Email address is validated.
-        "3xx":
+        "300":
           description: |-
             Email address is validated, and the ``next_link`` parameter was
             provided to the ``requestToken`` call.  The user must be redirected
             to the URL provided by the ``next_link`` parameter.
-        "4xx":
+        "400":
           description:
             Validation failed.

--- a/api/identity/phone_associations.yaml
+++ b/api/identity/phone_associations.yaml
@@ -166,11 +166,11 @@ paths:
       responses:
         "200":
           description: Phone number is validated.
-        "3xx":
+        "300":
           description: |-
             Phone number address is validated, and the ``next_link`` parameter
             was provided to the ``requestToken`` call. The user must be
             redirected to the URL provided by the ``next_link`` parameter.
-        "4xx":
+        "400":
           description:
             Validation failed.


### PR DESCRIPTION
range definition for response codes is an oapi3 feature.
it goes without warning with this patch,
may the experts decide about the numbers to use ;)