### PR TITLE
Render enums inside additionalProps as one more table

### DIFF
--- a/api/client-server/capabilities.yaml
+++ b/api/client-server/capabilities.yaml
@@ -96,6 +96,7 @@ paths:
                         example: "1"
                       available:
                         type: object
+                        title: AvailableRoomVersions
                         description: |-
                           A detailed description of the room versions the server supports.
                         additionalProperties:

--- a/changelogs/client_server/2245.clarification
+++ b/changelogs/client_server/2245.clarification
@@ -1,0 +1,1 @@
+List available enum values for the room versions capability

--- a/changelogs/client_server/2245.clarification
+++ b/changelogs/client_server/2245.clarification
@@ -1,1 +1,1 @@
-List available enum values for the room versions capability
+List available enum values for the room versions capability.

--- a/scripts/templating/matrix_templates/units.py
+++ b/scripts/templating/matrix_templates/units.py
@@ -211,9 +211,17 @@ def get_json_schema_object_fields(obj, enforce_title=False):
 
         key_type = additionalProps.get("x-pattern", "string")
         res = process_data_type(additionalProps)
+        tables = res["tables"]
+        val_title = res["title"]
+        if res.get("enum_desc") and val_title != "enum":
+            # A map to enum needs another table with enum description
+            tables.append(TypeTable(
+                title=val_title,
+                rows=[TypeTableRow(key="(mapped value)", title="enum", desc=res["desc"])]
+            ))
         return {
-            "title": "{%s: %s}" % (key_type, res["title"]),
-            "tables": res["tables"],
+            "title": "{%s: %s}" % (key_type, val_title),
+            "tables": tables,
         }
 
     if not props:
@@ -338,8 +346,8 @@ def process_data_type(prop, required=False, enforce_title=True):
         prop_title = prop_type
 
     if prop.get("enum"):
+        prop_title = prop.get("title", "enum")
         if len(prop["enum"]) > 1:
-            prop_title = "enum"
             enum_desc = (
                 "One of: %s" % json.dumps(prop["enum"])
             )


### PR DESCRIPTION
`/capabilities` uses `additionalProperties` that maps to an enum value. The code parsing `additionalProperties` almost doesn't use the Swagger data on the enum, leading to #2242. This PR adds rendering the data on enum into another table.