### PR TITLE
Fix the action of a room key request cancellation.

### DIFF
--- a/event-schemas/examples/m.room_key_request$cancel_request
+++ b/event-schemas/examples/m.room_key_request$cancel_request
@@ -1,6 +1,6 @@
 {
   "content": {
-    "action": "cancel_request",
+    "action": "request_cancellation",
     "requesting_device_id": "RJYKSTBOIE",
     "request_id": "1495474790150.19"
   },

--- a/event-schemas/schema/m.room_key_request
+++ b/event-schemas/schema/m.room_key_request
@@ -38,7 +38,7 @@ properties:
       action:
         enum:
           - request
-          - cancel_request
+          - request_cancellation
         type: string
       requesting_device_id:
         description: ID of the device requesting the key.

--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -756,8 +756,8 @@ sending `m.room_key_request`_ to-device messages to other devices with
 device, it can forward the keys to the first device by sending an encrypted
 `m.forwarded_room_key`_ to-device message. The first device should then send an
 `m.room_key_request`_ to-device message with ``action`` set to
-``cancel_request`` to the other devices that it had originally sent the key
-request to; a device that receives a ``cancel_request`` should disregard any
+``request_cancellation`` to the other devices that it had originally sent the key
+request to; a device that receives a ``request_cancellation`` should disregard any
 previously-received ``request`` message with the same ``request_id`` and
 ``requesting_device_id``.
 


### PR DESCRIPTION
The spec states that the action of a room key request cancellation
should be "cancel_request" but every known implementation uses
"request_cancellation" instead.

This patch fixes the spec to reflect the implementations.