### PR TITLE
MSC2290: Separate Endpoints for Threepid Binding

### DIFF
--- a/proposals/2229-rebind-existing-3pid.md
+++ b/proposals/2229-rebind-existing-3pid.md
@@ -2,6 +2,15 @@
 
 ## Note: This MSC has been made obselete by MSC2290.
 
+MSC2290 provides two separate API endpoints, one for adding a 3PID to the
+homeserver, and another for binding to an identity server. These new
+endpoints will allow the homeserver to enforce rules on emails that already
+exist on the homeserver, only when modifying homeserver email, while only
+needing to forward requests when binding to an identity server. This removes
+the problem MSC2229 is trying to solve, and it is thus made obselete.
+
+---
+
 ```
 3PID
     noun

--- a/proposals/2229-rebind-existing-3pid.md
+++ b/proposals/2229-rebind-existing-3pid.md
@@ -1,5 +1,7 @@
 # Allowing 3PID Owners to Rebind
 
+## Note: This MSC has been made obselete by MSC2290.
+
 ```
 3PID
     noun

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -2,7 +2,7 @@
 
 On the Client Server API there is currently a single endpoint for binding a
 threepid (an email or a phone number): [POST
-/_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid).
+/account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid).
 Depending on whether the `bind` flag is `true` or `false`, the threepid will
 be bound to either a user's account on the homeserver, or both the homeserver
 and an identity server.
@@ -13,7 +13,7 @@ also be bound to a user's account on the homeserver. This allows the
 threepid to be used for message notifications, login, password reset, and
 other important functions.
 
-Typically, when using the `POST /_matrix/client/r0/account/3pid` endpoint,
+Typically, when using the `/account/3pid` endpoint,
 the identity server handles the verification -- either by sending an email to
 an email address, or a SMS message to a phone number. Once completed, the
 homeserver will check with the identity server that verification had indeed
@@ -68,9 +68,10 @@ the MSC is no longer relevant.
 ## Proposal
 
 A new endpoint will be added to the Client Server API: `POST
-/_matrix/client/r0/account/3pid/identity/bind`, and will require
-authentication. The endpoint definition is the same as `POST
-/_matrix/client/r0/account/3pid`, minus the `bind` flag.
+/account/3pid/identity/bind`, and will require authentication. The endpoint
+definition is the same as [POST
+/account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid),
+minus the `bind` flag.
 
 An example of binding a threepid to **an identity server only** with this new endpoint is as follows:
 
@@ -150,13 +151,13 @@ The threepid will then be bound to the user's account.
 The achieve the above flows, some changes need to be made to existing
 endpoints. This MSC requests that the `id_server` and `id_access_token`
 parameters be removed from the Client-Server API's [POST
-/_matrix/client/r0/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-email-requesttoken)
+/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-email-requesttoken)
 and [POST
-/_matrix/client/r0/account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-msisdn-requesttoken)
+/account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-msisdn-requesttoken)
 endpoints, as these endpoints are now only intended for the homeserver to
 send validation requests from. Additionally, the same parameters will be
 removed from the [POST
-/_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid) endpoint's
+/account/3pid](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid) endpoint's
 `three_pid_creds` parameter as an identity server is no longer required to
 perform verification.
 

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -55,7 +55,7 @@ brought to the top level of the request body. The request parameters of `POST
 `client_secret` and `sid`.
 
 The homeserver should prevent a threepid being added to a user's account if
-it already part of another user's account. However, the homeserver should not
+it's already part of another user's account. However, the homeserver should not
 check for existing threepids when binding to an identity server. Identity
 servers do not enforce this requirement and neither should the proxying
 homeserver.

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -145,7 +145,7 @@ POST https://home.server/_matrix/client/r0/account/3pid/add
 
 The threepid will then be bound to the user's account.
 
-The achieve the above flows, some changes need to be made to existing
+To achieve the above flows, some changes need to be made to existing
 endpoints. This MSC requests that the `id_server` and `id_access_token`
 parameters be removed from the Client-Server API's [POST
 /account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid-email-requesttoken)

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -145,27 +145,33 @@ given ID and client_secret was validated, and if so adds the threepid to the
 user's account.
 
 To achieve the above flows, some changes need to be made to existing
-endpoints. The `id_server` and `id_access_token` parameters are to be removed
-from the Client-Server API's [POST
-/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-email-requesttoken)
-and [POST
-/account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-msisdn-requesttoken)
-endpoints, as these endpoints are now only intended for the homeserver to
-send validation requests from.
-
-Additionally, the [POST
+endpoints. The [POST
 /account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid)
 endpoint is deprecated as the two new endpoints replace its functionality.
 The `bind` parameter is to be removed, with the endpoint functioning as if
 `bind` was `false`. Allowing an endpoint to add a threepid to both the
 identity server and homeserver at the same time requires one to trust the
 other, which is the exact behaviour we're trying to eliminate. Doing this
-also helps backward compatibility, as explained below.
+also helps backward compatibility, as explained in [Backwards
+compatibility](#backwards-compatibility).
 
-The text "It is imperative that the homeserver keep a list of trusted
-Identity Servers and only proxies to those that it trusts." is to be removed
-from all parts of the spec, as the homeserver should no longer need to trust
-any identity servers.
+The `id_server` and `id_access_token` parameters are to be removed
+from all of the Client-Server API's `requestToken` endpoints. That is:
+
+* [POST /account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-email-requesttoken)
+* [POST /account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-msisdn-requesttoken)
+* [POST /register/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-register-email-requesttoken)
+* [POST /register/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-register-msisdn-requesttoken)
+* [POST /account/password/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-password-email-requesttoken)
+* [POST /account/password/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-password-msisdn-requesttoken)
+
+Either the homeserver itself or a service that the homeserver delegates to
+should be handling the sending of validation messages, not a user-provided
+server. Any mention of the homeserver being able to proxy to an identity
+server in the above endpoint descriptions, as well as the text "It is
+imperative that the homeserver keep a list of trusted Identity Servers and
+only proxies to those that it trusts." is to be removed from all parts of the
+spec, as the homeserver should no longer need to trust any identity servers.
 
 ## Tradeoffs
 
@@ -204,6 +210,6 @@ security and improve decentralisation in the Matrix ecosystem to boot.
 
 Some endpoints of the Client Server API allow a user to provide an
 `id_server` parameter. Caution should be taken for homeserver developers to
-stop using these user-provided identity servers for any sensitive tasks, such
-as password reset or account registration, if it removes the concept of a
-trusted identity server list.
+stop using these user-provided identity servers for any sensitive tasks where
+possible, such as password reset or account registration, if it removes the
+concept of a trusted identity server list.

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -172,16 +172,18 @@ about hundreds of fake threepid additions to a user's account).
 
 ## Backwards compatibility
 
+A new flag will be added to `/versions`' unstable_features section,
+`m.separate_add_and_bind`. If this flag is present and set to `true`, then
+clients should use the new API endpoints to carry out threepid adds and
+binds. If this flag is not present or set to `false`, clients should use
+`/account/3pid`, being aware that they can only bind threepids to the
+homeserver, not the identity server.
+
 Old matrix clients will continue to use the `/account/3pid` endpoint. This
 MSC removes the `bind` parameter and forces `/account/3pid` calls to act as
 if `bind` was set to `false`. Old clients will still be able to add 3pids to
 the homeserver, but not bind to the identity server. New homeservers must
 ignore any `id_server` information passed to this endpoint.
-
-New matrix clients running with old homeservers should try their desired
-endpoint (either `/account/3pid/add` or `/account/3pid/bind`) and on
-receiving a HTTP `404` error code, should either attempt to use
-`/account/3pid` with the `bind` parameter or give up, at their discretion.
 
 ## Security considerations
 

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -70,7 +70,8 @@ homeserver.
 An example of binding a threepid to an identity server with this new endpoint
 is as follows:
 
-First the client must request the threepid be validated by its chosen identity server.
+First the client must request the threepid be validated by its chosen
+identity server.
 
 ```
 POST https://identity.server/_matrix/identity/v2/validate/email/requestToken
@@ -89,7 +90,8 @@ ID, the given client_secret, and a randomly-generated token.
 Once an email has been sent, the user clicks the link in the email, which
 notifies the identity server that the email has been verified.
 
-Next, the client completes the bind by calling the new endpoint on the homeserver:
+Next, the client completes the bind by calling the new endpoint on the
+homeserver:
 
 ```
 POST https://home.server/_matrix/client/r0/account/3pid/bind

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -135,7 +135,7 @@ The client then sends a request to the old endpoint on the homeserver to bind
 the threepid to user's account.
 
 ```
-POST /_matrix/client/r0/account/3pid/bind
+POST https://home.server/_matrix/client/r0/account/3pid/add
 
 {
     "sid": "abc123987",
@@ -177,11 +177,11 @@ again to finalize the validation afterwards.
 
 ## Backwards compatibility
 
-Old matrix clients will continue to use the `/account/3pid` endpoint. As this
+Old matrix clients will continue to use the `/account/3pid` endpoint. This
 MSC removes the `bind` parameter and forces `/account/3pid` calls to act as
-if `bind` was set to `false`, old clients will still be able to add 3pids,
-but they will only be added to the homeserver, not the identity server. New
-homeservers will ignore any `id_server` information passed to this endpoint.
+if `bind` was set to `false`. Old clients will still be able to add 3pids to
+the homeserver, but not the identity server. New homeservers must ignore any
+`id_server` information passed to this endpoint.
 
 New matrix clients running with old homeservers should try their desired
 endpoint (either `/account/3pid/add` or `/account/3pid/bind`) and on

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -93,7 +93,9 @@ POST https://home.server/_matrix/client/r0/account/3pid/bind
 
 The homeserver will then make a bind request to the specified identity server
 on behalf of the user. The homeserver will record if the bind was successful
-and notify the user.
+and notify the user. The homeserver will remember this bind and the identity
+server it occurred on so that it can perform an unbind later if the user
+requests it or their account is deactivated.
 
 The threepid has now been bound on the user's requested identity server
 without causing that threepid to be used for password resets or any other

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -1,0 +1,190 @@
+# Separate Endpoints for Binding Threepids
+
+On the Client Server API there is currently a single API for binding a
+threepid (an email or a phone number): [POST
+/_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid).
+Depending on whether the `bind` flag is `true` or `false`, the threepid will
+be bound to either a user's account on the homeserver, or both the homeserver
+and an identity server.
+
+A threepid can be bound to an identity server to allow other users to find
+their Matrix ID using their email address or phone number. A threepid can
+also be bound to a user's account on the homeserver. This allows that
+threepid to be used for message notifications, login, password reset, and
+other important functions.
+
+Typically, when using the `POST /_matrix/client/r0/account/3pid` endpoint,
+the identity server handles the verification -- either by sending an email to
+the email address, or a SMS message to the phone number. Once completed, the
+homeserver would check with the identity server that verification had indeed
+happened, and if so, the threepid would be bound (again, either to the
+homeserver, or the homeserver and identity server simultaneously).
+
+Now, consider the fact that the identity server used in this process is
+provided by the user, using the endpoint's `id_server` parameter. If the user were
+to supply a malicious identity server that would immediately answer "yes" to
+any threepid validation, then the user could add any threepid to their
+account on the homeserver (which is likely not something homeserver admins want).
+
+To solve this problem, we propose adding a second endpoint that is only used
+for binding to an identity server of the user's choice. This endpoint will
+not bind the threepid to the user's account on the homeserver, only on the
+identity server.
+
+In addition, the existing binding endpoint will lose the ability to bind
+threepids to an identity server, by removing its `bind` flag. Instead, it
+will solely be used to bind to the user's account on the homeserver.
+
+To be clear, the above issue is not a long-standing security issue. Indeed it
+is not a problem in any released version of Synapse, as Synapse keeps a list
+of "trusted identity servers" that acts a whitelist for what identity servers
+a user can specify.
+
+Synapse is soon to lose this whitelist however, as part of lessening the
+reliance of homeservers on identity servers. This cannot be done while the
+homeserver is still trusting an identity server for validation of threepids.
+If the endpoints are split, the homeserver will handle the validation of
+threepids being added to user accounts, and identity servers will validate
+threepids being added to their own database.
+
+One may question why clients don't just contact an identity server directly
+to bind a threepid, bypassing the implications of binding through a
+homeserver. While this will work, binds should still occur through a
+homeserver such that the homeserver can keep track of which binds were made,
+which is important when a user wishes to deactivate their account (and remove
+all of their bindings made on different identity servers).
+
+A bind could be made on an identity server, which could then tell the
+homeserver that a validation occured, but then there are security
+considerations about how to authenticate an identity server in that instance
+(and prevent people pretending to be identity servers and telling homeservers
+about hundreds of fake binds to a user's account).
+
+This MSC obseletes
+[MSC2229](https://github.com/matrix-org/matrix-doc/pull/2229), which dealt
+with changing the rules of the `bind` flag. Since this flag is being removed,
+the MSC is no longer relevant.
+
+## Proposal
+
+A new endpoint will be added to the Client Server API: `POST /_matrix/client/r0/account/3pid/identity/bind`, and requires authentication.
+
+The endpoint definition is the same as `POST
+/_matrix/client/r0/account/3pid`, minus the `bind` flag.
+
+An example of binding a threepid to an identity server with this new endpoint:
+
+First the client must request the threepid be validated by its chosen identity server.
+
+```
+POST https://identity.server/_matrix/identity/v2/validate/email/requestToken
+
+{
+    "client_secret": "don'tT3ll",
+    "email": "bob@example.com",
+    "send_attempt": 1
+}
+```
+
+Once an email has been sent, the user clicks the link in the email, which
+notifies the identity server that the email has been verified.
+
+Next, the client completes the bind by calling the new endpoint on the homeserver:
+
+```
+POST https://home.server/_matrix/client/r0/account/3pid/identity/bind
+
+{
+    "three_pid_creds": {
+        "id_server": "example.org",
+        "id_access_token": "abc123_OpaqueString",
+        "sid": "abc123987",
+        "client_secret": "don'tT3ll"
+    }
+}
+```
+
+The homeserver will then make a bind request on behalf of the user to the
+specified identity server. The homeserver will record if the bind was
+successful and notify the user.
+
+And for completeness, here is an example of binding a threepid to the
+homeserver only, using the old endpoint:
+
+The homeserver is validating the threepid in this instance, so the client
+must use the `/requestToken` endpoint of the homeserver:
+
+```
+POST https://home.server/_matrix/client/r0/account/3pid/email/requestToken
+
+{
+    "client_secret": "don'tT3ll",
+    "email": "bob@example.com",
+    "send_attempt": 1,
+}
+```
+
+Once an email has been sent, the user clicks the link in the email, which
+notifies the homeserver that the email has been verified.
+
+The client then sends a request to the old endpoint to bind the threepid to
+user's account.
+
+```
+POST /_matrix/client/r0/account/3pid
+
+{
+    "three_pid_creds": {
+        "sid": "abc123987",
+        "client_secret": "don'tT3ll"
+    }
+}
+```
+
+The threepid will then be bound to the user's account.
+
+Users will be able to perform binds to an identity server for a threepid even if that threepid has not been bound to the user's account on the homeserver before.
+
+The achieve the above flow, some changes need to be made to existing
+endpoints as well. This MSC requests that the `id_server` and
+`id_access_token` parameters be removed from the Client-Server API's [POST
+/_matrix/client/r0/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-email-requesttoken)
+endpoint, as this endpoint is now only intended for the homeserver to send
+emails from. Additionally, the same parameters will be removed from the [POST
+/_matrix/client/r0/account/3pid](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid)endpoint's
+`three_pid_creds` parameter as an identity server is no longer required to
+perform verification.
+
+This MSC also requests that the text "It is imperative that the homeserver
+keep a list of trusted Identity Servers and only proxies to those that it
+trusts." be removed from all parts of the spec, as the homeserver should no
+longer need to trust any identity servers.
+
+## Tradeoffs
+
+It may be possible to reduce the two calls per flow into a single endpoint,
+but the current asynchronous approach makes it easy for a client to send a
+request, go offline, have the threepid be validated, and then come online
+again to finalize the validation afterwards.
+
+## Backwards compatibility
+
+TODO
+
+## Security considerations
+
+Reducing the homeserver's trust in identity servers should be a boost to security and improve decentralisation in the Matrix ecosystem to boot.
+
+Caution should be taken for homeserver developers to be sure not to continue
+to use user-provided identity servers for any sensitive tasks once it removes
+the concept of a trusted identity server.
+
+## Conclusion
+
+This MSC helps reduce the homeserver's trust in an identity server even
+further to the point where it is only used for binding addresses for lookup -
+which was the original intention of the Identity Service API.
+
+Additionally, by clearly separating the threepid bind endpoint into two
+endpoints that each have a clear intention, the concept of threepid binding
+becomes a lot easier to reason about.

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -31,13 +31,12 @@ in any released version of Synapse, as Synapse keeps a list of "trusted
 identity servers" that acts a whitelist for what identity servers a user can
 specify.
 
-The requirement for homeservers to keep this whitelist is soon to be lost
-however, as part of lessening the reliance of homeservers on identity
-servers. This cannot be done while the homeserver is still trusting an
-identity server for validation of threepids. If the endpoints are split, the
-homeserver will handle the validation of threepids being added to user
-accounts, and identity servers will validate threepids being added to their
-own database.
+Synapse is soon to lose this whitelist however, as part of lessening the
+reliance of homeservers on identity servers. This cannot be done while the
+homeserver is still trusting an identity server for validation of threepids.
+If the endpoints are split, the homeserver will handle the validation of
+threepids being added to user accounts, and identity servers will validate
+threepids being added to their own database.
 
 To solve this problem, we propose adding two new endpoints. One that is only
 used for binding to user's account, and another that is only for binding to
@@ -139,10 +138,8 @@ the threepid to user's account.
 POST /_matrix/client/r0/account/3pid/bind
 
 {
-    "three_pid_creds": {
-        "sid": "abc123987",
-        "client_secret": "don'tT3ll"
-    }
+    "sid": "abc123987",
+    "client_secret": "don'tT3ll"
 }
 ```
 

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -164,8 +164,10 @@ other, which is the exact behaviour we're trying to eliminate. Doing this
 also helps backward compatibility, as explained in [Backwards
 compatibility](#backwards-compatibility).
 
-The `id_server` and `id_access_token` parameters are to be removed
-from all of the Client-Server API's `requestToken` endpoints. That is:
+Either the homeserver itself or a service that the homeserver delegates to
+should be handling the sending of validation messages, not a user-provided
+server. Any mention of the homeserver being able to proxy to an identity
+server in the below endpoint descriptions: 
 
 * [POST /account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-email-requesttoken)
 * [POST /account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-msisdn-requesttoken)
@@ -174,13 +176,10 @@ from all of the Client-Server API's `requestToken` endpoints. That is:
 * [POST /account/password/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-password-email-requesttoken)
 * [POST /account/password/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-password-msisdn-requesttoken)
 
-Either the homeserver itself or a service that the homeserver delegates to
-should be handling the sending of validation messages, not a user-provided
-server. Any mention of the homeserver being able to proxy to an identity
-server in the above endpoint descriptions, as well as the text "It is
-imperative that the homeserver keep a list of trusted Identity Servers and
-only proxies to those that it trusts." is to be removed from all parts of the
-spec, as the homeserver should no longer need to trust any identity servers.
+As well as the text "It is imperative that the homeserver keep a list of
+trusted Identity Servers and only proxies to those that it trusts." is to be
+removed from all parts of the spec, as the homeserver should no longer need
+to trust any identity servers.
 
 ## Tradeoffs
 

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -133,8 +133,8 @@ POST https://home.server/_matrix/client/r0/account/3pid/add
 The threepid has now been added to the user's account.
 
 To achieve the above flows, some changes need to be made to existing
-endpoints. This MSC requests that the `id_server` and `id_access_token`
-parameters be removed from the Client-Server API's [POST
+endpoints. The `id_server` and `id_access_token` parameters are to be removed
+from the Client-Server API's [POST
 /account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid-email-requesttoken)
 and [POST
 /account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid-msisdn-requesttoken)

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -108,7 +108,7 @@ The homeserver will then make a bind request to the specified identity server
 on behalf of the user. The homeserver will record if the bind was successful
 and notify the user.
 
-The threepid has now been binded on the user's requested identity server
+The threepid has now been bound on the user's requested identity server
 without causing that threepid to be used for password resets or any other
 homeserver-related functions.
 

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -131,8 +131,8 @@ POST https://home.server/_matrix/client/r0/account/3pid/email/requestToken
 Once an email has been sent, the user clicks the link in the email, which
 notifies the homeserver that the threepid has been verified.
 
-The client then sends a request to the old endpoint on the homeserver to bind
-the threepid to user's account.
+The client then sends a request to the endpoint on the homeserver to bind
+the threepid to a user's account.
 
 ```
 POST https://home.server/_matrix/client/r0/account/3pid/add

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -48,7 +48,7 @@ To solve this problem, two new endpoints will be added to the Client Server
 API: `POST /account/3pid/bind` and `POST /account/3pid/add`. Both will
 require authentication and be rate-limited. The request parameters of `POST
 /account/3pid/bind` are the same as [POST
-/account/3pid](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid),
+/account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid),
 minus the `bind` flag, and the contents of `three_pid_creds` have been
 brought to the top level of the request body. The request parameters of `POST
 /account/3pid/add` will simply consist of a JSON body containing
@@ -135,14 +135,14 @@ The threepid has now been added to the user's account.
 To achieve the above flows, some changes need to be made to existing
 endpoints. The `id_server` and `id_access_token` parameters are to be removed
 from the Client-Server API's [POST
-/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid-email-requesttoken)
+/account/3pid/email/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-email-requesttoken)
 and [POST
-/account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid-msisdn-requesttoken)
+/account/3pid/msisdn/requestToken](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid-msisdn-requesttoken)
 endpoints, as these endpoints are now only intended for the homeserver to
 send validation requests from.
 
 Additionally, the [POST
-/account/3pid](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid)
+/account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid)
 endpoint is deprecated as the two new endpoints replace its functionality.
 The `bind` parameter is to be removed, with the endpoint functioning as if
 `bind` was `false`. Allowing an endpoint to add a threepid to both the

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -75,6 +75,10 @@ POST https://identity.server/_matrix/identity/v2/validate/email/requestToken
 }
 ```
 
+The identity server must send an email to the specified address, including a
+link to a URL on the identity server which will accept the validation session
+ID, the given client_secret, and a randomly-generated token.
+
 Once an email has been sent, the user clicks the link in the email, which
 notifies the identity server that the email has been verified.
 
@@ -117,6 +121,10 @@ POST https://home.server/_matrix/client/r0/account/3pid/email/requestToken
 }
 ```
 
+Here the homeserver must send an email to the specified address, including a
+link to a URL on the homeserver which will accept the validation session ID,
+the given client_secret, and a randomly-generated token.
+
 Once an email has been sent, the user clicks the link in the email, which
 notifies the homeserver that the threepid has been verified.
 
@@ -132,7 +140,9 @@ POST https://home.server/_matrix/client/r0/account/3pid/add
 }
 ```
 
-The threepid has now been added to the user's account.
+The homeserver checks the threepid validation session referred to by the
+given ID and client_secret was validated, and if so adds the threepid to the
+user's account.
 
 To achieve the above flows, some changes need to be made to existing
 endpoints. The `id_server` and `id_access_token` parameters are to be removed

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -5,15 +5,10 @@ threepid (an email or a phone number): [POST
 /account/3pid](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid).
 Depending on whether the `bind` flag is `true` or `false`, the threepid will
 be bound to either a user's account on the homeserver, or both the homeserver
-and an identity server.
-
-For context a threepid can be bound to an identity server to allow other
-users to find their Matrix ID using their email address or phone number. A
-threepid can also be added to a user's account on the homeserver. This allows
-the threepid to be used for message notifications, login, password reset, and
-other important functions. We use the term `add` when talking about adding a
-threepid to a homeserver, and `bind` when binding a threepid to an identity
-server. This terminology will be used throughout the rest of this proposal.
+and an identity server. Note that we use the term `add` when talking about
+adding a threepid to a homeserver, and `bind` when binding a threepid to an
+identity server. This terminology will be used throughout the rest of this
+proposal.
 
 Typically, when using the `/account/3pid` endpoint, the identity server
 handles the verification -- either by sending an email to an email address,

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -45,8 +45,15 @@ will validate threepids being bound to themselves.
 ## Proposal
 
 To solve this problem, two new endpoints will be added to the Client Server
-API: `POST /account/3pid/bind` and `POST /account/3pid/add`. Both will
-require authentication and be rate-limited. The request parameters of `POST
+API: `POST /account/3pid/bind` and `POST /account/3pid/add`. Binding to an
+identity server will require standard authentication, whereas adding a 3pid
+to a user account will require [User-Interactive
+Authentication](https://matrix.org/docs/spec/client_server/r0.5.0#user-interactive-authentication-api).
+The latter is to prevent someone from adding a 3pid (which can be used to
+reset passwords) to someone who's left their account open on a public
+computer, without needing their password to do so.
+
+Both endpoints will be rate-limited. The request parameters of `POST
 /account/3pid/bind` are the same as [POST
 /account/3pid](https://matrix.org/docs/spec/client_server/r0.5.0#post-matrix-client-r0-account-3pid),
 minus the `bind` flag, and the contents of `three_pid_creds` have been

--- a/proposals/2290-separate-threepid-bind-hs.md
+++ b/proposals/2290-separate-threepid-bind-hs.md
@@ -155,7 +155,7 @@ send validation requests from.
 Additionally, the [POST
 /account/3pid](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-account-3pid)
 endpoint is deprecated as the two new endpoints replace its functionality.
-The `bind` endpoint will also be removed, with the endpoint functioning as if
+The `bind` parameter will also be removed, with the endpoint functioning as if
 `bind` was `false`. Allowing an endpoint to add a threepid to both the
 identity server and homeserver at the same time requires one to trust the
 other, which is the exact behaviour we're trying to eliminate. Doing this


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-doc/blob/anoa/msc_separate_hs_api/proposals/2290-separate-threepid-bind-hs.md)

~~TODO: Backwards compatibility is still being figured out.~~

Implementation: https://github.com/matrix-org/synapse/pull/6043