### PR TITLE
Clarify that submit_url is without authentication

### DIFF
--- a/api/client-server/administrative_contact.yaml
+++ b/api/client-server/administrative_contact.yaml
@@ -157,9 +157,10 @@ paths:
                     An optional field containing a URL where the client must
                     submit the validation token to, with identical parameters
                     to the Identity Service API's ``POST
-                    /validate/email/submitToken`` endpoint. The homeserver must
-                    send this token to the user (if applicable), who should
-                    then be prompted to provide it to the client.
+                    /validate/email/submitToken`` endpoint (without the requirement
+                    for an access token). The homeserver must send this token to the
+                    user (if applicable), who should then be prompted to provide it
+                    to the client.
 
                     If this field is not present, the client can assume that
                     verification will happen without the client's involvement

--- a/api/client-server/definitions/request_token_response.yaml
+++ b/api/client-server/definitions/request_token_response.yaml
@@ -25,9 +25,9 @@ properties:
     description: |-
       An optional field containing a URL where the client must submit the
       validation token to, with identical parameters to the Identity Service
-      API's ``POST /validate/email/submitToken`` endpoint. The homeserver must
-      send this token to the user (if applicable), who should then be
-      prompted to provide it to the client.
+      API's ``POST /validate/email/submitToken`` endpoint (without the requirement
+      for an access token). The homeserver must send this token to the user (if
+      applicable), who should then be prompted to provide it to the client.
 
       If this field is not present, the client can assume that verification
       will happen without the client's involvement provided the homeserver

--- a/changelogs/client_server/newsfragments/2341.clarification
+++ b/changelogs/client_server/newsfragments/2341.clarification
@@ -1,0 +1,1 @@
+Clarify that the ``submit_url`` field is without authentication.


### PR DESCRIPTION
The request is authorized by its parameters, not by an additional access token.

Fixes https://github.com/matrix-org/matrix-doc/issues/2298