### PR TITLE
Recommend that clients don't preview URLs in encrypted rooms

### DIFF
--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -340,6 +340,14 @@ paths:
   "/preview_url":
     get:
       summary: "Get information about a URL for a client"
+      description: |-
+        Get information about a URL for the client. Typically this is called when a
+        client sees a URL in a message and wants to render a preview for the user.
+
+        .. Note::
+          Clients should consider avoiding this endpoint for URLs posted in encrypted
+          rooms.
+
       operationId: getUrlPreview
       produces: ["application/json"]
       security:

--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -346,7 +346,9 @@ paths:
 
         .. Note::
           Clients should consider avoiding this endpoint for URLs posted in encrypted
-          rooms.
+          rooms. Encrypted rooms often contain more sensitive information the users
+          do not want to share with the homeserver, and this can mean that the URLs
+          being shared should also not be shared with the homeserver.
 
       operationId: getUrlPreview
       produces: ["application/json"]

--- a/changelogs/client_server/newsfragments/2343.clarification
+++ b/changelogs/client_server/newsfragments/2343.clarification
@@ -1,0 +1,1 @@
+Clarify that clients should consider not requesting URL previews in encrypted rooms.


### PR DESCRIPTION
Any stronger of a recommendation would probably require a MSC due to the behaviour change. 

Fixes https://github.com/matrix-org/matrix-doc/issues/2120