### PR TITLE
Add filter query param to /context

### DIFF
--- a/api/client-server/event_context.yaml
+++ b/api/client-server/event_context.yaml
@@ -64,8 +64,10 @@ paths:
           type: string
           description: |-
             A JSON ``RoomEventFilter`` to filter the returned events with. The
-            filter may be applied before or/and after the ``limit`` parameter -
-            whichever the homeserver prefers.
+            filter is only applied to ``events_before``, ``events_after``, and
+            ``state``. It is not applied to the ``event`` itself. The filter may 
+            be applied before or/and after the ``limit`` parameter - whichever the 
+            homeserver prefers.
 
             See `Filtering <#filtering>`_ for more information.
           x-example: "66696p746572"

--- a/api/client-server/event_context.yaml
+++ b/api/client-server/event_context.yaml
@@ -59,6 +59,17 @@ paths:
           description: |-
             The maximum number of events to return. Default: 10.
           x-example: 3
+        - in: query
+          name: filter
+          type: string
+          description: |-
+            The ID of a filter created using the filter API or a filter JSON
+            object encoded as a string. The server will detect whether it is
+            an ID or a JSON object by whether the first character is a ``"{"``
+            open brace.
+
+            See `Filtering <#filtering>`_ for more information.
+          x-example: "66696p746572"
       responses:
         200:
           description: The events and state surrounding the requested event.

--- a/api/client-server/event_context.yaml
+++ b/api/client-server/event_context.yaml
@@ -64,7 +64,7 @@ paths:
           type: string
           description: |-
             A JSON ``RoomEventFilter`` to filter the returned events with. The
-            filter can be applied before or/and after the ``limit`` parameter -
+            filter may be applied before or/and after the ``limit`` parameter -
             whichever the homeserver prefers.
 
             See `Filtering <#filtering>`_ for more information.

--- a/api/client-server/event_context.yaml
+++ b/api/client-server/event_context.yaml
@@ -63,10 +63,9 @@ paths:
           name: filter
           type: string
           description: |-
-            The ID of a filter created using the filter API or a filter JSON
-            object encoded as a string. The server will detect whether it is
-            an ID or a JSON object by whether the first character is a ``"{"``
-            open brace.
+            A JSON ``RoomEventFilter`` to filter the returned events with. The
+            filter can be applied before or/and after the ``limit`` parameter -
+            whichever the homeserver prefers.
 
             See `Filtering <#filtering>`_ for more information.
           x-example: "66696p746572"

--- a/changelogs/client_server/newsfragments/2344.clarification
+++ b/changelogs/client_server/newsfragments/2344.clarification
@@ -1,0 +1,1 @@
+Add missing information on how filters are meant to work with ``/context``.


### PR DESCRIPTION
This was missed as part of lazy-loading.

Fixes https://github.com/matrix-org/matrix-doc/issues/2338