### PR TITLE
Clarify that the room ID is the object key in /sync responses

### DIFF
--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -136,7 +136,8 @@ paths:
                     title: Joined Rooms
                     type: object
                     description: |-
-                      The rooms that the user has joined.
+                      The rooms that the user has joined, mapped as room ID to
+                      room information.
                     additionalProperties:
                       title: Joined Room
                       type: object
@@ -249,7 +250,8 @@ paths:
                     title: Invited Rooms
                     type: object
                     description: |-
-                      The rooms that the user has been invited to.
+                      The rooms that the user has been invited to, mapped as room ID to
+                      room information.
                     additionalProperties:
                       title: Invited Room
                       type: object
@@ -280,7 +282,8 @@ paths:
                     title: Left rooms
                     type: object
                     description: |-
-                      The rooms that the user has left or been banned from.
+                      The rooms that the user has left or been banned from, mapped as room ID to
+                      room information.
                     additionalProperties:
                       title: Left Room
                       type: object

--- a/changelogs/client_server/newsfragments/2345.clarification
+++ b/changelogs/client_server/newsfragments/2345.clarification
@@ -1,0 +1,1 @@
+Clarify what the keys are for rooms in ``/sync``.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2269