### PR TITLE
MSC2376: Disable URL Previews

### DIFF
--- a/proposals/2376-no-url-previews.md
+++ b/proposals/2376-no-url-previews.md
@@ -1,4 +1,6 @@
 # MSC 2376: Disable URL Previews
+This MSC is an alternative suggestion to [MSC2385](https://github.com/matrix-org/matrix-doc/pull/2385).
+
 Currently URLs posted in chat give a URL preview. Sometimes, for example with bots, this can be
 unwanted. For instance if a bot is posting a message with a lot of links, or the content of the link
 is already obvious from the message itself.
@@ -32,7 +34,7 @@ A flag could be set for the entire message to disable URL previews, however that
 having within a message one URL with preview and one without.
 
 Alternatively, a new, optional, key `url_previews` with an array of the URLs to preview for could be
-introduced.
+introduced. See [MSC2385](https://github.com/matrix-org/matrix-doc/pull/2385).
 
 ## Security considerations
 You could get tricked more easily into being Rickroll'd. This can be alleviated by encouraging

--- a/proposals/2376-no-url-previews.md
+++ b/proposals/2376-no-url-previews.md
@@ -1,0 +1,32 @@
+# MSC 2376: Disable URL Previews
+Currently URLs posted in chat give a URL preview. Sometimes, for example with bots, this can be
+unwanted, as the user is already basically aware what the link the bot is posting is following to.
+
+## Proposal
+This proposal is about adding a new attribute to the `formatted_body` of messages with type
+`m.room.member` and msgtype `m.text`.
+
+It adds a new attribute, `data-mx-nopreview` to the `<a>` tag. If this attribute is present the
+client is expected **not** to display a URL preview.
+
+### Example
+```json
+{
+	"msgtype": "m.text",
+	"format": "org.matrix.custom.html",
+	"body": "Hey, look at this awesome MSC!",
+	"formatted_body": "Hey, look at <a data-mx-nopreview src=\"https://github.com/matrix-org/matrix-doc/pull/2379\">this</a> awesome MSC!"
+}
+```
+
+## Potential issues
+HTML tags are usually meant to be for formatting. Disabling URL previews isn't strictly formatting.
+However, as the client will already have parsed the tag in order to generate a URL preview the place
+seems appropriate.
+
+## Alternatives
+A flag could be set for the entire message to disable URL previews, however that doesn't allow for
+having within a message one URL with preview and one without.
+
+## Security considerations
+You could get tricked more easily into being Rickroll'd.

--- a/proposals/2376-no-url-previews.md
+++ b/proposals/2376-no-url-previews.md
@@ -5,7 +5,7 @@ is already obvious from the message itself.
 
 ## Proposal
 This proposal adds a new attribute to the `formatted_body` key of messages with type
-`m.room.member` and msgtype `m.text`.
+`m.room.message` and msgtype `m.text`.
 
 It adds a new attribute, `data-mx-nopreview` to the `<a>` HTML tag. If this attribute is present the
 client SHOULD NOT display a URL preview.
@@ -22,12 +22,16 @@ client SHOULD NOT display a URL preview.
 
 ## Potential issues
 HTML tags are usually meant for formatting. Disabling URL previews isn't strictly formatting.
-However, as the client will already have parsed the tag in order to generate a URL preview the place
-seems appropriate.
+
+Additionally, clients may currently only gather the URL previews only from the `body`, forcing them
+to parse the `formatted_body` as well.
 
 ## Alternatives
 A flag could be set for the entire message to disable URL previews, however that doesn't allow for
 having within a message one URL with preview and one without.
+
+Alternatively, a new, optional, key `url_previews` with an array of the URLs to preview for could be
+introduced.
 
 ## Security considerations
 You could get tricked more easily into being Rickroll'd.

--- a/proposals/2376-no-url-previews.md
+++ b/proposals/2376-no-url-previews.md
@@ -1,26 +1,27 @@
 # MSC 2376: Disable URL Previews
 Currently URLs posted in chat give a URL preview. Sometimes, for example with bots, this can be
-unwanted, as the user is already basically aware what the link the bot is posting is following to.
+unwanted. For instance if a bot is posting a message with a lot of links, or the content of the link
+is already obvious from the message itself.
 
 ## Proposal
-This proposal is about adding a new attribute to the `formatted_body` of messages with type
+This proposal adds a new attribute to the `formatted_body` key of messages with type
 `m.room.member` and msgtype `m.text`.
 
-It adds a new attribute, `data-mx-nopreview` to the `<a>` tag. If this attribute is present the
-client is expected **not** to display a URL preview.
+It adds a new attribute, `data-mx-nopreview` to the `<a>` HTML tag. If this attribute is present the
+client SHOULD NOT display a URL preview.
 
 ### Example
 ```json
 {
 	"msgtype": "m.text",
 	"format": "org.matrix.custom.html",
-	"body": "Hey, look at this awesome MSC!",
-	"formatted_body": "Hey, look at <a data-mx-nopreview src=\"https://github.com/matrix-org/matrix-doc/pull/2379\">this</a> awesome MSC!"
+	"body": "Hey, look at what I did! MSC2376: Disable URL Previews",
+	"formatted_body": "Hey, look at what I did! <a data-mx-nopreview src=\"https://github.com/matrix-org/matrix-doc/pull/2379\">MSC2376: Disable URL Previews</a>"
 }
 ```
 
 ## Potential issues
-HTML tags are usually meant to be for formatting. Disabling URL previews isn't strictly formatting.
+HTML tags are usually meant for formatting. Disabling URL previews isn't strictly formatting.
 However, as the client will already have parsed the tag in order to generate a URL preview the place
 seems appropriate.
 

--- a/proposals/2376-no-url-previews.md
+++ b/proposals/2376-no-url-previews.md
@@ -35,4 +35,6 @@ Alternatively, a new, optional, key `url_previews` with an array of the URLs to 
 introduced.
 
 ## Security considerations
-You could get tricked more easily into being Rickroll'd.
+You could get tricked more easily into being Rickroll'd. This can be alleviated by encouraging
+clients to request previews explicitly (either by hovering or by clicking a special button next to
+the link).

--- a/proposals/2376-no-url-previews.md
+++ b/proposals/2376-no-url-previews.md
@@ -7,8 +7,9 @@ is already obvious from the message itself.
 This proposal adds a new attribute to the `formatted_body` key of messages with type
 `m.room.message` and msgtype `m.text`.
 
-It adds a new attribute, `data-mx-nopreview` to the `<a>` HTML tag. If this attribute is present the
-client SHOULD NOT display a URL preview.
+It adds a new attribute, `data-mx-nopreview` to the `<a>` HTML tag. The presence of the attribute
+can be used as a hint by clients to indicate that a URL preview for the link is not necessary, and
+clients may skip the link when displaying previews.
 
 ### Example
 ```json
@@ -16,7 +17,7 @@ client SHOULD NOT display a URL preview.
 	"msgtype": "m.text",
 	"format": "org.matrix.custom.html",
 	"body": "Hey, look at what I did! MSC2376: Disable URL Previews",
-	"formatted_body": "Hey, look at what I did! <a data-mx-nopreview src=\"https://github.com/matrix-org/matrix-doc/pull/2379\">MSC2376: Disable URL Previews</a>"
+	"formatted_body": "Hey, look at what I did! <a data-mx-nopreview src=\"https://github.com/matrix-org/matrix-doc/pull/2376\">MSC2376: Disable URL Previews</a>"
 }
 ```
 


### PR DESCRIPTION
[Rendered](https://github.com/Sorunome/matrix-doc/blob/soru/no-url-previews/proposals/2376-no-url-previews.md)

This MSC provides an alternative method to [MSC2385](https://github.com/matrix-org/matrix-doc/pull/2385)

Signed-off-by: Sorunome <mail@sorunome.de>