### PR TITLE
Clarify description of user directory

### DIFF
--- a/api/client-server/users.yaml
+++ b/api/client-server/users.yaml
@@ -31,7 +31,7 @@ paths:
     post:
       summary: Searches the user directory.
       description: |-
-        Performs a search for users on the homeserver. The homeserver may
+        Performs a search for users. The homeserver may
         determine which subset of users are searched, however the homeserver
         MUST at a minimum consider the users the requesting user shares a
         room with and those who reside in public rooms (known to the homeserver).

--- a/changelogs/client_server/newsfragments/2381.clarification
+++ b/changelogs/client_server/newsfragments/2381.clarification
@@ -1,0 +1,1 @@
+Minor clarification for what the user directory searches.


### PR DESCRIPTION
The leading sentence here seems a little contradictory with the suggestion later in the paragraph that the homeserver SHOULD consider remote users.

Signed off by Stuart Mumford <stuart@cadair.com>