### PR TITLE
Change state_type to event_type

### DIFF
--- a/specification/rooms/v1.rst
+++ b/specification/rooms/v1.rst
@@ -94,7 +94,7 @@ results of the resolution so far.
   passes authentication in :math:`R` and add it to :math:`R`.
 
 A *conflict* occurs between states where those states have different
-``event_ids`` for the same ``(state_type, state_key)``. The events thus
+``event_ids`` for the same ``(event_type, state_key)``. The events thus
 affected are said to be *conflicting* events.
 
 


### PR DESCRIPTION
I couldn't find any other reference to a state_type within the entire specification. I assume this is supposed to be the event_type? This aligns with the description of changes resulting from a state update.

Signed-off-by: Carolin Beer  mail[at]carolin[dot]beer