### PR TITLE
Add missing tags to push rules endpoints

### DIFF
--- a/api/client-server/pushrules.yaml
+++ b/api/client-server/pushrules.yaml
@@ -498,6 +498,8 @@ paths:
                 type: boolean
                 description: Whether the push rule is enabled or not.
             required: ["enabled"]
+      tags:
+        - Push notifications
     put:
       summary: "Enable or disable a push rule."
       description: |-
@@ -601,6 +603,8 @@ paths:
                 items:
                   type: string
             required: ["actions"]
+      tags:
+        - Push notifications
     put:
       summary: "Set the actions for a push rule."
       description: |-


### PR DESCRIPTION
Without the tags, the endpoints don't end up in the swagger. No changelog for this because it doesn't affect the spec itself.

ref: https://matrix.to/#/!jxlRxnrZCsjpjDubDX:matrix.org/$zGvwcC4-LjWUb51PAEja0_2lGf5dIZJKp0xjdlBATgk?via=matrix.org&via=feneas.org&via=t2l.io