### PR TITLE
1929-admin-contact: correct json in response format

### DIFF
--- a/proposals/1929-admin-contact.md
+++ b/proposals/1929-admin-contact.md
@@ -14,16 +14,16 @@ The response format should be:
 
 ```javascript
 {
-    admins: [{
-        matrix_id: "@admin:domain.tld",
-        email_address: "admin@domain.tld",
-        role: "admin" # If omitted, the default will be "admin"
+    "admins": [{
+        "matrix_id": "@admin:domain.tld",
+        "email_address": "admin@domain.tld",
+        "role": "admin" # If omitted, the default will be "admin"
     },
     {
-        email_address: "security@domain.tld",
-        role: "security"
+        "email_address": "security@domain.tld",
+        "role": "security"
     }],
-    support_page: "https://domain.tld/support.html"
+    "support_page": "https://domain.tld/support.html"
 }
 ```
 


### PR DESCRIPTION
There are missing quotation marks around the keys to make the response format valid json.