### PR TITLE
Fix key export format example

### DIFF
--- a/changelogs/client_server/newsfragments/2430.clarification
+++ b/changelogs/client_server/newsfragments/2430.clarification
@@ -1,0 +1,1 @@
+Fix key export format example to match the specification.

--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -844,24 +844,22 @@ Example:
 
 .. code:: json
 
-    {
-        "sessions": [
-            {
-                "algorithm": "m.megolm.v1.aes-sha2",
-                "forwarding_curve25519_key_chain": [
-                    "hPQNcabIABgGnx3/ACv/jmMmiQHoeFfuLB17tzWp6Hw"
-                ],
-                "room_id": "!Cuyf34gef24t:localhost",
-                "sender_key": "RF3s+E7RkTQTGF2d8Deol0FkQvgII2aJDf3/Jp5mxVU",
-                "sender_claimed_keys": {
-                    "ed25519": "<device ed25519 identity key>",
-                },
-                "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ",
-                "session_key": "AgAAAADxKHa9uFxcXzwYoNueL5Xqi69IkD4sni8Llf..."
+    [
+        {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "forwarding_curve25519_key_chain": [
+                "hPQNcabIABgGnx3/ACv/jmMmiQHoeFfuLB17tzWp6Hw"
+            ],
+            "room_id": "!Cuyf34gef24t:localhost",
+            "sender_key": "RF3s+E7RkTQTGF2d8Deol0FkQvgII2aJDf3/Jp5mxVU",
+            "sender_claimed_keys": {
+                "ed25519": "<device ed25519 identity key>",
             },
-            ...
-        ]
-    }
+            "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ",
+            "session_key": "AgAAAADxKHa9uFxcXzwYoNueL5Xqi69IkD4sni8Llf..."
+        },
+        ...
+    ]
 
 Messaging Algorithms
 --------------------


### PR DESCRIPTION
Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

Some "errors" were fixed in the spec in #1939 to let the format match, what riot uses to export session keys. Sadly the example was forgotten to be fixed and having the wrong example could make it easy to misunderstand the spec at that location. I actually introduced a bug in nheko, that broke key import, through a bad copy and paste when refactoring. Took me a while to figure out, why I couldn't import session keys from riot anymore, since the parser matched the example in the spec... Well, this should prevent that from happening again!