### PR TITLE
MSC2444: peeking over federation via /peek

### DIFF
--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -222,7 +222,9 @@ world-readable.
  * simply use `room_id` for idempotency rather than requiring a separate
    `peek_id`. One reason not to do this is to allow a future extension where
    there are multiple subscriptions active, each filtering out different event
-   types. In the meantime, implementers can use a hard-coded constant.
+   types. Another reason that `peek_id` is useful is to improve idempotency
+   with rapid peek/unpeek/peek cycles, to ensure we aren't `DELETE`ing the
+   wrong peek.
 
  * An earlier rejected solution is
    [MSC1777](https://github.com/matrix-org/matrix-doc/pull/1777), which

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -224,6 +224,17 @@ world-readable.
    there are multiple subscriptions active, each filtering out different event
    types. In the meantime, implementers can use a hard-coded constant.
 
+## Future extensions
+
+These features are explicitly descoped for the purposes of this MSC.
+
+ * It may be useful to allow peeking servers to "filter" the events to be
+   returned - for example, if you only care about particular events, or
+   particular servers - e.g. if load-balancing peeking via multiple servers.
+
+   It's worth noting that this would make it very hard for peeking servers to
+   reliably track state changes and detect missing events.
+
 ## Security considerations
 
  * A malicious server could set up multiple peeks to multiple target servers by
@@ -246,12 +257,7 @@ world-readable.
 
 This doesn't solve the problem that rooms wink out of existence when all
 participants leave (https://github.com/matrix-org/matrix-doc/issues/534),
-unlike other approaches to peeking (e.g. MSC1777)
-
-Do we allow filtering the peek? (e.g. if you only care about particular
-events, or particular servers - e.g. if load-balancing peeking via multiple
-servers). Similarly, is it concerning that this significantly overlaps with
-the /sync CS API?
+unlike other approaches to peeking (e.g. MSC1777).
 
 How do we handle backpressure or rate limiting on the event stream (if at
 all?)

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -199,7 +199,21 @@ tuple, the target server returns a 404 error with `M_NOT_FOUND`.
 The target server should expire any peek which is not renewed before the
 `renewal_interval` elapses.
 
-XXX how to tell the peeking server?
+It should indicate the expiry to the peeking server via `PUT
+/_matrix/federation/v1/send/`, via a new `expired_peeks` key:
+
+```
+PUT /_matrix/federation/v1/send/S0meTransacti0nId HTTP/1.1
+
+{
+  "expired_peeks": [
+    {
+      "room_id": "{roomId}",
+      "peek_id": "{peekId}"
+    }
+  ]
+}
+```
 
 ### Joining a room
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -75,6 +75,14 @@ We require `/peek`s to be regularly renewed even if the server has been acceptin
 peeked events, as the fact a server happens to accept peeked events doesn't
 mean that it was necessarily deliberately peeking.
 
+Finally, the response also includes a `latest_event_id` field which provides
+the most recent event (as ordered by stream id) at the point of the `/peek`.
+This is the same event_id that you would pass to `/state` to get the same
+response as this `/peek`.
+
+If the peek is renewed without having lapsed, `PUT /peek` simply returns `{}`
+on success.
+
 PUT returns 403 if the user does not have permission to peek into the room,
 and 404 if the room ID or peek ID is not known to the peeked server.
 If the server implementation doesn't wish to honour the peek request due to
@@ -109,7 +117,8 @@ PUT /_matrix/federation/v1/peek/{roomId}/{peekId}?ver=5&ver=6
         }
       }
     ],
-    "renewal_interval": 3600000
+    "renewal_interval": 3600000,
+    "latest_event_id": "$6omAdDmGphrSAE_zH5RhMPAJzUQWAYEYPwr6wnl4ptz"
 }
 ```
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -224,6 +224,35 @@ world-readable.
    there are multiple subscriptions active, each filtering out different event
    types. In the meantime, implementers can use a hard-coded constant.
 
+ * An earlier rejected solution is
+   [MSC1777](https://github.com/matrix-org/matrix-doc/pull/1777), which
+   proposed joining a pseudouser (`@:server`) to a room in order to peek into
+   it. However:
+
+   * being forced to write to a room DAG (by joining such a user) in order to
+     perform a read-only operation (peeking) is somewhat inefficient.
+
+   * it also constitutes a privacy violation - tantamount to a tracking
+     pixel. If I'm on a smallish server and I happen to briefly peek into
+     `#nsfw:matrix.org`, I don't want every random server in that room to know
+     that I did so. It's even worse than sending read-receipts.
+
+   * In the interests of empowering the user, it's actually quite nice to
+     (theoretically at least) have some control over which servers you trust to
+     peek via.
+
+    * That said, a P2P world is going to need a totally different approach,
+      which might be back towards MSC1777 but using
+      [MSC1228](https://github.com/matrix-org/matrix-doc/pull/1228)-style IDs
+      to protect privacy. We need to solve scalability of "which nodes are
+      participating in the room" irrespectively of whether those nodes are
+      active or passive. So it's worth noting this solution (MSC2444) is very
+      much for today's federated architecture.
+
+    * MSC1777 offers a solution for EDU transmission which this MSC does not,
+      given we don't currently have any data flows for mirroring other servers'
+      EDUs.
+
 ## Future extensions
 
 These features are explicitly descoped for the purposes of this MSC.
@@ -264,18 +293,14 @@ all?)
 
 ## Dependencies
 
-This unblocks MSC1769 (profiles as rooms) and MSC1772 (groups as rooms)
-and is required for MSC2753 (peeking via /sync) to be of any use.
+This unblocks [MSC1769](https://github.com/matrix-org/matrix-doc/pull/1769)
+(profiles as rooms) and
+[MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772) (Matrix Spaces),
+and is required for
+[MSC2753](https://github.com/matrix-org/matrix-doc/pull/2753) (peeking via
+/sync) to be of any use.
 
-## History
-
-This would close https://github.com/matrix-org/matrix-doc/issues/913
-
-An earlier rejected solution is MSC1777, which proposed joining a pseudouser
-(`@:server`) to a room in order to peek into it.  However, being forced to write
-to a room DAG (by joining such a user) in order to perform a read-only operation
-(peeking) was deemed inefficient and rejected.
-
+This would close https://github.com/matrix-org/matrix-doc/issues/913.
 
 ## Footnotes
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -26,8 +26,9 @@ We do this by subscribing to a room on one or more servers via a new `/peek`
 S2S API, which lets users on a given server declare their interest in viewing
 events in that room.  Having started peeking into the room, the server(s)
 being peeked will relay *all* events it sees in that room to the peeking
-server (including ones from other servers).  It will also service the backfill
-and event-retrieval APIs as if the peeking server was in the room.
+server (including ones from other servers).  Backfill
+and event-retrieval APIs should be changed to be queryable from servers not
+in the room if the room is peekable.
 
 This continues until the peeking server calls DELETE on the peek it initiated.
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -1,0 +1,104 @@
+# Proposal for implementing peeking over federation (peek API)
+
+## Problem
+
+Currently you can't peek over federation, as it was never designed or
+implemented due to time constraints when peeking was originally added to Matrix
+in 2016.
+
+As well as stopping users from previewing rooms before joining, the fact that
+servers can't participate in remote rooms without joining them first is
+inconvenient in many other ways:
+
+ * You can't reliably participate in E2E encryption in rooms you're invited to
+   unless the server is actually participating in the room
+   (https://github.com/vector-im/riot-web/issues/2713)
+ * You can't use rooms as generic pubsub mechanisms for synchronising data like
+   profiles, groups, device-lists etc if you can't peek into them remotely.
+ * Search engines can't work if they can't peek remote rooms.
+
+## Solution
+
+We let servers participate in peekable rooms (i.e. those with `world_readable`
+`m.room.history_visibility`) without having actually joined them.
+
+We do this by subscribing to a room on one or more servers via a new `/peek`
+S2S API, which lets users on a given server declare their interest in viewing
+events in that room.  Having started peeking into the room, the server(s)
+being peeked will relay *all* events it sees in that room to the peeking
+server (including ones from other servers).  It will also service the backfill
+and event-retrieval APIs as if the peeking server was in the room.
+
+This continues until the peeking server calls DELETE on the peek it initiated.
+
+To start peeking, firstly the peeking server must pick server(s) to peek via.
+This is typically the same server you would use to try to join the room via
+(i.e. one taken from the alias, or the via param on a matrix.to URL). The
+server could also call S2S /state on m.room.members to find other servers
+participating in the room and try to peek them from too.
+
+The peeking server starts to peek by PUTting to `/peek` on the peeked server.
+The request takes an empty object as a body as a placeholder for future (where
+we might put filters). The peeking server selects an ID for the peeking
+subscription for the purposes of idempotency. The ID must be 8 or less bytes
+of ASCII and should be unique for a given peeking & peeked server.
+
+```
+PUT /_matrix/federation/v1/peek/{roomId}/{peekId}
+{}
+
+{
+    "peek_id": "12345",
+}
+```
+
+```
+DELETE /_matrix/federation/v1/peek/{roomId}/{peekId}
+{}
+```
+
+If the peeking server hasn't heard any events from the peeked server for a
+while, it should attempt to re-PUT the /peek. If the peeked server is
+unavailable, it should retry via other servers from the room's members until
+it can reestablish.
+
+## Security considerations
+
+The peeked server becomes a centralisation point which could conspire against
+the peeking server to withhold events.  This is not that dissimilar to trying
+to join a room via a malicious server, however, and can be mitigated somewhat
+if the peeking server tries to query missing events from other servers.
+The peeking server could also peek to multiple servers for resilience against
+this sort of attack.
+
+The peeked server will be able to track the metadata surrounding which servers
+are peeking into which of its rooms, and when.  This could be particularly
+sensitive for single-person servers peeking at profile rooms.
+
+## Design considerations
+
+This doesn't solve the problem that rooms wink out of existence when all
+participants leave (https://github.com/matrix-org/matrix-doc/issues/534),
+unlike other approaches to peeking (e.g. MSC1777)
+
+Do we allow filtering the peek? (e.g. if you only care about particular
+events, or particular servers - e.g. if load-balancing peeking via multiple
+servers). Similarly, is it concerning that this significantly overlaps with
+the /sync CS API?
+
+How do we handle backpressure or rate limiting on the event stream (if at
+all?)
+
+## Dependencies
+
+This unblocks MSC1769 (profiles as rooms) and MSC1772 (groups as rooms)
+and is required for MSC1776 (peeking via /sync) to be of any use.
+
+## History
+
+This would close https://github.com/matrix-org/matrix-doc/issues/913
+
+An earlier rejected solution is MSC1777, which proposed joining a pseudouser
+(`@:server`) to a room in order to peek into it.  However, being forced to write
+to a room DAG (by joining such a user) in order to perform a read-only operation
+(peeking) was deemed inefficient and rejected.

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -47,7 +47,7 @@ of ASCII and should be unique for a given peeking & peeked server.
 PUT and DELETE return 200 OK with an empty `{}` on success.
 
 ```
-PUT /_matrix/federation/v1/peek/{roomId}/{peekId}
+PUT /_matrix/federation/v2/peek/{roomId}/{peekId}
 {}
 
 200 OK

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -8,14 +8,19 @@ in 2016.
 
 As well as stopping users from previewing rooms before joining, the fact that
 servers can't participate in remote rooms without joining them first is
-inconvenient in many other ways:
+inconvenient in other ways:
 
- * You can't reliably participate in E2E encryption in rooms you're invited to
-   unless the server is actually participating in the room
-   (https://github.com/vector-im/riot-web/issues/2713)
  * You can't use rooms as generic pubsub mechanisms for synchronising data like
-   profiles, groups, device-lists etc if you can't peek into them remotely.
+   profiles, groups, reputation lists, device-lists etc if you can't peek into
+   them remotely.
  * Matrix-speaking search engines can't work if they can't peek remote rooms.
+
+A related problem (not solved by this MSC) is that servers can't participate
+in E2E encryption before joining a room, given the other users in the
+room do not know to encrypt for the peeking device.  This also impacts invited
+users (https://github.com/vector-im/riot-web/issues/2713), given the invited
+server doesn't currently tell the inviter about devicelist changes unless
+the inviter is joined.
 
 ## Solution
 
@@ -119,6 +124,12 @@ When the user joins the peeked room, the server should just emit the right
 membership event rather than calling /make_join or /send_join, to avoid the
 unnecessary burden of a full room join, given the server is already participating
 in the room.
+
+It is considered a feature that you cannot peek into encrypted rooms, given
+the act of peeking would leak the identity of the peeker to the joined users
+in the room (as they'd need to encrypt for the peeker).  This also feels
+acceptable given there is little point in encrypting something intended to be
+world-readable.
 
 ## Security considerations
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -241,17 +241,16 @@ world-readable.
      (theoretically at least) have some control over which servers you trust to
      peek via.
 
-    * That said, a P2P world is going to need a totally different approach,
-      which might be back towards MSC1777 but using
-      [MSC1228](https://github.com/matrix-org/matrix-doc/pull/1228)-style IDs
-      to protect privacy. We need to solve scalability of "which nodes are
-      participating in the room" irrespectively of whether those nodes are
-      active or passive. So it's worth noting this solution (MSC2444) is very
-      much for today's federated architecture.
+   * That said, a P2P world is going to need a totally different approach,
+     which might be back towards MSC1777 but using
+     [MSC1228](https://github.com/matrix-org/matrix-doc/pull/1228)-style IDs to
+     protect privacy. We need to solve scalability of "which nodes are
+     participating in the room" irrespectively of whether those nodes are
+     active or passive. So it's worth noting this solution (MSC2444) is very
+     much for today's federated architecture.
 
-    * MSC1777 offers a solution for EDU transmission which this MSC does not,
-      given we don't currently have any data flows for mirroring other servers'
-      EDUs.
+   * MSC1777 offers a solution for EDU transmission which this MSC does not,
+     given we don't currently have any data flows for mirroring other servers' EDUs.
 
 ## Future extensions
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -46,7 +46,8 @@ The request takes an empty object as a body as a placeholder for future (where
 we might put filters). The peeking server selects an ID for the peeking
 subscription for the purposes of idempotency. The ID must be 8 or less bytes
 of ASCII and should be unique for a given `{ origin_server, room_id, target_server }`
-tuple.
+tuple. The request takes `?ver=` querystring parameters with the same behaviour
+as `/make_join` to advertise the room versions the peeking server supports.
 
 We don't just use the `room_id` for idempotency because we may want to add
 filtering in future to the /peek invocation, and this lets us distinguish
@@ -68,13 +69,15 @@ mean that it was necessarily deliberately peeking.
 PUT returns 403 if the user does not have permission to peek into the room,
 and 404 if the room ID or peek ID is not known to the peeked server.
 If the server implementation doesn't wish to honour the peek request due to
-server load, it may respond with 429.
+server load, it may respond with 429.  If the room version of the room being
+peeked isn't supported by the peeking server, it responds with 400 and
+`M_INCOMPATIBLE_ROOM_VERSION`.
 
 DELETE return 200 OK with an empty `{}` on success, and 404 if the room ID or peek ID is
 not known to the peeked server.
 
 ```
-PUT /_matrix/federation/v2/peek/{roomId}/{peekId}
+PUT /_matrix/federation/v1/peek/{roomId}/{peekId}?ver=5&ver=6
 {}
 
 200 OK

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -16,11 +16,15 @@ inconvenient in other ways:
  * Matrix-speaking search engines can't work if they can't peek remote rooms.
 
 A related problem (not solved by this MSC) is that servers can't participate
-in E2E encryption before joining a room, given the other users in the
-room do not know to encrypt for the peeking device.  This also impacts invited
-users (https://github.com/vector-im/riot-web/issues/2713), given the invited
-server doesn't currently tell the inviter about devicelist changes unless
-the inviter is joined.
+in E2E encryption when peeking into a room, given the other users in the
+room do not know to encrypt for the peeking device.
+
+Another related problem (not solved by this MSC) is that invited users can't
+reliably participate in E2E encryption before joining a room, given the invited
+server doesn't currently have a way to know about new users/devices in the room
+without peeking, and so doesn't tell them if the invited user's devices changes.
+(https://github.com/vector-im/element-web/issues/2713#issuecomment-691480736
+outlines a fix to this, not covered by this MSC).
 
 ## Solution
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -75,11 +75,12 @@ We require `/peek`s to be regularly renewed even if the server has been acceptin
 peeked events, as the fact a server happens to accept peeked events doesn't
 mean that it was necessarily deliberately peeking.
 
-Finally, the response also includes a `latest_event_id` field which provides
+Finally, the response also includes a `latest_event` field which provides
 the most recent event (as ordered by stream id) at the point of the `/peek`.
-This is the same event_id that you would pass to `/state` to get the same
+This is the event whose id you would pass to `/state` to get the same
 response as this `/peek`, and identifies the precise point in time that the
-given state refers to.
+given state refers to.  We return a full event rather than an eventid to
+avoid an unnecessary roundtrip.
 
 If the peek is renewed without having lapsed, `PUT /peek` simply returns `{}`
 on success.
@@ -119,7 +120,14 @@ PUT /_matrix/federation/v1/peek/{roomId}/{peekId}?ver=5&ver=6
       }
     ],
     "renewal_interval": 3600000,
-    "latest_event_id": "$6omAdDmGphrSAE_zH5RhMPAJzUQWAYEYPwr6wnl4ptz"
+    "latest_event": {
+        "type": "m.room.minimal_pdu",
+        "room_id": "!somewhere:example.org",
+        "content": {
+          "see_room_version_spec": "The event format changes depending on the room version."
+        }
+      }
+    }
 }
 ```
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -143,7 +143,7 @@ all?)
 ## Dependencies
 
 This unblocks MSC1769 (profiles as rooms) and MSC1772 (groups as rooms)
-and is required for MSC1776 (peeking via /sync) to be of any use.
+and is required for MSC2753 (peeking via /sync) to be of any use.
 
 ## History
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -250,7 +250,15 @@ world-readable.
      much for today's federated architecture.
 
    * MSC1777 offers a solution for EDU transmission which this MSC does not,
-     given we don't currently have any data flows for mirroring other servers' EDUs.
+     given we don't currently have any data flows for mirroring other servers'
+     EDUs.
+
+ * Rather than attempting to maintain a local replica of peeked traffic, have
+   the peeking server proxy any peek requests from the client-server API onto
+   the target server, somehow.  This couples room availability to the peeked
+   server and means we don't have a local replica we can index or serve
+   independently etc - and also means you could have problems deduplicating
+   peeks between local clients.
 
 ## Future extensions
 

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -78,7 +78,8 @@ mean that it was necessarily deliberately peeking.
 Finally, the response also includes a `latest_event_id` field which provides
 the most recent event (as ordered by stream id) at the point of the `/peek`.
 This is the same event_id that you would pass to `/state` to get the same
-response as this `/peek`.
+response as this `/peek`, and identifies the precise point in time that the
+given state refers to.
 
 If the peek is renewed without having lapsed, `PUT /peek` simply returns `{}`
 on success.

--- a/proposals/2444-peeking-over-federation-peek-api.md
+++ b/proposals/2444-peeking-over-federation-peek-api.md
@@ -43,17 +43,21 @@ we might put filters). The peeking server selects an ID for the peeking
 subscription for the purposes of idempotency. The ID must be 8 or less bytes
 of ASCII and should be unique for a given peeking & peeked server.
 
+PUT and DELETE return 200 OK with an empty `{}` on success.
+
 ```
 PUT /_matrix/federation/v1/peek/{roomId}/{peekId}
 {}
 
-{
-    "peek_id": "12345",
-}
+200 OK
+{}
 ```
 
 ```
 DELETE /_matrix/federation/v1/peek/{roomId}/{peekId}
+{}
+
+200 OK
 {}
 ```
 


### PR DESCRIPTION
A new MSC for proposing how peeking over federation could work, hopefully replacing #1777  
This one introduces the idea of a `/peek` API in S2S which lets a peeking server subscribe to events from given server(s) so it can have a read-only peek view of peekable rooms.  This is based on the review of #1777 in Oct 2019.

[Rendered](https://github.com/matrix-org/matrix-doc/blob/matthew/msc2444/proposals/2444-peeking-over-federation-peek-api.md)

Obsoletes #1777