### PR TITLE
MSC2451: Remove `query_auth` federation endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.swp
 _rendered.rst
 /.vscode/
+/.idea/

--- a/proposals/2451-remove-query_auth-federation-endpoint.md
+++ b/proposals/2451-remove-query_auth-federation-endpoint.md
@@ -1,4 +1,4 @@
-# MSCxxxx: Remove the `query_auth` federation endpoint
+# MSC2451: Remove the `query_auth` federation endpoint
 
 The `query_auth` federation endpoint is unused by Synapse and should be removed.
 The current implementation in Synapse is not robust and will return a 500 error

--- a/proposals/2451-remove-query_auth-federation-endpoint.md
+++ b/proposals/2451-remove-query_auth-federation-endpoint.md
@@ -1,8 +1,19 @@
 # MSC2451: Remove the `query_auth` federation endpoint
 
-The `query_auth` federation endpoint is unused by Synapse and should be removed.
-The current implementation in Synapse is not robust and will return a 500 error
-in some situations.
+This API was added without sufficient thought nor testing. The endpoint isn't
+used in any known implementations, and we do not believe it to be necessary
+for federation to work. The only known implementation (in Synapse) was not fully
+fleshed out and is broken.
+
+For background, the idea behind this endpoint was that two homeservers would be
+able to share state events with the hope of filling in missing state from one
+of homeservers allowing state resolution to complete. This was to protect
+against a joining server not providing the full (or providing stale) state.
+
+In addition to the ideas above not coming to fruition, it is unclear whether the
+current design of this endpoint would be sufficient. If this state negotiation
+feature is needed in the future it should be redesigned from scratch via the MSC
+proposal process.
 
 ## Proposal
 
@@ -17,7 +28,8 @@ this endpoint should have minimal impact as it was an unused error path in
 Synapse. The federation client code to call this endpoint was removed in Synapse
 v1.5.0rc1.
 
-Note that dendrite has never implemented this federation endpoint.
+There is no evidence of other homeserver implementations having implemented this
+endpoint.
 
 ### History
 

--- a/proposals/2451-remove-query_auth-federation-endpoint.md
+++ b/proposals/2451-remove-query_auth-federation-endpoint.md
@@ -37,7 +37,7 @@ error condition is never assigned).
 
 ## Alternatives
 
-The endpoint could be deprecated in removed in a future version of the specification.
+The endpoint could be deprecated and removed in a future version of the specification.
 
 ## Security considerations
 

--- a/proposals/xxxx-remove-query_auth-federation-endpoint.md
+++ b/proposals/xxxx-remove-query_auth-federation-endpoint.md
@@ -1,0 +1,31 @@
+# MSCxxxx: Remove the `query_auth` federation endpoint
+
+The `query_auth` federation endpoint is unused by Synapse and should be removed.
+The current implementation in Synapse is broken and will return a 500 error in
+some situations.
+
+## Proposal
+
+Remove:
+
+* [POST `/_matrix/federation/v1/query_auth/{roomId}/{eventId}`](https://matrix.org/docs/spec/server_server/r0.1.3#post-matrix-federation-v1-query-auth-roomid-eventid)
+
+## Potential issues
+
+Removing this endpoint impacts backwards compatibility.
+
+In practice, removing this endpoint should have minimal impact. Since 1.5.0rc1
+of Synapse this endpoint is not called (see [#6214](https://github.com/matrix-org/synapse/pull/6214)).
+During removal it was noted that the code to call this endpoint was already
+unreachable.
+
+Note that it seems like this was initially supported in Synapse v0.7.0. It is
+not clear at what point it became unused.
+
+## Alternatives
+
+The endpoint could be deprecated in removed in a future version of the specification.
+
+## Security considerations
+
+None.

--- a/proposals/xxxx-remove-query_auth-federation-endpoint.md
+++ b/proposals/xxxx-remove-query_auth-federation-endpoint.md
@@ -1,26 +1,39 @@
 # MSCxxxx: Remove the `query_auth` federation endpoint
 
 The `query_auth` federation endpoint is unused by Synapse and should be removed.
-The current implementation in Synapse is broken and will return a 500 error in
-some situations.
+The current implementation in Synapse is not robust and will return a 500 error
+in some situations.
 
 ## Proposal
 
-Remove:
+Remove the following endpoint:
 
 * [POST `/_matrix/federation/v1/query_auth/{roomId}/{eventId}`](https://matrix.org/docs/spec/server_server/r0.1.3#post-matrix-federation-v1-query-auth-roomid-eventid)
 
 ## Potential issues
 
-Removing this endpoint impacts backwards compatibility.
+Removing this endpoint impacts backwards compatibility, in practice removing
+this endpoint should have minimal impact as it was an unused error path in
+Synapse. The federation client code to call this endpoint was removed in Synapse
+v1.5.0rc1.
 
-In practice, removing this endpoint should have minimal impact. Since 1.5.0rc1
-of Synapse this endpoint is not called (see [#6214](https://github.com/matrix-org/synapse/pull/6214)).
+Note that dendrite has never implemented this federation endpoint.
+
+### History
+
+This endpoint (and the federation client code) to call it was initially
+added in Synapse v0.7.0 (see [#43](https://github.com/matrix-org/synapse/pull/43)).
+The federation client code was heavily modified for v1.0.0rc1 (see
+[#5227](https://github.com/matrix-org/synapse/pull/5227/)),
+
+The federation client code to call this endpoint was removed in v1.5.0rc1 of
+Synapse (see [#6214](https://github.com/matrix-org/synapse/pull/6214). After
+that point this endpoint is not called).
+
 During removal it was noted that the code to call this endpoint was already
-unreachable.
-
-Note that it seems like this was initially supported in Synapse v0.7.0. It is
-not clear at what point it became unused.
+unreachable. It seems that this code was never reachable and was meant for an
+error situation which was never built out (see `git log -S NOT_ANCESTOR`, the
+error condition is never assigned).
 
 ## Alternatives
 


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-doc/blob/clokep/remove-old-fed-endpoint/proposals/2451-remove-query_auth-federation-endpoint.md).

This is the first MSC I've put up, so let me know if I've done anything very wrong!