### PR TITLE
clarify first run of iterative auth checks

### DIFF
--- a/specification/rooms/v2.rst
+++ b/specification/rooms/v2.rst
@@ -148,8 +148,8 @@ The *resolution* of a set of states is obtained as follows:
 1. Take all *power events* and any events in their auth chains, recursively,
    that appear in the *full conflicted set* and order them by the *reverse
    topological power ordering*.
-2. Apply the *iterative auth checks algorithm* on the *unconflicted state map*
-   and the list of events from the previous step to get a partially resolved
+2. Apply the *iterative auth checks algorithm*, starting from the *unconflicted state map*,
+   to the list of events from the previous step to get a partially resolved
    state.
 3. Take all remaining events that weren't picked in step 1 and order them by
    the mainline ordering based on the power level in the partially resolved


### PR DESCRIPTION
The current wording of the spec sounds like the iterative auth check should be applied to the unconflicted state map, which has issues since 1. the unconflicted state map is unordered, so applying the iterative auth checks map reject different events depending on what order the events are given to it, and 2. the iterative auth checks might reject some events, which is not the intention.

This new wording hopefully makes it clearer that you start with the unconflicted state set, and then you apply the iterative auth checks to the events from the previous step.

From https://github.com/matrix-org/gomatrixserverlib/pull/153#discussion_r387140188:

> The MSC said:
>
>>  Apply the iterative auth checks algorithm based on the unconflicted state map to get a partial set of resolved state.
>
> so the spec probably meant to say:
>
>>  Apply the iterative auth checks algorithm, based on the unconflicted state map, to the list of events from the previous step...
>
> I just checked what synapse does, and it just copies the unconflicted state.
>
> I'll make a PR to fix it in the spec.
>
> (It shouldn't make a difference in the end result, but it should be faster to not do the sorting and auth checks on the unconflicted state.)