### PR TITLE
fix pagination in proposals scraper

### DIFF
--- a/scripts/proposals.py
+++ b/scripts/proposals.py
@@ -38,7 +38,7 @@ def getpage(url):
     pagecount = 1
     for link in resp.links.values():
         if link['rel'] == 'last':
-            pagecount = int(re.search('page=(.+?)', link['url']).group(1))
+            pagecount = int(re.search('page=(.+)', link['url']).group(1))
 
     val = resp.json()
     if not isinstance(val, list):

--- a/scripts/proposals.py
+++ b/scripts/proposals.py
@@ -38,7 +38,10 @@ def getpage(url):
     pagecount = 1
     for link in resp.links.values():
         if link['rel'] == 'last':
-            pagecount = int(re.search('page=(.+)', link['url']).group(1))
+            # we extract the pagecount from the `page` param of the last url
+            # in the response, eg
+            # 'https://api.github.com/repositories/24998719/issues?state=all&labels=proposal&page=10'
+            pagecount = int(re.search('page=(\d+)', link['url']).group(1))
 
     val = resp.json()
     if not isinstance(val, list):


### PR DESCRIPTION
Caused by us getting to **10** pages of proposals, which tricked the pagination regex into thinking there is only one page.