### PR TITLE
Fix typo in Fed. API request auth python example

### DIFF
--- a/changelogs/server_server/newsfragments/2510
+++ b/changelogs/server_server/newsfragments/2510
@@ -1,0 +1,1 @@
+Fix typo in Request Authentication python example

--- a/specification/server_server_api.rst
+++ b/specification/server_server_api.rst
@@ -316,8 +316,8 @@ Example python code:
              "destination": destination_name,
         }
 
-        if content_json is not None:
-            request["content"] = content
+        if content is not None:
+            request_json["content"] = content
 
         signed_json = sign_json(request_json, origin_name, origin_signing_key)
 


### PR DESCRIPTION
Fixes the typo in the Request Authentication python example. It seems like a copy paste error.

Closes: #2509
Signed-off-by: Rudi Floren <rudi.floren@gmail.com>