### PR TITLE
Fix .m.rule.contains_user_name push rule to highlight

### DIFF
--- a/changelogs/client_server/newsfragments/2519.clarification
+++ b/changelogs/client_server/newsfragments/2519.clarification
@@ -1,0 +1,1 @@
+Fix the ``.m.rule.contains_user_name`` default push rule to set the highlight tweak, matching Synapse and users' expectations.

--- a/specification/modules/push.rst
+++ b/specification/modules/push.rst
@@ -473,6 +473,9 @@ Definition (as a ``content`` rule):
             {
                 "set_tweak": "sound",
                 "value": "default"
+            },
+            {
+                "set_tweak": "highlight"
             }
         ]
     }


### PR DESCRIPTION
This fixes the default to match Synapse. [anoa in #matrix-spec agreed](https://matrix.to/#/!NasysSDfxKxZBzJJoE:matrix.org/$f6X2M4pAfPo01zQ62MpfEZ7EIQ4iDHSBUqIQ9s9B_UE?via=matrix.org&via=amorgan.xyz&via=pixie.town) that this is indeed a spec bug.