### PR TITLE
Add an additional parameter to the modify password API per MSC2457.

### DIFF
--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -345,7 +345,8 @@ paths:
               logout_devices:
                 type: boolean
                 description: |-
-                  Whether other access tokens should be revoked if the request succeeds. Defaults to true.
+                  Whether the other access tokens, and their associated devices, for the user should be 
+                  revoked if the request succeeds. Defaults to true.
                 example: true
               auth:
                 description: |-

--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -328,7 +328,8 @@ paths:
 
         The homeserver may change the flows available depending on whether a
         valid access token is provided. The homeserver SHOULD NOT revoke the
-        access token provided in the request.
+        access token provided in the request. Whether other access tokens for
+        the user are revoked depends on the request parameters.
       security:
         - accessToken: []
       operationId: changePassword

--- a/api/client-server/registration.yaml
+++ b/api/client-server/registration.yaml
@@ -328,8 +328,7 @@ paths:
 
         The homeserver may change the flows available depending on whether a
         valid access token is provided. The homeserver SHOULD NOT revoke the
-        access token provided in the request, however all other access tokens
-        for the user should be revoked if the request succeeds.
+        access token provided in the request.
       security:
         - accessToken: []
       operationId: changePassword
@@ -343,6 +342,11 @@ paths:
                 type: string
                 description: The new password for the account.
                 example: "ihatebananas"
+              logout_devices:
+                type: boolean
+                description: |-
+                  Whether other access tokens should be revoked if the request succeeds. Defaults to true.
+                example: true
               auth:
                 description: |-
                   Additional authentication information for the user-interactive authentication API.

--- a/changelogs/client_server/newsfragments/2523.feature
+++ b/changelogs/client_server/newsfragments/2523.feature
@@ -1,0 +1,1 @@
+Optionally invalidate other access tokens during password modification per `MSC 2457 <https://github.com/matrix-org/matrix-doc/pull/2457>`_.

--- a/changelogs/client_server/newsfragments/2523.feature
+++ b/changelogs/client_server/newsfragments/2523.feature
@@ -1,1 +1,1 @@
-Optionally invalidate other access tokens during password modification per `MSC 2457 <https://github.com/matrix-org/matrix-doc/pull/2457>`_.
+Optionally invalidate other access tokens during password modification per `MSC2457 <https://github.com/matrix-org/matrix-doc/pull/2457>`_.


### PR DESCRIPTION
This is per MSC #2457 ([rendered version](https://github.com/matrix-org/matrix-doc/blob/master/proposals/2457-password-modification-invalidating-devices.md)).

Synapse v1.12.0 added this as an optional parameter in matrix-org/synapse#7085.