### PR TITLE
MSC2526: Add ability to delete key backups

### DIFF
--- a/proposals/2526-add-delete-backup.md
+++ b/proposals/2526-add-delete-backup.md
@@ -1,4 +1,4 @@
-# Add ability to delete key backups
+# MSC2526: Add ability to delete key backups
 
 [MSC1219](https://github.com/matrix-org/matrix-doc/issues/1219) defined a
 mechanism for key backups.  However, it inadvertently omitted the endpoint to

--- a/proposals/2526-add-delete-backup.md
+++ b/proposals/2526-add-delete-backup.md
@@ -8,7 +8,7 @@ delete an entire key backup.  This proposal adds the endpoint.
 
 An endpoint is added, `DELETE /room_keys/version/{version}`, that deletes a
 backup version.  Both the information about the key backup, as well as all keys
-associated with the backup should be deleted.  Like `POST
-/room_keys/version/{version}`, and unlike `GET /room_keys/version/{version}`,
-`{version}` cannot be empty, to ensure that the wrong backup is not
-accidentally deleted.
+associated with the backup should be deleted.  If the specified version was
+previously deleted, the endpoint succeeds, returning an HTTP code of 200.  If
+the specified version never existed, the endpoint returns an HTTP code of 404
+with a Matrix `errcode` of `M_NOT_FOUND`.

--- a/proposals/xxxx-add-delete-backup.md
+++ b/proposals/xxxx-add-delete-backup.md
@@ -1,0 +1,14 @@
+# Add ability to delete key backups
+
+[MSC1219](https://github.com/matrix-org/matrix-doc/issues/1219) defined a
+mechanism for key backups.  However, it inadvertently omitted the endpoint to
+delete an entire key backup.  This proposal adds the endpoint.
+
+## Proposal
+
+An endpoint is added, `DELETE /room_keys/version/{version}`, that deletes a
+backup version.  Both the information about the key backup, as well as all keys
+associated with the backup should be deleted.  Like `POST
+/room_keys/version/{version}`, and unlike `GET /room_keys/version/{version}`,
+`{version}` cannot be empty, to ensure that the wrong backup is not
+accidentally deleted.


### PR DESCRIPTION
[Rendered](https://github.com/uhoreg/matrix-doc/blob/e2e_delete_backup/proposals/2526-add-delete-backup.md)

Hopefully this is uncontroversial.  I'd like to get this approved soon, since I'm preparing a spec PR for key backups (#2387), and would prefer to merge it all in one go, rather than making a separate PR to add this later.