### PR TITLE
MSC2545: Image Packs (Emoticons & Stickers)

### DIFF
--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -205,7 +205,7 @@ Related issue: https://github.com/matrix-org/matrix-doc/issues/2418
 ## Unstable prefix
 The `m.image_pack` in the account data is replaced with `im.ponies.user_emotes`. The `m.image_pack` in
 the room state is replaced with `im.ponies.room_emotes`. The `m.image_pack.rooms` is replaced with
-`im.ponies.room_emotes`.
+`im.ponies.emote_rooms`.
 
 Some existing implementations using `im.ponies.user_emotes` and `im.ponies.room_emotes` currently use
 a dict called `short` which is just a map of the shortcode to the mxc url.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -1,19 +1,19 @@
-# MSC2545: Emotes
+# MSC2545: Emoticons
 
-Emotes.....emotes!
+Emoticons, or short emotes...we need them!
 
-# Proposal
-Emotes have at least a shortcode and an mxc uri. They are sent as `<img>` tags currently already in
+## Proposal
+Emoticons have at least a shortcode and an mxc uri. They are sent as `<img>` tags currently already in
 the spec, as such existing clients *should* be able to render them (support for this is sadly poor,
-even within riot flavours). To allow clients to distinguish emotes from other inline images, a new
-property `data-mx-emote` is introduced. A client may chose to ignore the size attributes of emotes
+even within riot flavours). To allow clients to distinguish emoticons from other inline images, a new
+property `data-mx-emoticon` is introduced. A client may chose to ignore the size attributes of emoticons
 when rendering, and instead pick the size based on other circumstances. This could e.g. be used to
-display emotes in messages with only emotes and emoji larger than usual, which is commonly found in
+display emoticons in messages with only emoticons and emoji larger than usual, which is commonly found in
 messengers. Such an `<img>` tag of a shortcode `:emote:` and an mxc uri `mxc://example.org/emote`
 could look as follows:
 
 ```html
-<img data-mx-emote src="mxc://example.org/emote" alt=":emote:" title=":emote:" height="32" />
+<img data-mx-emoticon src="mxc://example.org/emote" alt=":emote:" title=":emote:" height="32" />
 ```
 
 Both the `alt` and the `title` attributes are specified as they serve different purposes: `alt` is
@@ -21,16 +21,16 @@ displayed if e.g. the emote does not load. `title` is displayed e.g. on mouse ho
 The height is just a height that looks good on most devices with the normal, default font size.
 No width is displayed as to not weirdly squish non-square emotes.
 
-## Emote sources
+### Emoticon sources
 In order to be able to send emotes the client needs to have a list of shortcodes and their corresponding
 mxc uris. All the emote sources described here are merely suggestions on where to get emotes from.
 A client is free to implement / design their own way of fetching emotes, e.g. via dropping image files
 into a folder and uploading them on-the-fly. For cross-compatibility between clients it'd still be a
 good idea to implement the emote sources described here. For this there are two different emote sources:
 
-### User emotes
+#### User emoticons
 User emotes are per-user emotes that are defined in the users respective account data. The type for that
-is `im.ponies.user_emotes` (later: `m.emotes`). The content is as following:
+is `im.ponies.user_emotes` (later: `m.emoticons`). The content is as following:
 
 ```json
 {
@@ -44,9 +44,9 @@ is `im.ponies.user_emotes` (later: `m.emotes`). The content is as following:
 The emotes are defined inside of a dict called `short`, which stands for shortcode. Other, additional
 keys may exist to define more metadata for the emotes. No such guide exists yet.
 
-### Room emotes
+#### Room emoticons
 Room emotes are per-room emotes that every user of a specific room can use inside of that room. They
-are set with a state event of type `im.ponies.room_emotes` (later: `m.emotes`). The state key denotes a possible
+are set with a state event of type `im.ponies.room_emotes` (later: `m.emoticons`). The state key denotes a possible
 pack, whereas the default one would be a blank state key. E.g. a discord bridge could set as state key
 `de.sorunome.mx-puppet-bridge.discord` and have all the bridged emotes in said state event, keeping
 bridged emotes from matrix emotes separate.
@@ -60,11 +60,11 @@ on the pack. The following keys for `pack` are valid:
    if it doesn't exist.
  - `name`: A short identifier of the pack. Defaults to the normalized state key, and if the state
    key is blank it defaults to "room".
-   
+
    Normalized means here, converting spaces to `-`, taking only alphanumerical characters, `-` and `_`,
    and casting it all to lowercase. In regex, this would be `[a-z0-9-_]+`.
 
-As such, a `im.ponies.room_emotes` (later: `m.emotes`) state event could look like the following:
+As such, a `im.ponies.room_emotes` (later: `m.emoticons`) state event could look like the following:
 
 ```json
 {
@@ -80,15 +80,13 @@ As such, a `im.ponies.room_emotes` (later: `m.emotes`) state event could look li
 }
 ```
 
-### Emote rooms
+#### Emoticon rooms
 While room emotes are specific to a room and are only accessible within that room, emote rooms should
 be accessible from everywhere. They do not differentiate themselves from room emotes at all, instead you
-set an event in your account data of type `im.ponies.emote_rooms` (later: `m.emotes.rooms`) which outlines
+set an event in your account data of type `im.ponies.emote_rooms` (later: `m.emoticons.rooms`) which outlines
 which room emote states should be globally accessible for that user. For that, a `room` key contains
 a map of room ids that map to state keys that map to an optional pack definition override.
-If you are currently viewing a room that is in your `im.ponies.emote_rooms` (later: `m.emotes.rooms`)
-it is expected that the client de-duplicates the packs, to only give suggestions for it onces.
-The the contents of `im.ponies.emote_rooms` (later: `m.emotes.rooms`) could look like the following:
+The the contents of `im.ponies.emote_rooms` (later: `m.emoticons.rooms`) could look like the following:
 
 ```json
 {
@@ -111,7 +109,19 @@ Here three emote packs are globally accessible to the user: Two defined in `!som
 (one with blank state key and one with state key `de.sorunome.mx-puppet-bridge.discord`) and one in
 `!someotherroom:example.org`.
 
-## Sending
+### Emoticon source priority and deduplicating
+When giving emoticon suggestions, clients are expected to deduplicate emotes by their mxc url. This
+not only ensures that, when viewing a room that you also have in `m.emoticons.rooms`, it won't be
+displayed twice, but also if you have e.g. a bot which syncs emotes over multiple rooms, those will
+also be deduplicated.
+
+Lastly, in order to have consistent and expected ordering of emotes when suggesting, they should be
+suggested in the following order:
+1. User emoticons (emotes set to your own account)
+2. Emoticon rooms (rooms whos emotes you enabled to be accessible everywhere)
+3. Room emoticons (emotes defined in the currently open room)
+
+### Sending
 In places where fancy tab-complete with the emote itself is not possible it is suggested that sending
 the shortcode will convert to the img tag, e.g. sending `Hey there :wave:` will convert to `Hey there <img-for-wave>`.
 
@@ -120,20 +130,17 @@ a user could specify the emote source by writing e.g. `:room~wave:` or `:user~wa
 pack name is used for room emotes, and "user" for user emotes. If a room pack does not have a short
 pack name and has a blank state key, then "room" is used.
 
-# Ideas
- - ???
-
-# Current implementations
-## Emote rendering (rendering of the `<img>` tag)
+## Current implementations
+### Emote rendering (rendering of the `<img>` tag)
  - riot-web
  - revolution
  - nheko
  - fluffychat
-## Emote sending, using the mentioned events here
+### Emote sending, using the mentioned events here
  - revolution
  - fluffychat
 
-# Security Considerations
+## Security Considerations
 When sending an `<img>` tag in an end-to-end encrypted room, the client will make a request to fetch
 said image, in this case an emote. As there is no way to encrypt content behind `<img>` tags yet,
 this could potentially leak part of the conversation. This is **not** a new security consideration,
@@ -141,13 +148,13 @@ it already exists. This, however, isn't much different from posting someone a li
 the recipient opens the link. Additionally, images, and thus emotes, are often cached by the client,
 not even necessarily leading to an http query.
 
-# Alternatives
+## Alternatives
 One can easily think of near infinite ways to implement emotes. The aspect of sending an `<img>` tag
-and marking it as an emote with `data-mx-emote` seems to be pretty universal though, so the question
+and marking it as an emote with `data-mx-emoticon` seems to be pretty universal though, so the question
 is mainly on different emote sources. For that, a separate MSC, [MSC1951](https://github.com/matrix-org/matrix-doc/pull/1951)
 already exists, so it is reasonable to compare this one with that one:
 
-## Comparison with MSC1951
+### Comparison with MSC1951
 MSC1951 defines a dedicated room as the only emote source. This MSC, however, also allows you to bind emotes
 to your own account, offering greater flexibility. In MSC1951 there can also only be a single emote
 pack in a room. This could be problematic in e.g. bridged rooms: You set some emotes from the matrix

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -23,7 +23,7 @@ mxc uris. For this there are two different emote sources:
 
 ### User emotes
 User emotes are per-user emotes that are defined in the users respective account data. The type for that
-is `im.ponies.user_emotes` (`m.emotes`). The content is as following:
+is `im.ponies.user_emotes` (later: `m.emotes`). The content is as following:
 
 ```json
 {
@@ -34,31 +34,30 @@ is `im.ponies.user_emotes` (`m.emotes`). The content is as following:
 }
 ```
 
-The emotes are defined inside of a dict called `short`, meant as the "short and easy" representation
-of the emotes. Other, additional keys may exist to define more metadata for the emotes. No such
-guide exists yet.
+The emotes are defined inside of a dict called `short`, which stands for shortcode. Other, additional
+keys may exist to define more metadata for the emotes. No such guide exists yet.
 
 ### Room emotes
 Room emotes are per-room emotes that every user of a specific room can use inside of that room. They
-are set with a state event of type `im.ponies.room_emotes` (`m.emotes`). The state key denotes a possible
+are set with a state event of type `im.ponies.room_emotes` (later: `m.emotes`). The state key denotes a possible
 pack, whereas the default one would be a blank state key. E.g. a discord bridge could set as state key
 `de.sorunome.mx-puppet-bridge.discord` and have all the bridged emotes in said state event, keeping
-bridged emotes from own, custom ones separate.
+bridged emotes from matrix emotes separate.
 
 The content extends that of the user emotes: It uses the `short` key, which is a map of the shortcode
 of the emote to its mxc uri. Additionally, an optional `pack` key can be set, which defines meta-information
-on the pack. The following attributes are there:
+on the pack. The following keys for `pack` are valid:
 
- - `pack.displayname`: An easy displayname for the pack. Defaults to the room name, if it doesn't exist
- - `pack.avatar_url`: The mxc uri of an avatar/icon to display for the pack. Defaults to the room name,
+ - `displayname`: An easy displayname for the pack. Defaults to the room name, if it doesn't exist
+ - `avatar_url`: The mxc uri of an avatar/icon to display for the pack. Defaults to the room name,
    if it doesn't exist.
- - `pack.short`: A short identifier of the pack. Defaults to the normalized state key, and if the state
+ - `name`: A short identifier of the pack. Defaults to the normalized state key, and if the state
    key is blank it defaults to "room".
    
    Normalized means here, converting spaces to `-`, taking only alphanumerical characters, `-` and `_`,
-   and casting it all to lowercase.
+   and casting it all to lowercase. In regex, this would be `[a-z0-9-_]+`.
 
-As such, a content of a room emote pack could look as following:
+As such, a `im.ponies.room_emotes` (later: `m.emotes`) state event could look like the following:
 
 ```json
 {
@@ -69,18 +68,20 @@ As such, a content of a room emote pack could look as following:
   "pack": {
     "displayname": "Emotes from Discord!",
     "avatar_url": "mxc://example.org/discord_guild",
-    "short": "some_discord_guild"
+    "name": "some_discord_guild"
   }
 }
 ```
 
 ### Emote rooms
 While room emotes are specific to a room and are only accessible within that room, emote rooms should
-be accessible from everywhere. They do not differentiate themself from room emotes at all, instead you
-set an event in your account data of type `im.ponies.emote_rooms` (`m.emotes.rooms`) which outlines
+be accessible from everywhere. They do not differentiate themselves from room emotes at all, instead you
+set an event in your account data of type `im.ponies.emote_rooms` (later: `m.emotes.rooms`) which outlines
 which room emote states should be globally accessible for that user. For that, a `room` key contains
-a map of room id that contains a map of state key that contains an optional pack definition override.
-As such, the contents of `im.ponies.emote_rooms` could look as follows:
+a map of room ids that map to state keys that map to an optional pack definition override.
+If you are currently viewing a room that is in your `im.ponies.emote_rooms` (later: `m.emotes.rooms`)
+it is expected that the client de-duplicates the packs, to only give suggestions for it onces.
+The the contents of `im.ponies.emote_rooms` (later: `m.emotes.rooms`) could look like the following:
 
 ```json
 {
@@ -88,7 +89,7 @@ As such, the contents of `im.ponies.emote_rooms` could look as follows:
     "!someroom:example.org": {
       "": {},
       "de.sorunome.mx-puppet-bridge.discord": {
-        "name": "Overriden name",
+        "displayname": "Overriden name",
         "short": "new_short_name"
       }
     },
@@ -109,7 +110,8 @@ the shortcode will convert to the img tag, e.g. sending `Hey there :wave:` will 
 
 If there are collisions due to the same emote shortcode being present as both room emote and user emote
 a user could specify the emote source by writing e.g. `:room~wave:` or `:user~wave:`. Here the short
-pack name is used for room emotes, and "user" for user emotes.
+pack name is used for room emotes, and "user" for user emotes. If a room pack does not have a short
+pack name and has a blank state key, then "room" is used.
 
 # Ideas
  - ???

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -5,6 +5,7 @@ Emoticons, or short emotes...we need them!
 We also need proper stickers, too!
 
 ## Terminology
+### Emoticons
 Since there is a lot of confusion of how this relates to `m.emote`, why this isn't called custom emoji
 etc, there it is:
 
@@ -23,6 +24,11 @@ are for.
 Now, a client may choose to name these however they like, we already have a naming disparity between
 spec and clients with groups vs communities. It is, however, imperative to name things in the spec
 accurately after what they are.
+
+### Stickers
+Stickers already exits in Matrix. They are reusable images one can send, usually as a reaction sent
+in the timeline to something. This MSC adds a way to distribute and define a source for a client to
+send them.
 
 ## Proposal
 ### Emoticons in the formatted body
@@ -59,7 +65,7 @@ To send stickers the already speced `m.sticker` is used.
 Emoticons are recommended to have a size of about 128x128 pixels. Even though the fallback specifies
 a height of 32, this is to ensure that the emotes still look good on higher DPI screens.
 
-Stickers are recommended to have a size of about 512x512 pixels.
+Stickers are recommended to have a size of up to 512x512 pixels.
 
 Furthermore, these images should either have a mimetype of `image/png`, `image/gif` or `image/webp`.
 They can be animated.
@@ -79,7 +85,7 @@ The pack object consists of the following keys:
    to the room avatar, if the pack is in the room. If the room also does not have an avatar, or the
    image pack event is not in a room, this pack does not have an avatar.
  - `usage`: (String[], optional) An array of the usages for this pack. Possible usages are `emoticon`
-   and `sticker`. If the usage is absent, a usage for all possible usage types is to be assumed.
+   and `sticker`. If the usage is absent or empty, a usage for all possible usage types is to be assumed.
  - `license`: (String, optional) The license of this pack.
 
 #### Image object
@@ -89,8 +95,8 @@ The image object conists of the following keys:
    the emote alt text. Defaults to the short code.
  - `info`: (`ImageInfo`, optional) The already speced `ImageInfo` object used for the `info` block of
    `m.sticker` events.
- - `usage`: (String[], optional) An array of the usages for this image. If present, this overrides
-   the usage defined at pack level for this particular image.
+ - `usage`: (String[], optional) An array of the usages for this image. If present and non-emtpy,
+   this overrides the usage defined at pack level for this particular image.
 
 #### Example image pack event
 Taking all this into account, an example pack event may look as following:
@@ -100,8 +106,8 @@ Taking all this into account, an example pack event may look as following:
     "emote": {
       "url": "mxc://example.org/blah"
     },
-    "sicker": {
-      "url": "mxc://example.og/sticker",
+    "sticker": {
+      "url": "mxc://example.org/sticker",
       "usage": ["sticker"]
     }
   },
@@ -169,10 +175,21 @@ that, when viewing a room that you also have in `m.image_pack.rooms`, it won't b
 but also if you have e.g. a bot which syncs emotes over multiple rooms, those will also be deduplicated.
 
 ### Sending
+#### Emoticons
 For emoticons a client could add deliminators (e.g. `:`) around around the image shortcode, meaning
 that if an image has a shortcode of `emote`, the user can enter `:emote:` to send it. If there are
 multiple emoticons with the same shortcode in a room the client could e.g. slugify the packs display
 name and then have the user enter `:slug~emote:`.
+
+The alt / title text fo the `<img>` tag is expected to be the `body` of the emote, or, if absent, its
+shotcode, optionally with tacked on deliminators.
+
+#### Stickers
+When sending a sticker the `body` of the `m.sticker` event should be set to the `body` defined for that
+image, or its shortcode, if absent.
+
+Furthermore, the `info` of the `m.sticker` event should be set to the `info` defined for that image,
+or a blank object, if absent.
 
 ## Security Considerations
 When sending an `<img>` tag in an encrypted room, the client will make a request to fetch
@@ -181,6 +198,8 @@ this could potentially leak part of the conversation. This is **not** a new secu
 it already exists. This, however, isn't much different from posting someone a link in an e2ee chat and
 the recipient opens the link. Additionally, images, and thus emotes, are often cached by the client,
 not even necessarily leading to an http query.
+
+Related issue: https://github.com/matrix-org/matrix-doc/issues/2418
 
 ## Unstable prefix
 The `m.image_pack` in the account data is replaced with `im.ponies.user_emotes`. The `m.image_pack` in

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -1,0 +1,49 @@
+# MSC2545: Emotes
+
+Emotes.....emotes!
+
+# Proposal
+Emotes have at least a shortcode and an mxc uri. They are sent as `<img>` tags currently already in
+the spec, as such existing clients *should* be able to render them (support for this is sadly poor,
+even within riot flavours). Such an `<img>` tag of a shortcode `:emote:` and an mxc uri `mxc://example.org/emote`
+could look as follows:
+
+```html
+<img src="mxc://example.org/emote" alt=":emote:" title=":emote:" height="32" />
+```
+
+Both the `alt` and the `title` attributes are specified as they serve different purposes: `alt` is
+displayed if e.g. the emote does not load. `title` is displayed e.g. on mouse hover over the emote.
+The height is just a height that looks good on most devices with the normal, default font size.
+No width is displayed as to not weirdly squish non-square emotes.
+
+## Emote sources
+In order to be able to send emotes the client needs to have a list of shortcodes and their corresponding
+mxc uris. For this there are two different emote sources:
+
+### User emotes
+User emotes are per-user emotes that are defined in the users respective account data. The type for that
+is `im.ponies.user_emotes`. The content is as following:
+
+```json
+{
+  "short": {
+    ":emote:": "mxc://example.org/blah",
+    ":other-emote:": "mxc://example.org/other-blah"
+  }
+}
+```
+
+The emotes are defined inside of a dict called `short`, meant as the "short and easy" representation
+of the emotes. Other, additional, keys may exist to define more metadata for the emotes. No such
+guide exists yet.
+
+### Room emotes
+Room emotes are per-room emotes that every user of a specific room can use inside of that room. They
+are set with a state event of type `im.ponies-room_emotes` and a blank state key. The contents are
+the same as for the user emotes.
+
+## Ideas
+ - Tag rooms as "these emotes can be used anywhere" inside of account data somehow
+ - Some kind of packs - for room emotes the state key could be used as pack identifier, for user
+   emotes something like `im.ponies.user_emotes.<pack_name>`.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -224,14 +224,25 @@ to your own account, offering greater flexibility. In MSC1951 there can also onl
 pack in a room. This could be problematic in e.g. bridged rooms: You set some emotes or stickers from the matrix
 side and a discord bridge would plop all the discord emotes and stickers in another pack in the same room.
 
-MSC1951 defines a way to recommend using a pack of a different room - this MSC does not have an equivalent
-to that. Instead, this MSC allows multiple image packs for a room, and allows you to enable an image
-pack to be globally available for yourself across all rooms you are in.
+The original sharing-focused idea of MSC1951 is still preserved: Once room types are a thing, you could
+still easily have an image pack-only room.
 
-The core difference is how MSC1951 and this MSC define the emotes themselves: In MSC1951 you have to
+MSC1951 defines a way to recommend using a pack of a different room - this MSC does not have an equivalent
+to that. Instead, this MSC allows multiple image packs for a room, typically one where you already
+chat in anyways. Furthermore it allows you to enable an image pack to be globally available for yourself
+across all rooms you are in.
+
+The core difference is how MSC1951 and this MSC define the image packs themselves: In MSC1951 you have to
 set one state event *per image*. While this might seem like a nice idea on the surface, it doesn't
-scale well. There are people who easily use and want hundreds or even thousands of emotes accessible.
+scale well. There are people who easily use and want hundreds or even thousands of image packs accessible.
 A simple dict of shortcode to mxc URI seems more appropriate for this.
 
+In general, MSC1951 feels like a heavier approach to image pack sources, while this MSC is more lightweight.
 
-In general, MSC1951 feels like a heavier approach to emote sources, while this MSC is more lightweight.
+## Looking further
+A couple of interesting points have been raised in the discussions of this MSC tangentially touch
+custom emoticons but warrant an MSC for themselves, as they touch more on how `<img>` is working.
+ - Figuring out how `<img>` should work with encrypted media.
+ - Allow SVGs in the `<img>` tag. Current problem: Clients typically try to thumbnail the mxc URL,
+   and most media repositories can't thumbnail SVGs. Possible solution: Somehow embed the mimetype.
+ - For stickers: Recommend rendering sizes / resolutions

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -86,7 +86,7 @@ The pack object consists of the following keys:
    image pack event is not in a room, this pack does not have an avatar.
  - `usage`: (String[], optional) An array of the usages for this pack. Possible usages are `emoticon`
    and `sticker`. If the usage is absent or empty, a usage for all possible usage types is to be assumed.
- - `license`: (String, optional) The license of this pack.
+ - `attribution`: (String, optional) The attribution of this pack.
 
 #### Image object
 The image object conists of the following keys:

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -62,6 +62,6 @@ could perhaps be added, see ideas section.
  - revolution
  - nheko
  - fluffychat
-## Emote sending, using the mentioned state events here
+## Emote sending, using the mentioned events here
  - revolution
  - fluffychat

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -35,7 +35,7 @@ is `im.ponies.user_emotes` (`m.emotes`). The content is as following:
 ```
 
 The emotes are defined inside of a dict called `short`, meant as the "short and easy" representation
-of the emotes. Other, additional, keys may exist to define more metadata for the emotes. No such
+of the emotes. Other, additional keys may exist to define more metadata for the emotes. No such
 guide exists yet.
 
 ### Room emotes

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -5,11 +5,15 @@ Emotes.....emotes!
 # Proposal
 Emotes have at least a shortcode and an mxc uri. They are sent as `<img>` tags currently already in
 the spec, as such existing clients *should* be able to render them (support for this is sadly poor,
-even within riot flavours). Such an `<img>` tag of a shortcode `:emote:` and an mxc uri `mxc://example.org/emote`
+even within riot flavours). To allow clients to distinguish emotes from other inline images, a new
+property `data-mx-emote` is introduced. A client may chose to ignore the size attributes of emotes
+when rendering, and instead pick the size based on other circumstances. This could e.g. be used to
+display emotes in messages with only emotes and emoji larger than usual, which is commonly found in
+messengers. Such an `<img>` tag of a shortcode `:emote:` and an mxc uri `mxc://example.org/emote`
 could look as follows:
 
 ```html
-<img src="mxc://example.org/emote" alt=":emote:" title=":emote:" height="32" />
+<img data-mx-emote src="mxc://example.org/emote" alt=":emote:" title=":emote:" height="32" />
 ```
 
 Both the `alt` and the `title` attributes are specified as they serve different purposes: `alt` is
@@ -19,7 +23,10 @@ No width is displayed as to not weirdly squish non-square emotes.
 
 ## Emote sources
 In order to be able to send emotes the client needs to have a list of shortcodes and their corresponding
-mxc uris. For this there are two different emote sources:
+mxc uris. All the emote sources described here are merely suggestions on where to get emotes from.
+A client is free to implement / design their own way of fetching emotes, e.g. via dropping image files
+into a folder and uploading them on-the-fly. For cross-compatibility between clients it'd still be a
+good idea to implement the emote sources described here. For this there are two different emote sources:
 
 ### User emotes
 User emotes are per-user emotes that are defined in the users respective account data. The type for that
@@ -125,3 +132,35 @@ pack name and has a blank state key, then "room" is used.
 ## Emote sending, using the mentioned events here
  - revolution
  - fluffychat
+
+# Security Considerations
+When sending an `<img>` tag in an end-to-end encrypted room, the client will make a request to fetch
+said image, in this case an emote. As there is no way to encrypt content behind `<img>` tags yet,
+this could potentially leak part of the conversation. This is **not** a new security consideration,
+it already exists. This, however, isn't much different of posting someone a link in an e2ee chat and
+the recipient opens the link. Additionally, images, and thus emotes, are often cached by the client,
+not even necessarily leading to an http query.
+
+# Alternatives
+One can easily think of near infinite ways to implement emotes. The aspect of sending an `<img>` tag
+and marking it as an emote with `data-mx-emote` seems to be pretty universal, though, so the question
+is mainly on different emote sources. For that, a separate MSC, [MSC1951](https://github.com/matrix-org/matrix-doc/pull/1951)
+already exists, so it is reasonable to compare this one with that one:
+
+## Comparison with MSC1951
+MSC1951 defines as only emote source a dedicated room. This MSC, however, also allows you to bind emotes
+to your own account, offering greater flexibility. In MSC1951 there can also only be a single emote
+pack in a room. This could be problematic in e.g. bridged rooms: You set some emotes from the matrix
+side and a discord bridge would plop all the discord emotes in another pack in the same room.
+
+MSC1951 defines a way to recommend using a pack of a different room - this MSC does not have an equivalent
+of that. Instead, this MSC allows multiple emote packs for a room, and allows you to enable an emote
+pack to be globally available for yourself accross all rooms you are in.
+
+The core difference is how MSC1951 and this MSC define the emotes themselves: In MSC1951 you have to
+set one state event *per emote*. While this might seem like a nice idea on the surface, it doesn't
+scale well. There are people who easily use and want hundreds or even thousands of emotes accessible.
+A simple dict of shortcode to mxc URI seems more appropriate for this.
+
+In general, MSC1951 feels like a heavier approach to emote sourcs, while this MSC is more lightweight
+and thus should allow significantly larger packs.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -53,7 +53,8 @@ The `src` attribute *must* be an mxc url. Other URIs, such as `https`, `mailto` 
 Emoticons are recommended to have a size of about 128x128 pixels. Even though the fallback specifies
 a height of 32, this is to ensure that the emotes still look good on higher DPI screens.
 
-Furthermore, emotes should either have a mimetype of `image/png`, `image/gif` or `image/webp`.
+Furthermore, emotes should either have a mimetype of `image/png`, `image/gif` or `image/webp`. Emotes
+can be animated.
 
 Due to the low resolution of emotes, `image/jpg`/`image/jpeg` has been purposefully excluded from this
 list.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -135,6 +135,11 @@ E.g. a discord bridge could set as state key
 `de.sorunome.mx-puppet-bridge.discord` and have all the bridged emotes in said state event, keeping
 bridged emotes from matrix emotes separate.
 
+#### Space image packs
+Clients should suggest image packs of a space that a room is in, if the user is also in the space.
+For that, the client should recursively check the `m.space.parent` state events and suggest emoticons
+and stickers from all the image packs found in those rooms/spaces.
+
 #### Image pack rooms
 While room image packs are specific to a room and are only accessible within that room, image pack
 rooms should be accessible from everywhere. They do not differentiate themselves from room emotes at
@@ -168,8 +173,7 @@ ordered list where you click an entry), the order of the images should be predic
 The ordering could look as following:
 1. User image pack (images set in your own account)
 2. Image pack rooms (rooms whos image packs you enabled to be accessible everywhere)
-3. Space image packs (image packs defined in claimed parents (`m.space.parent`), recursively. Important:
-   clients must make sure to break recursion loops), if the user is in them
+3. Space image packs (packs sent in the space, if present)
 4. Room image packs (images defined in the currently open room)
 
 Furthermore, clients are expected to deduplicate images based on their mxc url. This not only ensures

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -95,8 +95,11 @@ The image object conists of the following keys:
    the emote alt text. Defaults to the short code.
  - `info`: (`ImageInfo`, optional) The already speced `ImageInfo` object used for the `info` block of
    `m.sticker` events.
- - `usage`: (String[], optional) An array of the usages for this image. If present and non-emtpy,
-   this overrides the usage defined at pack level for this particular image.
+ - `usage`: (String[], optional) An array of the usages for this image. If present and non-empty,
+   this overrides the usage defined at pack level for this particular image. This is useful to e.g.
+   have one pack contain mixed emotes and stickers. Additionally there is only a single account data
+   level image pack, meaning this is required to have a mixture of emotes and stickers available in
+   account data.
 
 #### Example image pack event
 Taking all this into account, an example pack event may look as following:
@@ -136,9 +139,9 @@ E.g. a discord bridge could set as state key
 bridged emotes from matrix emotes separate.
 
 #### Space image packs
-Clients should suggest image packs of a space that a room is in, if the user is also in the space.
-For that, the client should recursively check the `m.space.parent` state events and suggest emoticons
-and stickers from all the image packs found in those rooms/spaces.
+Clients should suggest image packs of a canonical space that a room is in, if the user is also in the
+space. This should be done recursively on canonical spaces. So, if a room has a canonical space and
+that space again has a canonical space, the clients should suggest image packs of both of those spaces.
 
 #### Image pack rooms
 While room image packs are specific to a room and are only accessible within that room, image pack
@@ -147,7 +150,7 @@ all, instead you set an event in your account data of type `m.image_pack.rooms` 
 which room image pack states are globally accessible for that user. For that, a `room` key contains
 a map of room ids that map to state keys that map to an object. While this MSC does not define any
 contents for this object, having this an object means greater flexibility in case of future changes.
-The the contents of `m.image_pack.rooms` could look like the following:
+The contents of `m.image_pack.rooms` could look like the following:
 
 ```json
 {
@@ -227,7 +230,7 @@ already exists, so it is reasonable to compare this one with that one:
 ### Comparison with MSC1951
 MSC1951 defines a dedicated room as the only image pack source. This MSC, however, also allows you to bind image packs
 to your own account, offering greater flexibility. In MSC1951 there can also only be a single image pack
-pack in a room. This could be problematic in e.g. bridged rooms: You set some emotes or stickers from the matrix
+in a room. This could be problematic in e.g. bridged rooms: You set some emotes or stickers from the matrix
 side and a discord bridge would plop all the discord emotes and stickers in another pack in the same room.
 
 The original sharing-focused idea of MSC1951 is still preserved: Once room types are a thing, you could

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -179,7 +179,8 @@ but also if you have e.g. a bot which syncs emotes over multiple rooms, those wi
 For emoticons a client could add deliminators (e.g. `:`) around around the image shortcode, meaning
 that if an image has a shortcode of `emote`, the user can enter `:emote:` to send it. If there are
 multiple emoticons with the same shortcode in a room the client could e.g. slugify the packs display
-name and then have the user enter `:slug~emote:`.
+name and then have the user enter `:slug~emote:`. As slugs typically match `^[\w-]+$` that should
+ensure complete-ability.
 
 The alt / title text fo the `<img>` tag is expected to be the `body` of the emote, or, if absent, its
 shotcode, optionally with tacked on deliminators.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -1,6 +1,8 @@
-# MSC2545: Emoticons
+# MSC2545: Image Packs (Emoticons & Stickers)
 
 Emoticons, or short emotes...we need them!
+
+We also need proper stickers, too!
 
 ## Terminology
 Since there is a lot of confusion of how this relates to `m.emote`, why this isn't called custom emoji
@@ -23,13 +25,14 @@ spec and clients with groups vs communities. It is, however, imperative to name 
 accurately after what they are.
 
 ## Proposal
+### Emoticons in the formatted body
 Emoticons have at least a shortcode and an mxc uri. They are sent as `<img>` tags currently already in
 the spec, as such existing clients should already be able to render them, though not all clients currently
 handle `img` tags. To allow clients to distinguish emoticons from other inline images, a new
 property, `data-mx-emoticon`, is introduced. A client can chose to ignore the size attributes of emoticons
 when rendering, and instead pick the size based on other circumstances. This could e.g. be used to
 display emoticons in messages with only emoticons and emoji larger than usual, which is commonly found in
-messengers. Such an `<img>` tag of a shortcode `:emote:` and an mxc uri `mxc://example.org/emote`
+messengers. Such an `<img>` tag of a shortcode `emote` and an mxc uri `mxc://example.org/emote`
 could look as follows:
 
 ```html
@@ -49,102 +52,98 @@ the attribute may even look like `data-mx-emoticon=""`.
 
 The `src` attribute *must* be an mxc url. Other URIs, such as `https`, `mailto` etc. are not allowed.
 
-### Emoticon image types
+### Sending stickers
+To send stickers the already speced `m.sticker` is used.
+
+### Image types
 Emoticons are recommended to have a size of about 128x128 pixels. Even though the fallback specifies
 a height of 32, this is to ensure that the emotes still look good on higher DPI screens.
 
-Furthermore, emotes should either have a mimetype of `image/png`, `image/gif` or `image/webp`. Emotes
-can be animated.
+Stickers are recommended to have a size of about 512x512 pixels.
+
+Furthermore, these images should either have a mimetype of `image/png`, `image/gif` or `image/webp`.
+They can be animated.
 
 Due to the low resolution of emotes, `image/jpg`/`image/jpeg` has been purposefully excluded from this
 list.
 
-### Emoticon sources
-So that emoticons are compatible between different clients, they should follow the emoticon sources
-described here.
+### Image pack event
+The image pack event has a type of `m.image_pack`. It contains a key `images`, which is a map from a
+short code to an image object. It may also contain a key `pack`, which is a pack object.
 
-#### User emoticons
-User emotes are per-user emotes that are defined in the user's respective account data. The type for that
-is `m.emoticons`, the content of which is as following:
+#### Pack object
+The pack object consists of the following keys:
+ - `display_name`: (String, optional) A display name for the pack. Defaults to the room name, if the
+   image pack event is in the room. This does not have to be unique within all packs of a room.
+ - `avatar_url`: (String, optional) The mxc uri of an avatar/icon to dipslay for the pack. Defautls
+   to the room avatar, if the pack is in the room. If the room also does not have an avatar, or the
+   image pack event is not in a room, this pack does not have an avatar.
+ - `usage`: (String[], optional) An array of the usages for this pack. Possible usages are `emoticon`
+   and `sticker`. If the usage is absent, a usage for all possible usage types is to be assumed.
+ - `license`: (String, optional) The license of this pack.
 
+#### Image object
+The image object conists of the following keys:
+ - `url`: (String, requried) The mxc URL for this image
+ - `body`: (String, optional) An optional body for this image, useful for the sticker body text or
+   the emote alt text. Defaults to the short code.
+ - `info`: (`ImageInfo`, optional) The already speced `ImageInfo` object used for the `info` block of
+   `m.sticker` events.
+ - `usage`: (String[], optional) An array of the usages for this image. If present, this overrides
+   the usage defined at pack level for this particular image.
+
+#### Example image pack event
+Taking all this into account, an example pack event may look as following:
 ```json
 {
-  "emoticons": {
-    ":emote": {
+  "images": {
+    "emote": {
       "url": "mxc://example.org/blah"
     },
-    ":other-emote:": {
-      "url": "mxc://example.org/other-blah"
+    "sicker": {
+      "url": "mxc://example.og/sticker",
+      "usage": ["sticker"]
     }
+  },
+  "pack": {
+    "display_name": "Awesome Pack",
+    "usage": ["emoticon"]
   }
 }
 ```
 
-The emotes are defined inside of a dict called `emoticons`. The key is the shortcode of the emoticon.
-The value is an object with `url` as a required field, containing the mxc uri as a string. This is so
-that it is easier for clients or future MSCs to define custom metadata to emotes directly.
+### Image sources
+There are several places where a client is expected to look for these `m.image_pack` events, mainly
+in their own account data and in room states.
 
-#### Room emoticons
-Room emotes are per-room emotes that every user of a specific room can only use inside of that room. They
-are set with a state event of type `m.emoticons`. Multiple packs can be specified by different state
-keys, the identifier being an opague string. An empty state key is the default pack for a room.
+#### User image packs
+Each user can have their own personal image pack defined in their own account data, with the normal
+`m.image_pack` event. The user is expected to be presented with these images in all rooms.
+
+#### Room image packs
+A room can have an unlimited amount of image packs, by specifying the `m.image_pack` state event with
+different state keys. The user is expected to be presented with these images only in the room they
+are defined in. To enable them to be presented in all rooms, see the section below.
+An empty state key is the default pack for a room.
 E.g. a discord bridge could set as state key
 `de.sorunome.mx-puppet-bridge.discord` and have all the bridged emotes in said state event, keeping
 bridged emotes from matrix emotes separate.
 
-The content extends that of the user emotes: It uses the `emoticons` key, which is a map of the shortcode
-of the emote to an object containing its mxc url, just as with user emoticons. Additionally, an optional `pack` key can be set,
-which defines meta-information on the pack. The following keys for `pack` are valid:
-
- - `display_name`: (String, optional) An easy display name for the pack. Defaults to the room name,
-   if it doesn't exist. This does not have to be unique within all packs of a room.
- - `avatar_url`: (String, optional) The mxc uri of an avatar/icon to display for the pack. Defaults
-   to the room avatar, if it doesn't exist. If the room also does not have one, then this pack does
-   not have an avatar.
- - `short`: (String, `^[a-z0-9-_]+$`, optional) A short human-readable identifier of the pack. Defaults
-   to the normalized state key, and if the state key is blank it defaults to "room". This is used to
-   easily specify which pack to pick an emoticon from, should there be clashes.
-
-   Normalized means here, converting spaces to `-`, taking only alphanumerical characters, `-` and `_`,
-   and casting it all to lowercase. In regex, this would be `^[a-z0-9-_]+$`.
-
-As such, a `m.emoticons` state event could look like the following:
-
-```json
-{
-  "emoticons": {
-    ":emote:": {
-      "url": "mxc://example.org/blah"
-    },
-    ":other-emote:": {
-      "url": "mxc://example.org/other-blah"
-    }
-  },
-  "pack": {
-    "display_name": "Emotes from Discord!",
-    "avatar_url": "mxc://example.org/discord_guild",
-    "short": "some_discord_guild"
-  }
-}
-```
-
-#### Emoticon rooms
-While room emotes are specific to a room and are only accessible within that room, emote rooms should
-be accessible from everywhere. They do not differentiate themselves from room emotes at all, instead you
-set an event in your account data of type `m.emoticons.rooms` which outlines
-which room emote states are globally accessible for that user. For that, a `room` key contains
-a map of room ids that map to state keys that map to an optional pack definition override.
-The the contents of `m.emoticons.rooms` could look like the following:
+#### Image pack rooms
+While room image packs are specific to a room and are only accessible within that room, image pack
+rooms should be accessible from everywhere. They do not differentiate themselves from room emotes at
+all, instead you set an event in your account data of type `m.image_pack.rooms` which outlines
+which room image pack states are globally accessible for that user. For that, a `room` key contains
+a map of room ids that map to state keys that map to an object. While this MSC does not define any
+contents for this object, having this an object means greater flexibility in case of future changes.
+The the contents of `m.image_pack.rooms` could look like the following:
 
 ```json
 {
   "rooms": {
     "!someroom:example.org": {
       "": {},
-      "de.sorunome.mx-puppet-bridge.discord": {
-        "display_name": "Overriden name",
-        "short": "new_short_name"
-      }
+      "de.sorunome.mx-puppet-bridge.discord": {}
     },
     "!someotherroom:example.org": {
       "": {}
@@ -155,28 +154,25 @@ The the contents of `m.emoticons.rooms` could look like the following:
 
 Here three emote packs are globally accessible to the user: Two defined in `!someroom:example.org`
 (one with blank state key and one with state key `de.sorunome.mx-puppet-bridge.discord`) and one in
-`!someotherroom:example.org`. The one in `!someroom:example.org` with state key `de.sorunome.mx-puppet-bridge.discord`
-has an override for `display_name` and `short` of that pack, so that for this user the pack displays
-differently for themselves.
+`!someotherroom:example.org`.
 
-### Emoticon source priority and deduplicating
-When giving emoticon suggestions, clients are expected to deduplicate emotes by their mxc url. This
-not only ensures that, when viewing a room that you also have in `m.emoticons.rooms`, it won't be
-displayed twice, but also if you have e.g. a bot which syncs emotes over multiple rooms, those will
-also be deduplicated.
+### Image pack source priority and deduplicating
+If a client gives image suggestions (emotes, stickers) to the user in some ordered fassion (e.g. a
+ordered list where you click an entry), the order of the images should be predictable between rooms.
+The ordering could look as following:
+1. User image pack (images set in your own account)
+2. Image pack rooms (rooms whos image packs you enabled to be accessible everywhere)
+3. Room image packs (images defined in the currently open room)
 
-Lastly, in order to have consistent and expected ordering of emotes when suggesting, they should be
-suggested in the following order:
-1. User emoticons (emotes set to your own account)
-2. Emoticon rooms (rooms whos emotes you enabled to be accessible everywhere)
-3. Room emoticons (emotes defined in the currently open room)
+Furthermore, clients are expected to deduplicate images based on their mxc url. This not only ensures
+that, when viewing a room that you also have in `m.image_pack.rooms`, it won't be displayed twice,
+but also if you have e.g. a bot which syncs emotes over multiple rooms, those will also be deduplicated.
 
 ### Sending
-Clients should consider converting shortcodes like `:wave:` to a relevant `<img>` tag for the emoticon.
-
-Clients should also consider supporting ways for the user to find the emoticon they are attempting to send,
-such as having a syntax like `:room~wave:` to find `wave` emoticon in the current room. Alternatives might also
-be `user` or pack `short` attributes to search within.
+For emoticons a client could add deliminators (e.g. `:`) around around the image shortcode, meaning
+that if an image has a shortcode of `emote`, the user can enter `:emote:` to send it. If there are
+multiple emoticons with the same shortcode in a room the client could e.g. slugify the packs display
+name and then have the user enter `:slug~emote:`.
 
 ## Security Considerations
 When sending an `<img>` tag in an encrypted room, the client will make a request to fetch
@@ -187,12 +183,14 @@ the recipient opens the link. Additionally, images, and thus emotes, are often c
 not even necessarily leading to an http query.
 
 ## Unstable prefix
-The `m.emoticons` in the account data is replaced with `im.ponies.user_emotes`. The `m.emoticons` in
-the room state is replaced with `im.ponies.room_emotes`. The `m.emoticons.rooms` is replaced with
+The `m.image_pack` in the account data is replaced with `im.ponies.user_emotes`. The `m.image_pack` in
+the room state is replaced with `im.ponies.room_emotes`. The `m.image_pack.rooms` is replaced with
 `im.ponies.room_emotes`.
 
 Some existing implementations using `im.ponies.user_emotes` and `im.ponies.room_emotes` currently use
 a dict called `short` which is just a map of the shortcode to the mxc url.
+
+Some other implementations currently also call the `images` key `emoticons`.
 
 ## Alternatives
 One can easily think of near infinite ways to implement emotes. The aspect of sending an `<img>` tag
@@ -201,17 +199,17 @@ is mainly on different emote sources. For that, a separate MSC, [MSC1951](https:
 already exists, so it is reasonable to compare this one with that one:
 
 ### Comparison with MSC1951
-MSC1951 defines a dedicated room as the only emote source. This MSC, however, also allows you to bind emotes
-to your own account, offering greater flexibility. In MSC1951 there can also only be a single emote
-pack in a room. This could be problematic in e.g. bridged rooms: You set some emotes from the matrix
-side and a discord bridge would plop all the discord emotes in another pack in the same room.
+MSC1951 defines a dedicated room as the only image pack source. This MSC, however, also allows you to bind image packs
+to your own account, offering greater flexibility. In MSC1951 there can also only be a single image pack
+pack in a room. This could be problematic in e.g. bridged rooms: You set some emotes or stickers from the matrix
+side and a discord bridge would plop all the discord emotes and stickers in another pack in the same room.
 
 MSC1951 defines a way to recommend using a pack of a different room - this MSC does not have an equivalent
-to that. Instead, this MSC allows multiple emote packs for a room, and allows you to enable an emote
+to that. Instead, this MSC allows multiple image packs for a room, and allows you to enable an image
 pack to be globally available for yourself across all rooms you are in.
 
 The core difference is how MSC1951 and this MSC define the emotes themselves: In MSC1951 you have to
-set one state event *per emote*. While this might seem like a nice idea on the surface, it doesn't
+set one state event *per image*. While this might seem like a nice idea on the surface, it doesn't
 scale well. There are people who easily use and want hundreds or even thousands of emotes accessible.
 A simple dict of shortcode to mxc URI seems more appropriate for this.
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -2,6 +2,26 @@
 
 Emoticons, or short emotes...we need them!
 
+## Terminology
+Since there is a lot of confusion of how this relates to `m.emote`, why this isn't called custom emoji
+etc, there it is:
+
+`m.emtoe` is for emotion - and it has been incorrectly named this way. `m.action` would have been more
+appropriate, as you use it to describe *actions*, not *emotions*. E.g. "/me is walking to the gym", or
+"/me is happy" and *not* "/me happy".
+
+That, however, is *not* what this MSC is about. Instead it is about emoticons, also known in short as
+emotes.
+
+Emoticons are just little images or text describing emotions or other things. Emoji are a subset of
+emoticons, namely those found within unicode. Custom emoji here would actually refer to a custom emoji
+font, that is your own rendering of 🦊, 🐱, etc., *not* new images. New images is what custom emoticons
+are for.
+
+Now, a client may chose to name these however they like, we already have a naming disparity between
+spec and clients with groups vs communities. It is, however, imperative to name things in the spec
+accurately after what they are.
+
 ## Proposal
 Emoticons have at least a shortcode and an mxc uri. They are sent as `<img>` tags currently already in
 the spec, as such existing clients *should* be able to render them (support for this is sadly poor,

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -168,7 +168,9 @@ ordered list where you click an entry), the order of the images should be predic
 The ordering could look as following:
 1. User image pack (images set in your own account)
 2. Image pack rooms (rooms whos image packs you enabled to be accessible everywhere)
-3. Room image packs (images defined in the currently open room)
+3. Space image packs (image packs defined in claimed parents (`m.space.parent`), recursively. Important:
+   clients must make sure to break recursion loops), if the user is in them
+4. Room image packs (images defined in the currently open room)
 
 Furthermore, clients are expected to deduplicate images based on their mxc url. This not only ensures
 that, when viewing a room that you also have in `m.image_pack.rooms`, it won't be displayed twice,

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -162,5 +162,8 @@ set one state event *per emote*. While this might seem like a nice idea on the s
 scale well. There are people who easily use and want hundreds or even thousands of emotes accessible.
 A simple dict of shortcode to mxc URI seems more appropriate for this.
 
+Additionally, this MSC is already used in the wild since about two years by some clients, while MSC1951
+only exists in MSC form, so far.
+
 In general, MSC1951 feels like a heavier approach to emote sourcs, while this MSC is more lightweight
 and thus should allow significantly larger packs.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -137,33 +137,33 @@ pack name and has a blank state key, then "room" is used.
 When sending an `<img>` tag in an end-to-end encrypted room, the client will make a request to fetch
 said image, in this case an emote. As there is no way to encrypt content behind `<img>` tags yet,
 this could potentially leak part of the conversation. This is **not** a new security consideration,
-it already exists. This, however, isn't much different of posting someone a link in an e2ee chat and
+it already exists. This, however, isn't much different from posting someone a link in an e2ee chat and
 the recipient opens the link. Additionally, images, and thus emotes, are often cached by the client,
 not even necessarily leading to an http query.
 
 # Alternatives
 One can easily think of near infinite ways to implement emotes. The aspect of sending an `<img>` tag
-and marking it as an emote with `data-mx-emote` seems to be pretty universal, though, so the question
+and marking it as an emote with `data-mx-emote` seems to be pretty universal though, so the question
 is mainly on different emote sources. For that, a separate MSC, [MSC1951](https://github.com/matrix-org/matrix-doc/pull/1951)
 already exists, so it is reasonable to compare this one with that one:
 
 ## Comparison with MSC1951
-MSC1951 defines as only emote source a dedicated room. This MSC, however, also allows you to bind emotes
+MSC1951 defines a dedicated room as the only emote source. This MSC, however, also allows you to bind emotes
 to your own account, offering greater flexibility. In MSC1951 there can also only be a single emote
 pack in a room. This could be problematic in e.g. bridged rooms: You set some emotes from the matrix
 side and a discord bridge would plop all the discord emotes in another pack in the same room.
 
 MSC1951 defines a way to recommend using a pack of a different room - this MSC does not have an equivalent
-of that. Instead, this MSC allows multiple emote packs for a room, and allows you to enable an emote
-pack to be globally available for yourself accross all rooms you are in.
+to that. Instead, this MSC allows multiple emote packs for a room, and allows you to enable an emote
+pack to be globally available for yourself across all rooms you are in.
 
 The core difference is how MSC1951 and this MSC define the emotes themselves: In MSC1951 you have to
 set one state event *per emote*. While this might seem like a nice idea on the surface, it doesn't
 scale well. There are people who easily use and want hundreds or even thousands of emotes accessible.
 A simple dict of shortcode to mxc URI seems more appropriate for this.
 
-Additionally, this MSC is already used in the wild since about two years by some clients, while MSC1951
-only exists in MSC form, so far.
+Additionally, this MSC has already been used in the wild for roughly two years by some clients, while MSC1951
+only exists in MSC form.
 
 In general, MSC1951 feels like a heavier approach to emote sourcs, while this MSC is more lightweight
-and thus should allow significantly larger packs.
+and thus should allow for significantly larger packs.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -26,7 +26,7 @@ spec and clients with groups vs communities. It is, however, imperative to name 
 accurately after what they are.
 
 ### Stickers
-Stickers already exits in Matrix. They are reusable images one can send, usually as a reaction sent
+Stickers already exist in Matrix. They are reusable images one can send, usually as a reaction sent
 in the timeline to something. This MSC adds a way to distribute and define a source for a client to
 send them.
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -40,7 +40,7 @@ guide exists yet.
 
 ### Room emotes
 Room emotes are per-room emotes that every user of a specific room can use inside of that room. They
-are set with a state event of type `im.ponies-room_emotes` and a blank state key. The contents are
+are set with a state event of type `im.ponies.room_emotes` and a blank state key. The contents are
 the same as for the user emotes.
 
 ## Sending

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -34,15 +34,23 @@ is `im.ponies.user_emotes` (later: `m.emoticons`). The content is as following:
 
 ```json
 {
-  "short": {
-    ":emote:": "mxc://example.org/blah",
-    ":other-emote:": "mxc://example.org/other-blah"
+  "emoticons": {
+    ":emote": {
+      "url": "mxc://example.org/blah"
+    },
+    ":other-emote:": {
+      "url": "mxc://example.org/other-blah"
+    }
   }
 }
 ```
 
-The emotes are defined inside of a dict called `short`, which stands for shortcode. Other, additional
-keys may exist to define more metadata for the emotes. No such guide exists yet.
+The emotes are defined inside of a dict called `emoticons`. The key is the shortcode of the emoticon.
+The value is an object with `url` containing the mxc url of the emote. This is so that it is easier
+for clients or future MSCs to define custom metadata to emotes directly.
+
+Some existing implementations using `im.ponies.user_emotes` currently use a dict called `short` which
+is just a map of the shortcode to the mxc url.
 
 #### Room emoticons
 Room emotes are per-room emotes that every user of a specific room can use inside of that room. They
@@ -51,9 +59,9 @@ pack, whereas the default one would be a blank state key. E.g. a discord bridge 
 `de.sorunome.mx-puppet-bridge.discord` and have all the bridged emotes in said state event, keeping
 bridged emotes from matrix emotes separate.
 
-The content extends that of the user emotes: It uses the `short` key, which is a map of the shortcode
-of the emote to its mxc uri. Additionally, an optional `pack` key can be set, which defines meta-information
-on the pack. The following keys for `pack` are valid:
+The content extends that of the user emotes: It uses the `emoticons` key, which is a map of the shortcode
+of the emote to an object containing its mxc url. Additionally, an optional `pack` key can be set,
+which defines meta-information on the pack. The following keys for `pack` are valid:
 
  - `displayname`: An easy displayname for the pack. Defaults to the room name, if it doesn't exist
  - `avatar_url`: The mxc uri of an avatar/icon to display for the pack. Defaults to the room name,
@@ -68,9 +76,13 @@ As such, a `im.ponies.room_emotes` (later: `m.emoticons`) state event could look
 
 ```json
 {
-  "short": {
-    ":emote:": "mxc://example.org/blah",
-    ":other-emote:": "mxc://example.org/other-blah"
+  "emoticons": {
+    ":emote:": {
+      "url": "mxc://example.org/blah"
+    },
+    ":other-emote:": {
+      "url": "mxc://example.org/other-blah"
+    }
   },
   "pack": {
     "displayname": "Emotes from Discord!",
@@ -79,6 +91,9 @@ As such, a `im.ponies.room_emotes` (later: `m.emoticons`) state event could look
   }
 }
 ```
+
+Similarly as before, there are already existing implementations using `short` which is a map of shortcode
+to mxc url.
 
 #### Emoticon rooms
 While room emotes are specific to a room and are only accessible within that room, emote rooms should

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -43,7 +43,25 @@ Room emotes are per-room emotes that every user of a specific room can use insid
 are set with a state event of type `im.ponies-room_emotes` and a blank state key. The contents are
 the same as for the user emotes.
 
-## Ideas
+## Sending
+In places where fancy tab-complete with the emote itself is not possible it is suggested that sending
+the shortcode will convert to the img tag, e.g. sending `Hey there :wave:` will convert to `Hey there <img-for-wave>`.
+
+If there are collisions due to the same emote shortcode being present as both room emote and user emote
+a user could specify the emote source by writing e.g. `:room~wave:` or `:user~wave:`. Other sources
+could perhaps be added, see ideas section.
+
+# Ideas
  - Tag rooms as "these emotes can be used anywhere" inside of account data somehow
  - Some kind of packs - for room emotes the state key could be used as pack identifier, for user
    emotes something like `im.ponies.user_emotes.<pack_name>`.
+
+# Current implementations
+## Emote rendering (rendering of the `<img>` tag)
+ - riot-web
+ - revolution
+ - nheko
+ - fluffychat
+## Emote sending, using the mentioned state events here
+ - revolution
+ - fluffychat

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -357,7 +357,8 @@ when designing auto-completion UI in the message field (i.e. `:some_emote/my_pac
 
 In addition, the space character is not allowed. This helps avoid common
 usability paper-cuts (multiple spaces between words, spaces at the beginning/end
-of a shortcode). Shortcodes containing multiple words are encouraged to use alterantive separators like hyphens (`-`) or underscores (`_`).
+of a shortcode). Shortcodes containing multiple words are encouraged to use alternative
+separators like hyphens (`-`) or underscores (`_`).
 
 Specifically, the `U+0020` character (normal space) is disallowed. There are
 multiple other byte sequences associated with spaces in Unicode, but as this is
@@ -441,14 +442,14 @@ available emotes.
 
 If there are multiple emotes with the same shortcode available (from multiple
 packs), the client could slugify the containing pack's display name and append
-it to each emote's shortcode, using a `/` to separate shortcode and image pack
-. For instance, the user could enter `:my_emo/my_pack_na:` to quickly surface an
+it to each emote's shortcode, using a `/` to separate shortcode and image pack.
+For instance, the user could enter `:my_emo/my_pack_na:` to quickly surface an
 image with shortcode `my_emote` in the pack `My Pack Name!`.
 
 It's important to note that image pack names aren't globally unique either, so
-even `:my-pack:emote:` could refer to multiple possible emotes. Thus, it is not
+even `:emote/my-pack:` could refer to multiple possible emotes. Thus, it is not
 recommended to add a feature to clients to try and automatically translate
-`:shortcode:` or `:image-pack-name:shortcode:` in the message field to a
+`:shortcode:` or `:shortcode/image-pack-name:` in the message field to a
 specific emote.
 
 A "search modal" or other UI that allows the user to tie-break is the approach

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -316,11 +316,7 @@ based on user preferences.
 
 A shortcode's length MUST not exceed 100 bytes. This is to prevent a
 sufficiently long shortcode from being impossible to insert into subsequent events
-due to exceeding the event limit (e.g. emoji reactions). This restriction MUST be
-enforced by servers when sending reactions, but servers MUST NOT reject events
-coming across federation due to having too many bytes in the shortcode field.
-This avoids a split-brain in the room. Servers MAY opt to locally redact events
-having too many bytes in the shortcode field.
+due to exceeding the event limit (e.g. emoji reactions). 
 
 The `:` character MUST NOT be included in the emote shortcode. The `:` character
 has become synonymous with emotes - oftentimes typing the `:` character in a
@@ -348,6 +344,11 @@ not considered.
 Any other character is explicitly allowed. This allows shortcodes containing
 non-Latin characters for communities of those languages, and ensures
 forwards-compatibility with future Unicode updates.
+
+These restrictions MUST be enforced by servers on the Client-Server API, but MUST
+NOT be enforced over the Federation API (i.e. when validating events received
+over federation). This avoids a split-brain in the room. Servers MAY opt to
+locally redact events having too many bytes in the shortcode field.
 
 ### Sending
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -226,44 +226,6 @@ translates to *all image packs that a room defines*, rather than *no image
 packs*. This is intended as an optimisation to reduce event size versus
 listing the (potentially many) packs a room may have.
 
-"All image packs that a room defines" does not include second-order packs listed
-in `m.image_pack.rooms` state events (defined below) in the room. This is to
-prevent loops when sourcing image packs.
-
-Clients should be aware that users may not be in the room referenced by this
-event, and MAY wish to show appropriate UX around this.
-
-#### `m.image_pack.rooms` state event
-
-This state event can be added to a room in order to reference an existing image
-pack from another room. This allows room administrators to make an image pack
-available to their local community without copying (and continuously updating)
-said packs.
-
-This state event has a similar structure to the equivalent account data event,
-and must have an empty state key:
-
-```json
-{
-  "type": "m.image_pack.rooms",
-  "state_key": "",
-  "content": {
-    "rooms": {
-      "!someroom:example.org": {
-        "": {},
-        "de.sorunome.mx-puppet-bridge.discord": {}
-      },
-      "!someotherroom:example.org": {
-        "": {}
-      }
-    }
-  }
-}
-```
-
-The definition of an empty object under a room ID from the `m.image_pack.rooms`
-account data event holds for this state event as well.
-
 Clients should be aware that users may not be in the room referenced by this
 event, and MAY wish to show appropriate UX around this.
 
@@ -289,9 +251,7 @@ A suggestion for clients of image pack ordering is as follows:
 2. Image pack rooms (defined in the `m.image_pack.rooms` user account data
     object)
 3. Room image packs (defined in the currently open room's state)
-4. Referenced room image packs (defined in the `m.image_pack.rooms` room
-    state event)
-5. Space image packs (defined in the hierarchy of canonical spaces for the
+4. Space image packs (defined in the hierarchy of canonical spaces for the
     current room)
 
 Note: this MSC does not define an ordering for images within packs. That is left
@@ -490,22 +450,12 @@ visible to homeservers.
 There is the potential for the administrator of an image pack, after getting
 users and rooms to add the pack, to add abusive imagery to the pack that
 users will then be exposed to. This is enabled by the `m.image_pack.rooms`
-state and account data events, which allow referencing external image packs.
+account data event, which allows referencing external image packs.
 
-This can be mitigated after the fact depending on how the user's client has
-sourced the offensive images:
+In this case, the user should remove the pack from their global configuration.
 
-1. The user has enabled a pack globally that's defined by a room
-2. The user is suggested a pack by their client as the current room they're
-    typing in references a pack (space, the new `m.image_pack.rooms` state
-    event, etc.)
-
-For 1., the user should remove the pack from their global configuration. For 2.,
-the user should inform the room admin. If the room admin should disappear, then
-this is fairly similar to an attacker spamming a room which has no moderation.
-
-Given the benefits of the features, and the assumption that such an attack has
-limited impact and rarely affects other messaging services, the features are
+Given the benefits of the feature, and the assumption that such an attack has
+limited impact and rarely affects other messaging services, the feature is
 left in.
 
 ## Unstable prefix
@@ -513,7 +463,6 @@ left in.
 | **Stable identifier** | **Unstable identifier** |
 |---|---|
 | `m.image_pack` state event type | `im.ponies.room_emotes` |
-| `m.image_pack.rooms` state event type | `im.ponies.emote_rooms` |
 | `m.image_pack.rooms` account data event type | `im.ponies.emote_rooms` |
 
 ## Potential Issues

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -94,17 +94,6 @@ property with an empty string for an image pack's `state_key`.
 }
 ```
 
-#### `m.image_pack` account data event
-
-A user may store a single, personal image pack within their account data using
-the `m.image_pack` account data event.
-
-The structure of this event is identical to the `m.image_pack` state event,
-other than the lack of a `state_key` field.
-
-`m.image_pack` account data events are exclusive to user account data. They
-should not be placed or searched for in room account data.
-
 #### Pack object
 
 A pack object consists of the following keys:
@@ -181,17 +170,13 @@ Taking all of this into account, a full image pack event may look like:
 
 #### User and room image packs
 
-The user SHOULD be presented with the images in their `m.image_pack` account
-data event while interacting in all rooms.
-
 A room itself can have an unlimited amount of image packs by specifying the
 `m.image_pack` state event with different state keys. By default, the user
 SHOULD be presented with these images only when interacting in the room that
 the packs are defined in.
 
 For a user to enable a room image pack to be presented in all rooms, the room ID
-can be added to a `m.image_pack.rooms` account data event. Note that this is
-separate from the `m.image_pack` account data event defined above.
+can be added to a `m.image_pack.rooms` account data event.
 
 #### `m.image_pack.rooms` account data event
 
@@ -524,7 +509,6 @@ left in.
 | **Stable identifier** | **Unstable identifier** |
 |---|---|
 | `m.image_pack` state event type | `im.ponies.room_emotes` |
-| `m.image_pack` account data event type | `im.ponies.user_emotes` |
 | `m.image_pack.rooms` account data event type | `im.ponies.emote_rooms` |
 
 ## Potential Issues

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -351,12 +351,18 @@ displaying emote shortcodes and others leaving it in, the `:` character is
 barred from the shortcode grammar. This is in attempt to standardise `:` as the
 delimiter character for shortcodes.
 
+Similarly, the `/` character MUST NOT be included in the emote shortcode. This
+character may be used by clients to deliminate between shortcode and image pack
+when designing auto-completion UI in the message field (i.e. `:some_emote/my_pack_slug:`)
+
 In addition, the space character is not allowed. This helps avoid common
 usability paper-cuts (multiple spaces between words, spaces at the beginning/end
-of a shortcode). Shortcodes containing multiple words are encouraged to use alterantive separators like hyphens or underscores.
+of a shortcode). Shortcodes containing multiple words are encouraged to use alterantive separators like hyphens (`-`) or underscores (`_`).
 
 Specifically, the `U+0020` character (normal space) is disallowed. There are
-multiple other byte sequences associated with spaces in Unicode.
+multiple other byte sequences associated with spaces in Unicode, but as this is
+only intended to eliminate a common foot gun, more esoteric space characters are
+not considered.
 
 Any other character is explicitly allowed. This allows shortcodes containing
 non-Latin characters for communities of those languages, and ensures
@@ -430,16 +436,23 @@ non-square emotes.
 ##### Client suggestions
 
 A client could use the `:` delimiter to signify that the user wants to send an
-emote. So, if the user enters `:emote:` in a message, the client could replace
-that text with the corresponding emote based on the shortcode. Likewise, typing
-`:` and then a character could initiate a search action through available
-emotes.
+emote. Typing `:` and then a character could initiate a search action through
+available emotes.
 
-If there are multiple emotes with the same shortcode available, the client could
-for example slugify the containing pack's display name and prepend it to each
-emote's shortcode with a separator character (i.e. `~`). For instance, the user
-could enter `:my-pack~emote:` to select an image with shortcode `emote` in the
-pack `my pack`.
+If there are multiple emotes with the same shortcode available (from multiple
+packs), the client could slugify the containing pack's display name and append
+it to each emote's shortcode, using a `/` to separate shortcode and image pack
+. For instance, the user could enter `:my_emo/my_pack_na:` to quickly surface an
+image with shortcode `my_emote` in the pack `My Pack Name!`.
+
+It's important to note that image pack names aren't globally unique either, so
+even `:my-pack:emote:` could refer to multiple possible emotes. Thus, it is not
+recommended to add a feature to clients to try and automatically translate
+`:shortcode:` or `:image-pack-name:shortcode:` in the message field to a
+specific emote.
+
+A "search modal" or other UI that allows the user to tie-break is the approach
+recommended by this proposal.
 
 #### Stickers
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -384,7 +384,8 @@ lead to unintended network requests.
 
 ##### `alt` attribute
 
-The `alt` attribute MUST be present. Its value SHOULD be the `body` of the emote, or if unavailable, its shortcode.
+Clients SHOULD include the `alt` attribute. Its value SHOULD be the `body` of
+the emote, or if unavailable, its shortcode.
 
 The `alt` attribute's meaning is inherited from the HTML specification:
 <https://html.spec.whatwg.org/multipage/images.html#alt>. It is primarily used
@@ -392,8 +393,8 @@ for accessibility purposes in describing an image for visually impaired users.
 
 ##### `title` attribute
 
-The `title` attribute MUST be present. Its value SHOULD be the shortcode of the
-emote.
+Clients SHOULD include the `title` attribute. Its value SHOULD be the shortcode
+of the emote.
 
 The `title` attribute's meaning is inherited from the HTML specification:
 <https://html.spec.whatwg.org/multipage/dom.html#attr-title>. It is primarily

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -143,14 +143,6 @@ An image object consists of the following keys:
 - `info`: **Optional, ImageInfo**. The already specified
     [`ImageInfo`](https://spec.matrix.org/v1.14/client-server-api/#msticker_imageinfo) 
     object (from `m.sticker`).
-- `usage`: **Optional, Array[String]**. An array of the usages for this
-    image. The possible values match those of the `usage` key of a pack object.
-
-    If present and non-empty, this overrides the usage defined at pack level for
-    this particular image. This is useful to e.g. have one pack contain mixed
-    emotes and stickers. Additionally, as there is only a single account data
-    level image pack, this is required to have a mixture of emotes and stickers
-    available in account data.
 
 An example of an image object:
 
@@ -158,7 +150,6 @@ An example of an image object:
 {
   "url": "mxc://element.io/1c8cac2c949b11649140b446d969d1934c59facf",
   "body": "a lazy cat lays on the floor",
-  "usage": ["sticker"],
   "info": {
     // ... ImageInfo ...
   }
@@ -210,7 +201,7 @@ The `m.image_pack.rooms` account data event consists of the following:
 This data structure allows specifying a single room image pack given the pack's
 room ID and `state_key`.
 
-Clients should make the corresponding room image pack globally accessible in all
+Clients should make the corresponding room image packs globally accessible in all
 rooms.
 
 While this MSC does not define any keys for the bottom-level object, defining it

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -76,7 +76,7 @@ property with an empty string for an image pack's `state_key`.
 
 `m.image_pack` state events contain the following keys within their `content`:
 
-* `images`: **Required, Map[String, Object]**. A map from a shortcode to an [Image Object](#image-object).
+* `images`: **Required, Map[String, Object]**. A map from a shortcode ([grammar](#shortcode-grammar)) to an [Image Object](#image-object).
 * `pack` **Optional, Object**. A [Pack Object](#pack-object).
 
 ```jsonc

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -336,7 +336,9 @@ based on user preferences.
 
 ### Shortcode grammar
 
-A shortcode's length MUST not exceed 100 bytes. This restriction MUST be
+A shortcode's length MUST not exceed 100 bytes. This is to prevent a
+sufficiently long shortcode from being impossible to insert into subsequent events
+due to exceeding the event limit (e.g. emoji reactions). This restriction MUST be
 enforced by servers when sending reactions, but servers MUST NOT reject events
 coming across federation due to having too many bytes in the shortcode field.
 This avoids a split-brain in the room. Servers MAY opt to locally redact events

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -316,39 +316,41 @@ based on user preferences.
 
 A shortcode's length MUST not exceed 100 bytes. This is to prevent a
 sufficiently long shortcode from being impossible to insert into subsequent events
-due to exceeding the event limit (e.g. emoji reactions). 
+due to exceeding the event limit (e.g. emoji reactions).
 
-The `:` character MUST NOT be included in the emote shortcode. The `:` character
-has become synonymous with emotes - oftentimes typing the `:` character in a
-message field will allow one to filter and choose and emote to send.
+A shortcode MUST match the following regular expression:
+`[a-zA-Z0-9-_]+`. Note that this disallows zero-length shortcodes - not least
+because searching for, and indexing, such shortcodes is complicated.
 
-To avoid client fragmentation, with some clients opting to trim `:` when
-displaying emote shortcodes and others leaving it in, the `:` character is
-barred from the shortcode grammar. This is in attempt to standardise `:` as the
-delimiter character for shortcodes.
+The `:` character is specifically not included, as it has become synonymous
+across messaging platforms with searching for emotes - oftentimes typing the `:`
+character in a message field will allow one to filter and choose an emote to
+send.
 
-Similarly, the `/` character MUST NOT be included in the emote shortcode. This
-character may be used by clients to deliminate between shortcode and image pack
-when designing auto-completion UI in the message field (i.e. `:some_emote/my_pack_slug:`)
+Similarly, the `/` character is specifically not included. This character may be
+used by clients to deliminate between shortcode and image pack when designing
+auto-completion UI in the message field (i.e. `:some_emote/my_pack_name:`).
 
-In addition, the space character is not allowed. This helps avoid common
-usability paper-cuts (multiple spaces between words, spaces at the beginning/end
-of a shortcode). Shortcodes containing multiple words are encouraged to use alternative
-separators like hyphens (`-`) or underscores (`_`).
+In addition, the space character is specifically not included. This helps avoid
+common usability paper-cuts (multiple spaces between words, spaces at the
+beginning/end of a shortcode). Shortcodes containing multiple words are
+encouraged to use the alternative separators provided; a hyphen (`-`) or
+an underscore (`_`).
 
-Specifically, the `U+0020` character (normal space) is disallowed. There are
-multiple other byte sequences associated with spaces in Unicode, but as this is
-only intended to eliminate a common foot gun, more esoteric space characters are
-not considered.
+The above character set does exclude characters from non-latin languages from
+being included (e.g. ブイチューバー). This is guard against various edge cases of
+including all of Unicode (control characters, zalgo, future unicode updates,
+etc.) leading to complicated implementations. It is assumed that users of other
+languages are able to type latin characters when necessary.
 
-Any other character is explicitly allowed. This allows shortcodes containing
-non-Latin characters for communities of those languages, and ensures
-forwards-compatibility with future Unicode updates.
+A future MSC could add the concept of "aliases" to images - secondary names,
+which would be any Unicode character, making searching for them with non-latin
+characters easier. 
 
 These restrictions MUST be enforced by servers on the Client-Server API, but MUST
 NOT be enforced over the Federation API (i.e. when validating events received
 over federation). This avoids a split-brain in the room. Servers MAY opt to
-locally redact events having too many bytes in the shortcode field.
+locally redact events that don't follow the shortcode grammar.
 
 ### Sending
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -118,8 +118,10 @@ A pack object consists of the following keys:
     room's avatar.
     Otherwise, the pack does not have an avatar.
 - `usage`: **Optional, Array[String]**. An array of the usages for this pack.
-    Possible usages are `emoticon` and `sticker`. If the usage is absent or
-    empty, all possible usage types are assumed.
+    Possible usages are `emoticon` and `sticker`. If the usage array is absent or
+    empty, all possible usage types are assumed. Client SHOULD use this field to
+    determine when to suggest images to use (i.e. in a sticker picker, emoji
+    picker) from an image pack.
 - `attribution`: **Optional, String**. The attribution for this pack.
 
 An example of a pack object:

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -510,6 +510,7 @@ left in.
 | **Stable identifier** | **Unstable identifier** |
 |---|---|
 | `m.image_pack` state event type | `im.ponies.room_emotes` |
+| `m.image_pack.rooms` state event type | `im.ponies.emote_rooms` |
 | `m.image_pack.rooms` account data event type | `im.ponies.emote_rooms` |
 
 ## Potential Issues

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -312,6 +312,10 @@ NOT be enforced over the Federation API (i.e. when validating events received
 over federation). This avoids a split-brain in the room. Servers MAY opt to
 locally redact events that don't follow the shortcode grammar.
 
+Clients SHOULD enforce this grammar as well when creating or editing image
+packs. Clients SHOULD ignore/hide image packs that contain an image with an
+invalid shortcode.
+
 ### Sending
 
 #### Custom emotes

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -451,6 +451,8 @@ the image, or if absent, an empty object.
 
 ## Security Considerations
 
+### Encrypted image packs
+
 This MSC considers that image packs, and the images contained within them, are
 not encrypted. That means media included in image packs cannot be hidden from
 the homeserver. That is a privacy and security concern.
@@ -484,6 +486,29 @@ Ultimately end-to-end encryption of image packs or emoticons is purposefully
 not within the scope of this MSC. That being said, clients SHOULD warn users
 that images in image packs sent in E2EE rooms are not encrypted and thus
 visible to homeservers.
+
+### Abusive images in packs
+
+There is the potential for the administrator of an image pack, after getting
+users and rooms to add the pack, to add abusive imagery to the pack that
+users will then be exposed to. This is enabled by the `m.image_pack.rooms`
+state and account data events, which allow referencing external image packs.
+
+This can be mitigated after the fact depending on how the user's client has
+sourced the offensive images:
+
+1. The user has enabled a pack globally that's defined by a room
+2. The user is suggested a pack by their client as the current room they're
+    typing in references a pack (space, the new `m.image_pack.rooms` state
+    event, etc.)
+
+For 1., the user should remove the pack from their global configuration. For 2.,
+the user should inform the room admin. If the room admin should disappear, then
+this is fairly similar to an attacker spamming a room which has no moderation.
+
+Given the benefits of the features, and the assumption that such an attack has
+limited impact and rarely affects other messaging services, the features are
+left in.
 
 ## Unstable prefix
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -254,6 +254,8 @@ Some other implementations currently also call the `images` key `emoticons`.
 
 ## Potential Issues
 
+### Multiple usages per pack complicates pack management client UI
+
 It's possible that allowing a pack to have multiple usages can complicate implementing UI for managing packs. 
 This was considered acceptable, as the benefit of being able to use a single pack in multiple contexts, as 
 well as this MSC originally allowing multiple usages-per-pack for much of its implementation lifespan, were 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -83,11 +83,13 @@ a height of 32, this is to ensure that emotes still look good on higher DPI scre
 
 Stickers SHOULD be at least 512x512 pixels, for the same reason.
 
-Furthermore, these images SHOULD either have a mimetype of `image/png`, `image/gif` or `image/webp`.
-They can be animated.
+Images filetypes are not limited by this proposal. Instead they are
+equivalent to the formats allowed in an
+[`m.image`](https://spec.matrix.org/v1.11/client-server-api/#mimage) event. As
+of writing, no limitations for `m.image` are currently defined (see [this spec
+issue](https://github.com/matrix-org/matrix-spec/issues/453)).
 
-Due to the low resolution of emotes, `image/jpg` and `image/jpeg` have been purposefully excluded from this
-list.
+Emoticons and stickers may be animated.
 
 ### Image pack event
 The image pack event has a type of `m.image_pack`. It contains a key `images`, which is a map from a

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -117,7 +117,7 @@ A pack object consists of the following keys:
     for the pack. If unset, and the pack is within a room, defaults to the
     room's avatar.
     Otherwise, the pack does not have an avatar.
-- `usage`: **Optional, Array of String**. An array of the usages for this pack.
+- `usage`: **Optional, Array[String]**. An array of the usages for this pack.
     Possible usages are `emoticon` and `sticker`. If the usage is absent or
     empty, all possible usage types are assumed.
 - `attribution`: **Optional, String**. The attribution for this pack.
@@ -351,11 +351,13 @@ their own messages.
 The `height` attribute MUST be present. This maintains backwards-compatibility
 with clients that do not support custom emotes.
 
-Clents SHOULD set `height` to "32px". This is a default that looks good on most
-devices. In practice, receiving clients are expected to override the height when
-rendering emotes based on their particular environment (the user's font size,
-etc.). Or they may choose to display messages containing only emoticons in a
-larger font.
+Clents SHOULD set `height` to "32px". This is a default intended to look good on
+most devices, and is for the benefit of legacy clients that do not treat custom
+emotes differently from other inline images.
+
+Clients implementing this MSC are expected to override the height when rendering
+emotes, based on their particular environment (the user's font size, etc.). Or
+they may choose to display messages containing only emoticons in a larger font.
 
 A `width` attribute is not required, in order to maintain the aspect ratio of
 non-square emotes.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -85,10 +85,10 @@ property with an empty string for an image pack's `state_key`.
   "state_key": "Blobcats",
   "content": {
     "images": {
-      "blob_amused": { ... Image Object ... },
-      "blob_angel": { ... Image Object ... }
+      "blob_amused": { /* ... Image Object ... */ },
+      "blob_angel": { /* ... Image Object ... */ }
     },
-    "pack": { ... Pack Object ... }
+    "pack": { /* ... Pack Object ... */ }
   },
   // ...
 }

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -105,7 +105,7 @@ The image object consists of the following keys:
    `m.sticker` events.
  - `usage`: (String[], optional) An array of the usages for this image. The possible values match those
    of the `usage` key of a pack object. If present and non-empty, this overrides the usage defined at
-   pack level for this particular image. This is useful to e.g. have one pack contain mixed emotees and
+   pack level for this particular image. This is useful to e.g. have one pack contain mixed emotes and
    stickers. Additionally, as there is only a single account data level image pack, this is required to
    have a mixture of emotes and stickers available in account data.
 
@@ -156,7 +156,7 @@ the `m.image_pack.rooms` key in a user's account data. The value is an object, w
 a map of room ids to the state keys to an object. If a room id / state key combination is provided in this form,
 clients should make the corresponding room image pack globally accessible in all rooms.
 
-Note that while this MSC does not define any keys for the bottom-level object, definint it as an object means greater
+Note that while this MSC does not define any keys for the bottom-level object, defining it as an object means greater
 flexibility in the case of future changes.
 
 The contents of `m.image_pack.rooms` could look like the following:
@@ -180,7 +180,7 @@ Here three emote packs are globally accessible to the user: Two defined in `!som
 `!someotherroom:example.org` (with a blank state key).
 
 ### Image pack source priority and deduplicating
-If a client gives image suggestions (emotes, stickers) to the user in some ordered fassion (e.g. an
+If a client gives image suggestions (emotes, stickers) to the user in some ordered fashion (e.g. an
 ordered list where you click an entry), the order of the images should be predictable between rooms.
 A suggestion for clients of image pack ordering is as follows:
 1. User image pack (defined in your own account data)
@@ -189,7 +189,7 @@ A suggestion for clients of image pack ordering is as follows:
 4. Room image packs (defined in the currently open room's state)
 
 Furthermore, clients are expected to de-duplicate images so that same images are not displayed multiple
-times. Such scenarios includ e.g.:
+times. Such scenarios include:
 1. when viewing a room that has a pack defined in the `m.image_pack.rooms` account data object, and
 2. a bot which syncs emotes over multiple rooms.
 
@@ -197,14 +197,14 @@ This could be done by deduplicating by the mxc URI.
 
 ### Sending
 #### Emoticons
-For emoticons a client could add deliminators (e.g. `:`) around the image shortcode, meaning
+For emoticons a client could add delimiters (e.g. `:`) around the image shortcode, meaning
 that if an image has a shortcode of `emote`, the user can enter `:emote:` to send it. If there are
 multiple emoticons with the same shortcode in a room, the client could e.g. slugify the packs display
 name and then have the user enter `:slug~emote:`. As slugs typically match `^[\w-]+$`, that should
 ensure complete-ability.
 
 The alt / title text for the `<img>` tag is expected to be the `body` of the emote. If absent, its
-shotcode should be used instead.
+shortcode should be used instead.
 
 #### Stickers
 When sending a sticker, the `body` of the `m.sticker` event should be set to the `body` defined for that

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -234,6 +234,61 @@ An example of a `m.image_pack.rooms` account data event:
 }
 ```
 
+Note that an empty object under a room ID, for example:
+
+```json
+{
+  "rooms": {
+    "!someroom:example.org": {}
+  }
+}
+```
+
+translates to *all image packs that a room defines*, rather than *no image
+packs*. This is intended as an optimisation to reduce event size versus
+listing the (potentially many) packs a room may have.
+
+"All image packs that a room defines" does not include second-order packs listed
+in `m.image_pack.rooms` state events (defined below) in the room. This is to
+prevent loops when sourcing image packs.
+
+Clients should be aware that users may not be in the room referenced by this
+event, and MAY wish to show appropriate UX around this.
+
+#### `m.image_pack.rooms` state event
+
+This state event can be added to a room in order to reference an existing image
+pack from another room. This allows room administrators to make an image pack
+available to their local community without copying (and continuously updating)
+said packs.
+
+This state event has a similar structure to the equivalent account data event,
+and must have an empty state key:
+
+```json
+{
+  "type": "m.image_pack.rooms",
+  "state_key": "",
+  "content": {
+    "rooms": {
+      "!someroom:example.org": {
+        "": {},
+        "de.sorunome.mx-puppet-bridge.discord": {}
+      },
+      "!someotherroom:example.org": {
+        "": {}
+      }
+    }
+  }
+}
+```
+
+The definition of an empty object under a room ID from the `m.image_pack.rooms`
+account data event holds for this state event as well.
+
+Clients should be aware that users may not be in the room referenced by this
+event, and MAY wish to show appropriate UX around this.
+
 #### Space image packs
 
 Clients SHOULD suggest image packs of a room's canonical space, if the user is
@@ -258,6 +313,8 @@ A suggestion for clients of image pack ordering is as follows:
 3. Space image packs (defined in the hierarchy of canonical spaces for the
     current room)
 4. Room image packs (defined in the currently open room's state)
+5. Referenced room image packs (defined in the `m.image_pack.rooms` room
+    state event)
 
 Note: this MSC does not define an ordering for images within packs. That is left
 to a future MSC.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -1,8 +1,16 @@
 # MSC2545: Image Packs (Emoticons & Stickers)
 
-Emoticons, or short emotes...we need them!
+Custom emoticons and stickers have become commonplace in modern messaging apps.
+They allow users to express themselves in ways that words, nor the
+standard Unicode set cannot. And they can be functional, allowing bots to convey
+meaning with custom symbols in messages or reactions.
 
-We also need proper stickers, too!
+If Matrix is to remain both a fun and useful messaging protocol, as well as a
+flexible platform for bridging into other protocols, support for custom
+emoticons and stickers are a must.
+
+This proposal outlines how custom emoticons and stickers can both be sent into
+rooms, as well as organised into "packs" and shared between users.
 
 ## Terminology
 ### Emoticons

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -241,6 +241,14 @@ it already exists. This, however, isn't much different from posting someone a li
 the recipient opens the link. Additionally, images, and thus emotes, are often cached by the client,
 not even necessarily leading to a http query.
 
+This MSC considers that imag epacks are not encrypted and that is a privacy and security concern.
+
+Encrypting image packs is dependent on encrypted state events being implemented in the protocol, potentially 
+by MSC3414 or another MSC.
+
+End to End Encryption isn't in the scope of this MSC. Clients should warn users that images in image packs 
+sent in E2EE rooms are not encrypted and thus visible to homeservers.
+
 Related issue: https://github.com/matrix-org/matrix-doc/issues/2418
 
 ## Unstable prefix

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -67,12 +67,12 @@ To send stickers, the already spec'd
 used.
 
 ### Image types
-Emoticons are recommended to have a size of about 128x128 pixels. Even though the fallback specifies
-a height of 32, this is to ensure that the emotes still look good on higher DPI screens.
+Emoticons SHOULD be at least 128x128 pixels. Even though the fallback specifies
+a height of 32, this is to ensure that emotes still look good on higher DPI screens.
 
-Stickers are recommended to have a size of up to 512x512 pixels.
+Stickers SHOULD be at least 512x512 pixels, for the same reason.
 
-Furthermore, these images should either have a mimetype of `image/png`, `image/gif` or `image/webp`.
+Furthermore, these images SHOULD either have a mimetype of `image/png`, `image/gif` or `image/webp`.
 They can be animated.
 
 Due to the low resolution of emotes, `image/jpg` and `image/jpeg` have been purposefully excluded from this

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -51,16 +51,18 @@ improved UX. Their meaning is inherited from the HTML specification
 [title](https://html.spec.whatwg.org/multipage/dom.html#attr-title)).
 
 The `height` is just a height that looks good on most devices with the normal, default font size.
-No width is displayed as to not weirdly squish non-square emotes. In order to maintain backwards-compatibility
+No width is displayed as to not squish non-square emotes. In order to maintain backwards-compatibility
 with clients not supporting emotes, specifying the `height` is required.
 
-If the new `data-mx-emoticon` attribute has a value, it is ignored. Due to limitations of some libraries
+If the new `data-mx-emoticon` attribute has a value, that value is ignored. Due to limitations of some libraries
 the attribute may even look like `data-mx-emoticon=""`.
 
-The `src` attribute *must* be a mxc url. Other URIs, such as `https`, `mailto` etc. are not allowed.
+The `src` attribute *must* be a mxc URI. Other URIs, such as `https`, `mailto` etc. are not allowed.
 
 ### Sending stickers
-To send stickers, the already spec'd `m.sticker` is used.
+To send stickers, the already spec'd
+[`m.sticker`](https://spec.matrix.org/v1.11/client-server-api/#msticker) is
+used.
 
 ### Image types
 Emoticons are recommended to have a size of about 128x128 pixels. Even though the fallback specifies

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -234,22 +234,36 @@ The `info` object of the `m.sticker` event should be set to the `info` object of
 an empty object.
 
 ## Security Considerations
-When sending an `<img>` tag in an encrypted room, the client will make a request to fetch
-said image, in this case an emote. As there is no way to encrypt content behind `<img>` tags yet,
-this could potentially leak part of the conversation. This is **not** a new security consideration,
-it already exists. This, however, isn't much different from posting someone a link in an e2ee chat and
-the recipient opens the link. Additionally, images, and thus emotes, are often cached by the client,
-not even necessarily leading to a http query.
 
-This MSC considers that imag epacks are not encrypted and that is a privacy and security concern.
+This MSC considers that image packs, and the images contained within them, are
+not encrypted. That means media included in image packs cannot be hidden from the
+homeserver. That is a privacy and security concern.
 
-Encrypting image packs is dependent on encrypted state events being implemented in the protocol, potentially 
-by MSC3414 or another MSC.
+In addition, a homeserver could deduce from traffic patterns that an encrypted
+event contains a certain emoticon by correlating the time an event was sent with
+other local, participating user's access requests to a particular piece of media.
+This is not a new concern, as the same attack can be performed for links sent in
+a chat with URL previews enabled in clients. In addition, caching of images across
+clients can help with reducing the need to download the media again.
 
-End to End Encryption isn't in the scope of this MSC. Clients should warn users that images in image packs 
-sent in E2EE rooms are not encrypted and thus visible to homeservers.
+Encrypting image packs is dependent on encrypted state events being implemented
+in the protocol; potentially by MSC3414 or another MSC.
 
-Related issue: https://github.com/matrix-org/matrix-doc/issues/2418
+Once encrypted state events are implemented, images could be encrypted before upload
+with a symmetric key included within the encrypted state event. Then, said key will
+be sent within the `<img>` tag emoticons are sent in, allowing other clients to download
+and decrypt the media. [This matrix-spec
+issue](https://github.com/matrix-org/matrix-doc/issues/2418) calls for standardising
+this behaviour for any kind of inline image.
+
+Encrypted emoticons sent in *non-E2EE* rooms would leak these keys, but this may be deemed
+acceptable as many emoticons would not be leaked. Plus, it still raises the barrier for
+homeserver operators to implement tooling to browse messages in E2EE rooms.
+
+Ultimately end-to-end encryption of image packs or emoticons is purposefully
+not within the scope of this MSC. That being said, clients SHOULD warn users
+that images in image packs sent in E2EE rooms are not encrypted and thus
+visible to homeservers.
 
 ## Unstable prefix
 The `m.image_pack` in the account data is replaced with `im.ponies.user_emotes`. The `m.image_pack` in

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -21,9 +21,9 @@ emoticons, namely those found within unicode. Custom emoji here would actually r
 font, that is your own rendering of 🦊, 🐱, etc., *not* new images. New images is what custom emoticons
 are for.
 
-Now, a client may choose to name these however they like. We already have a naming disparity between
-spec and clients with groups vs communities. It is, however, imperative to name things in the spec
-accurately after what they are.
+Now, a client may choose to name these however they like. In the spec's history,
+it has had naming disparity with clients, i.e. "groups" vs "communities". It is,
+however, imperative to name things in the spec accurately after what they are.
 
 ### Stickers
 Stickers already exist in Matrix. They are reusable images one can send, usually as a reaction to

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -58,9 +58,12 @@ improved UX. Their meaning is inherited from the HTML specification
 ([alt](https://html.spec.whatwg.org/multipage/images.html#alt),
 [title](https://html.spec.whatwg.org/multipage/dom.html#attr-title)).
 
-The `height` is just a height that looks good on most devices with the normal, default font size.
-No width is displayed as to not squish non-square emotes. In order to maintain backwards-compatibility
-with clients not supporting emotes, specifying the `height` is required.
+The `height` SHOULD be set to "32px". This is a default that looks good on most
+devices. In practice, receiving clients are expected to override the height when
+rendering emotes based on their particular environment (the user's font size,
+etc.). In order to maintain backwards-compatibility with clients that do not
+support emotes, specifying the `height` is required. No width is specified as to
+maintain the aspect ratio of non-square emotes. 
 
 If the new `data-mx-emoticon` attribute has a value, that value is ignored. Due to limitations of some libraries
 the attribute may even look like `data-mx-emoticon=""`.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -54,8 +54,9 @@ servers when sending reactions, but servers should not reject events coming acro
 too many bytes in the shortcode field. Servers may still opt to locally redact events having too many bytes 
 in the shortcode field.
 
-The : character MUST NOT be included in the emote shortcode, so as not to end up with fragmentation with 
-some clients removing : from the UI.
+The `:` character MUST NOT be included in the emote shortcode, so as not to end up with fragmentation with 
+some clients removing `:` from the UI. Other than `:`, any other character is explicitly allowed so that 
+we do not exclude languages which do not use the Latin alphabet.
 
 ```html
 <img data-mx-emoticon src="mxc://example.org/emote" alt="emote" title="emote" height="32" />

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -45,9 +45,10 @@ could look as follows:
 <img data-mx-emoticon src="mxc://example.org/emote" alt=":emote:" title=":emote:" height="32" />
 ```
 
-Both the `alt` and the `title` attributes are specified as they serve different purposes: `alt` is
-displayed if e.g. the emote does not load. `title` is displayed e.g. on mouse hover over the emote.
-Thus, specifying both the `alt` and `title` attributes is required.
+`alt` and `title` are required attributes for their roles in accessibility and
+improved UX. Their meaning is inherited from the HTML specification
+([alt](https://html.spec.whatwg.org/multipage/images.html#alt),
+[title](https://html.spec.whatwg.org/multipage/dom.html#attr-title)).
 
 The `height` is just a height that looks good on most devices with the normal, default font size.
 No width is displayed as to not weirdly squish non-square emotes. In order to maintain backwards-compatibility

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -49,8 +49,16 @@ display messages with only emoticons and emoji as larger than usual, which is co
 messengers. Such an `<img>` tag of a shortcode `emote` and a mxc uri `mxc://example.org/emote`
 could look as follows:
 
+The shortcode must have a length of less than or equal to 100 bytes. This restriction must be enforced by 
+servers when sending reactions, but servers should not reject events coming across federation due to having 
+too many bytes in the shortcode field. Servers may still opt to locally redact events having too many bytes 
+in the shortcode field.
+
+The : character MUST NOT be included in the emote shortcode, so as not to end up with fragmentation with 
+some clients removing : from the UI.
+
 ```html
-<img data-mx-emoticon src="mxc://example.org/emote" alt=":emote:" title=":emote:" height="32" />
+<img data-mx-emoticon src="mxc://example.org/emote" alt="emote" title="emote" height="32" />
 ```
 
 `alt` and `title` are required attributes for their roles in accessibility and
@@ -197,7 +205,7 @@ Here three emote packs are globally accessible to the user: Two defined in `!som
 (one with blank state key and one with state key `de.sorunome.mx-puppet-bridge.discord`) and one in
 `!someotherroom:example.org` (with a blank state key).
 
-### Image pack source priority and deduplicating
+### Image pack source priority
 If a client gives image suggestions (emotes, stickers) to the user in some ordered fashion (e.g. an
 ordered list where you click an entry), the order of the images should be predictable between rooms.
 A suggestion for clients of image pack ordering is as follows:
@@ -205,13 +213,6 @@ A suggestion for clients of image pack ordering is as follows:
 2. Image pack rooms (defined in the `m.image_pack.rooms` account data object)
 3. Space image packs (defined in the hierarchy of canonical spaces for the current room)
 4. Room image packs (defined in the currently open room's state)
-
-Furthermore, clients are expected to de-duplicate images so that same images are not displayed multiple
-times. Such scenarios include:
-1. when viewing a room that has a pack defined in the `m.image_pack.rooms` account data object, and
-2. a bot which syncs emotes over multiple rooms.
-
-This could be done by deduplicating by the mxc URI.
 
 ### Sending
 #### Emoticons

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -40,8 +40,8 @@ send them.
 
 ## Proposal
 ### Emoticons in the formatted body
-Emoticons have at least a shortcode and a mxc uri. They are sent as `<img>` tags, which are currently in
-the spec. As such, many existing clients are able to render them.
+Emoticons have at least a shortcode and a mxc uri. A shortcode is a short identifier for an emoji. They 
+are sent as `<img>` tags, which are currently in the spec. As such, many existing clients are able to render them.
 To allow clients to distinguish emoticons from other inline images, a new
 property, `data-mx-emoticon`, is introduced. A client can choose to ignore the size attributes of emoticons
 when rendering, and instead pick the size based on other circumstances. This could e.g. be used to

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -261,6 +261,11 @@ This was considered acceptable, as the benefit of being able to use a single pac
 well as this MSC originally allowing multiple usages-per-pack for much of its implementation lifespan, were 
 considered to outweigh the alternative.
 
+### Event size limits
+
+Due to size limitations of events (65535 bytes), image packs are limted to around 400 emotes per pack. This 
+has been deemed sufficient for the vast majority of use cases.
+
 ## Alternatives
 One can easily think of near infinite ways to implement emotes. The aspect of sending an `<img>` tag
 and marking it as an emote with `data-mx-emoticon` seems to be pretty universal though, so the question

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -301,3 +301,7 @@ custom emoticons. Each warrant an MSC for themselves however, as they touch more
  - Allow SVGs in the `<img>` tag. Current problem: Clients typically try to thumbnail the mxc URL,
    and most media repositories can't thumbnail SVGs. Possible solution: Somehow embed the mimetype.
  - For stickers: Recommend rendering sizes / resolutions
+
+## Dependencies
+
+This MSC does not depend on any other MSCs.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -57,7 +57,9 @@ with clients not supporting emotes, specifying the `height` is required.
 If the new `data-mx-emoticon` attribute has a value, that value is ignored. Due to limitations of some libraries
 the attribute may even look like `data-mx-emoticon=""`.
 
-The `src` attribute *must* be a mxc URI. Other URIs, such as `https`, `mailto` etc. are not allowed.
+The `src` attribute *must* be a mxc URI. Other URI schemes, such as `https`,
+`mailto` etc. are not allowed. Clients MUST NOT attempt to render images
+accessible through other URI schemes.
 
 ### Sending stickers
 To send stickers, the already spec'd

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -1,8 +1,10 @@
 # MSC2545: Image Packs (Emoticons & Stickers)
 
+## Introduction
+
 Custom emoticons and stickers have become commonplace in modern messaging apps.
-They allow users to express themselves in ways that words, nor the
-standard Unicode set cannot. And they can be functional, allowing bots to convey
+They allow users to express themselves in ways that words - nor the
+standard Unicode set - cannot. And they can be functional, allowing bots to convey
 meaning with custom symbols in messages or reactions.
 
 If Matrix is to remain both a fun and useful messaging protocol, as well as a
@@ -12,132 +14,159 @@ emoticons and stickers are a must.
 This proposal outlines how custom emoticons and stickers can both be sent into
 rooms, as well as organised into "packs" and shared between users.
 
-## Terminology
-### Emoticons
-Since there is a lot of confusion of how this relates to `m.emote`, why this isn't called "custom emoji"
-etc,:
-
-`m.emote` is for emotion - and it has been incorrectly named this way. `m.action` would have been more
-appropriate, as you use it to describe *actions*, not *emotions*. E.g. "/me is walking to the gym", or
-"/me is happy" and *not* "/me happy".
-
-That, however, is *not* what this MSC is about. Instead, it is about emoticons, also known in short as
-emotes.
-
-Emoticons are just little images or text describing emotions or other things. Emoji are a subset of
-emoticons, namely those found within unicode. Custom emoji here would actually refer to a custom emoji
-font, that is your own rendering of 🦊, 🐱, etc., *not* new images. New images is what custom emoticons
-are for.
-
-Now, a client may choose to name these however they like. In the spec's history,
-it has had naming disparity with clients, i.e. "groups" vs "communities". It is,
-however, imperative to name things in the spec accurately after what they are.
-
-### Stickers
-Stickers already exist in Matrix. They are reusable images one can send, usually as a reaction to
-something sent in the timeline. This MSC adds a way to distribute and define a source for a client to
-send them.
-
 ## Proposal
-### Emoticons in the formatted body
-Emoticons have at least a shortcode and a mxc uri. A shortcode is a short identifier for an emoji. They 
-are sent as `<img>` tags, which are currently in the spec. As such, many existing clients are able to render them.
-To allow clients to distinguish emoticons from other inline images, a new
-property, `data-mx-emoticon`, is introduced. A client can choose to ignore the size attributes of emoticons
-when rendering, and instead pick the size based on other circumstances. This could e.g. be used to
-display messages with only emoticons and emoji as larger than usual, which is commonly found in
-messengers. Such an `<img>` tag of a shortcode `emote` and a mxc uri `mxc://example.org/emote`
-could look as follows:
 
-The shortcode must have a length of less than or equal to 100 bytes. This restriction must be enforced by 
-servers when sending reactions, but servers should not reject events coming across federation due to having 
-too many bytes in the shortcode field. Servers may still opt to locally redact events having too many bytes 
-in the shortcode field.
+### Terminology
 
-The `:` character MUST NOT be included in the emote shortcode, so as not to end up with fragmentation with 
-some clients removing `:` from the UI. Other than `:`, any other character is explicitly allowed so that 
-we do not exclude languages which do not use the Latin alphabet.
+#### Emoticons and emotes
 
-```html
-<img data-mx-emoticon src="mxc://example.org/emote" alt="emote" title="emote" height="32" />
+There is confusion around how this relates to [`m.emote`
+msgtype](https://spec.matrix.org/v1.14/client-server-api/#mroommessage-msgtypes)
+as well as why this proposal isn't called "custom emoji", etc.
+
+In short, `m.emote` is for emotion - and it has been incorrectly named this way.
+`m.action` would have been more appropriate, as you use it to describe
+*actions*, not *emotions*. E.g. "/me is walking to the gym", or "/me is happy"
+and *not* "/me happy".
+
+That, however, is not what this MSC is about. Instead, it is about emoticons,
+also known in short as "emotes".
+
+Emotes are images or text describing emotions or other things. Emoji are a
+subset of emotes, namely those found within the Unicode spec. Custom emoji,
+therefore, would actually refer to a custom emoji font; one's own rendering of
+Unicode's 🦊, 🐱, etc. This differs from new images; which is what custom
+emoticons are for.
+
+A client may of course choose to name these however they like. In the spec's
+history, it has had naming disparity with clients, i.e. "groups" vs
+"communities". It is, however, imperative to name things in the spec accurately
+after what they are.
+
+#### Stickers
+
+Stickers already exist in Matrix (see the [`m.sticker` event
+type](https://spec.matrix.org/v1.14/client-server-api/#msticker). They are
+reusable images one can send; typically as a reaction to something sent in the
+timeline. The value this MSC brings to stickers is creating a mechanism to
+distribute them, such that a client can surface them to a user to choose and
+send.
+
+#### Shortcodes
+
+A "shortcode" is a short, unique identifier for an emote or a sticker.
+
+A shortcode is NOT intended to be a visual description of an image, often to
+aide the visually impaired. That is more suitable to the `body` field; defined
+as part of an "Image object" below and on
+[`m.sticker`](https://spec.matrix.org/v1.14/client-server-api/#msticker) events.
+
+### Image packs
+
+Part of the joy of custom emotes (and stickers) is to be able to organise them
+into packs and share these packs with others. This proposal defines a mechanism
+for doing so.
+
+#### `m.image_pack` state event
+
+Image packs are defined by a new state event with type `m.image_pack`. The
+`state_key` is simply a unique identifier for the pack itself. It is not
+intended to be surfaced to users. This proposal does not associate any special
+property with an empty string for an image pack's `state_key`.
+
+`m.image_pack` state events contain the following keys within their `content`:
+
+* `images`: **Required, Map[String, Object]**. A map from a shortcode to an Image Object.
+* `pack`" **Optional, Object**. A Pack Object.
+
+```jsonc
+{
+  "type": "m.image_pack",
+  "state_key": "Blobcats",
+  "content": {
+    "images": {
+      "blob_amused": { ... Image Object ... },
+      "blob_angel": { ... Image Object ... }
+    },
+    "pack": { ... Pack Object ... }
+  },
+  // ...
+}
 ```
 
-`alt` and `title` are required attributes for their roles in accessibility and
-improved UX. Their meaning is inherited from the HTML specification
-([alt](https://html.spec.whatwg.org/multipage/images.html#alt),
-[title](https://html.spec.whatwg.org/multipage/dom.html#attr-title)).
+#### `m.image_pack` account data event
 
-The `height` SHOULD be set to "32px". This is a default that looks good on most
-devices. In practice, receiving clients are expected to override the height when
-rendering emotes based on their particular environment (the user's font size,
-etc.). In order to maintain backwards-compatibility with clients that do not
-support emotes, specifying the `height` is required. No width is specified as to
-maintain the aspect ratio of non-square emotes. 
+A user may store a single, personal image pack within their account data using
+the `m.image_pack` account data event.
 
-If the new `data-mx-emoticon` attribute has a value, that value is ignored. Due to limitations of some libraries
-the attribute may even look like `data-mx-emoticon=""`.
+The structure of this event is identical to the `m.image_pack` state event,
+other than the lack of a `state_key` field.
 
-The `src` attribute *must* be a mxc URI. Other URI schemes, such as `https`,
-`mailto` etc. are not allowed. Clients MUST NOT attempt to render images
-accessible through other URI schemes.
-
-### Sending stickers
-To send stickers, the already spec'd
-[`m.sticker`](https://spec.matrix.org/v1.11/client-server-api/#msticker) is
-used.
-
-### Image types
-Emoticons SHOULD be at least 128x128 pixels. Even though the fallback specifies
-a height of 32, this is to ensure that emotes still look good on higher DPI screens.
-
-Stickers SHOULD be at least 512x512 pixels, for the same reason.
-
-Images filetypes are not limited by this proposal. Instead they are
-equivalent to the formats allowed in an
-[`m.image`](https://spec.matrix.org/v1.11/client-server-api/#mimage) event. As
-of writing, no limitations for `m.image` are currently defined (see [this spec
-issue](https://github.com/matrix-org/matrix-spec/issues/453)).
-
-Emoticons and stickers may be animated.
-
-### Image pack event
-The image pack event has a type of `m.image_pack`. It contains a key `images`, which is a map from a
-short code to an image object. It may also contain a key `pack`, which is a pack object, described in
-the following section.
+`m.image_pack` account data events are exclusive to user account data. They
+should not be placed or searched for in room account data.
 
 #### Pack object
-The pack object consists of the following keys:
- - `display_name`: (String, optional) A display name for the pack. Defaults to the room name, if the
-   image pack event is in the room. This does not have to be unique from other packs in a room.
- - `avatar_url`: (String, optional) The mxc uri of an avatar/icon to display for the pack. Defaults
-   to the room avatar, if the pack is in the room. Otherwise, the pack does not have an avatar.
- - `usage`: (String[], optional) An array of the usages for this pack. Possible usages are `"emoticon"`
-   and `"sticker"`. If the usage is absent or empty, a usage for all possible usage types is to be assumed.
- - `attribution`: (String, optional) The attribution of this pack.
 
-Example:
+A pack object consists of the following keys:
+
+- `display_name`: **Optional, String**. A display name for the pack.
+    If unset, and the pack event is within a room, defaults to the room's name.
+    Otherwise, the pack does not have a name.
+    This does not have to be unique from other packs in a room.
+- `avatar_url`: **Optional, String**. The MXC uri of an avatar/icon to display
+    for the pack. If unset, and the pack is within a room, defaults to the
+    room's avatar.
+    Otherwise, the pack does not have an avatar.
+- `usage`: **Optional, Array of String**. An array of the usages for this pack.
+    Possible usages are `emoticon` and `sticker`. If the usage is absent or
+    empty, all possible usage types are assumed.
+- `attribution`: **Optional, String**. The attribution for this pack.
+
+An example of a pack object:
+
 ```json
 {
   "display_name": "Awesome Pack",
-  "usage": ["emoticon"]
+  "avatar_url": "mxc://element.io/6130836e26b462a6fe63d4e080dd9d2037490f2b",
+  "usage": ["emoticon"],
+  "attribution": "From https://commons.wikimedia.org/wiki/Category:Blob_emoji and various Fediverse instances"
 }
 ```
 
 #### Image object
-The image object consists of the following keys:
- - `url`: (String, required) The mxc URL for this image.
- - `body`: (String, optional) An optional text body for this image. Useful for the sticker body text or
-   the emote alt text. Defaults to the shortcode.
- - `info`: (`ImageInfo`, optional) The already spec'd `ImageInfo` object used for the `info` block of
-   `m.sticker` events.
- - `usage`: (String[], optional) An array of the usages for this image. The possible values match those
-   of the `usage` key of a pack object. If present and non-empty, this overrides the usage defined at
-   pack level for this particular image. This is useful to e.g. have one pack contain mixed emotes and
-   stickers. Additionally, as there is only a single account data level image pack, this is required to
-   have a mixture of emotes and stickers available in account data.
 
-#### Example image pack event
-Taking all of this into account, an example pack event may look like the following:
+An image object consists of the following keys:
+
+- `url`: **Required, String**. The MXC URL for this image.
+- `body`: **Optional, String**. A textual representation or associated 
+    description of the image.
+- `info`: **Optional, ImageInfo**. The already specified
+    [`ImageInfo`](https://spec.matrix.org/v1.14/client-server-api/#msticker_imageinfo) 
+    object (from `m.sticker`).
+- `usage`: **Optional, Array of String**. An array of the usages for this
+    image. The possible values match those of the `usage` key of a pack object.
+
+    If present and non-empty, this overrides the usage defined at pack level for
+    this particular image. This is useful to e.g. have one pack contain mixed
+    emotes and stickers. Additionally, as there is only a single account data
+    level image pack, this is required to have a mixture of emotes and stickers
+    available in account data.
+
+An example of an image object:
+
+```jsonc
+{
+  "url": "mxc://element.io/1c8cac2c949b11649140b446d969d1934c59facf",
+  "body": "a lazy cat lays on the floor",
+  "usage": ["sticker"],
+  "info": {
+    // ... ImageInfo ...
+  }
+}
+```
+
+Taking all of this into account, a full image pack event may look like:
+
 ```json
 {
   "images": {
@@ -151,42 +180,45 @@ Taking all of this into account, an example pack event may look like the followi
   },
   "pack": {
     "display_name": "Awesome Pack",
-    "usage": ["emoticon"]
+    "usage": ["emoticon"],
+    "attribution": "drawn by @kayley:example.org"
   }
 }
 ```
 
-### Image sources
-There are several places where a client is expected to look for events with type `m.image_pack`, mainly
-in their own account data and in room state.
+#### User and room image packs
 
-#### User image packs
-Each user can have their own personal image pack defined in their account data, under the
-`m.image_pack` key. The user is expected to be presented with these images in all rooms.
+The user SHOULD be presented with the images in their `m.image_pack` account
+data event while interacting in all rooms.
 
-#### Room image packs
-A room can have an unlimited amount of image packs, by specifying the `m.image_pack` state event with
-different state keys. By default, the user is expected to be presented with these images only in the room they
-they are defined in. To enable them to be presented in all rooms, see the "Image pack rooms" section.
-E.g. a discord bridge could set as state key
-`de.sorunome.mx-puppet-bridge.discord` and have all the bridged emotes in said state event, keeping
-bridged emotes from matrix emotes separate.
+A room itself can have an unlimited amount of image packs by specifying the
+`m.image_pack` state event with different state keys. By default, the user
+SHOULD be presented with these images only when interacting in the room that
+the packs are defined in.
 
-#### Space image packs
-Clients should suggest image packs of a room's canonical space, if the user is also in that space.
- This should be done recursively on canonical spaces. So, if a room has a canonical space and
-that space again has a canonical space, the clients should suggest image packs of both of those spaces.
+For a user to enable a room image pack to be presented in all rooms, the room ID
+can be added to a `m.image_pack.rooms` account data event. Note that this is
+separate from the `m.image_pack` account data event defined above.
 
-#### Image pack rooms
-While room image packs are specific to a room, they can be made accessible from anywhere by setting
-the `m.image_pack.rooms` key in a user's account data. The value is an object, with a `room` key containing
-a map of room ids to the state keys to an object. If a room id / state key combination is provided in this form,
-clients should make the corresponding room image pack globally accessible in all rooms.
+#### `m.image_pack.rooms` account data event
 
-Note that while this MSC does not define any keys for the bottom-level object, defining it as an object means greater
-flexibility in the case of future changes.
+The `m.image_pack.rooms` account data event consists of the following:
 
-The contents of `m.image_pack.rooms` could look like the following:
+- `rooms` **Required, Map[String, Map[String, Object]]**. A map of room ID to
+    another map: from `state_key` to an empty object.
+
+This data structure allows specifying a single room image pack given the pack's
+room ID and `state_key`.
+
+Clients should make the corresponding room image pack globally accessible in all
+rooms.
+
+While this MSC does not define any keys for the bottom-level object, defining it
+as an object means greater flexibility in the case of future changes. For
+instance, a future MSC could define only certain images to be sourced from a
+pack, instead of the entire pack.
+
+An example of a `m.image_pack.rooms` account data event:
 
 ```json
 {
@@ -202,63 +234,184 @@ The contents of `m.image_pack.rooms` could look like the following:
 }
 ```
 
-Here three emote packs are globally accessible to the user: Two defined in `!someroom:example.org`
-(one with blank state key and one with state key `de.sorunome.mx-puppet-bridge.discord`) and one in
-`!someotherroom:example.org` (with a blank state key).
+#### Space image packs
 
-### Image pack source priority
-If a client gives image suggestions (emotes, stickers) to the user in some ordered fashion (e.g. an
-ordered list where you click an entry), the order of the images should be predictable between rooms.
+Clients SHOULD suggest image packs of a room's canonical space, if the user is
+also in that space. This should be done recursively on canonical spaces. So, if
+a room has a canonical space and that space again has a canonical space, the
+clients should suggest image packs of both of those spaces.
+
+Care should be taken to avoid cycles when iterating, and to limit the max chain
+length of rooms to a sensible number.
+
+#### Image pack source priority
+
+If a client gives image suggestions (emotes, stickers) to the user in some
+ordered fashion (e.g. an ordered list where you click an entry), the order of
+the image packs SHOULD be predictable between rooms.
+
 A suggestion for clients of image pack ordering is as follows:
-1. User image pack (defined in your own account data)
-2. Image pack rooms (defined in the `m.image_pack.rooms` account data object)
-3. Space image packs (defined in the hierarchy of canonical spaces for the current room)
+
+1. User image pack (defined in the user's account data)
+2. Image pack rooms (defined in the `m.image_pack.rooms` user account data
+    object)
+3. Space image packs (defined in the hierarchy of canonical spaces for the
+    current room)
 4. Room image packs (defined in the currently open room's state)
 
-### Sending
-#### Emoticons
-For emoticons a client could add delimiters (e.g. `:`) around the image shortcode, meaning
-that if an image has a shortcode of `emote`, the user can enter `:emote:` to send it. If there are
-multiple emoticons with the same shortcode in a room, the client could e.g. slugify the packs display
-name and then have the user enter `:slug~emote:`. As slugs typically match `^[\w-]+$`, that should
-ensure complete-ability.
+Note: this MSC does not define an ordering for images within packs. That is left
+to a future MSC.
 
-The alt / title text for the `<img>` tag is expected to be the `body` of the emote. If absent, its
-shortcode should be used instead.
+### Image properties
+
+Emoticons SHOULD be at least 128x128 pixels. This is to ensure that custom emotes look good, even on higher DPI displays.
+
+Stickers SHOULD be at least 512x512 pixels, for the same reason.
+
+Images filetypes are not limited by this proposal. Instead they are
+equivalent to the formats allowed in an
+[`m.image`](https://spec.matrix.org/v1.11/client-server-api/#mimage) event. As
+of writing, no limitations for `m.image` are currently defined (see [this spec
+issue](https://github.com/matrix-org/matrix-spec/issues/453)).
+
+Emotes and stickers may be animated, and clients may choose to pause animations
+based on user preferences.
+
+### Shortcode grammar
+
+A shortcode's length MUST not exceed 100 bytes. This restriction MUST be
+enforced by servers when sending reactions, but servers MUST NOT reject events
+coming across federation due to having too many bytes in the shortcode field.
+This avoids a split-brain in the room. Servers MAY opt to locally redact events
+having too many bytes in the shortcode field.
+
+The `:` character MUST NOT be included in the emote shortcode. The `:` character
+has become synonymous with emotes - oftentimes typing the `:` character in a
+message field will allow one to filter and choose and emote to send.
+
+To avoid client fragmentation, with some clients opting to trim `:` when
+displaying emote shortcodes and others leaving it in, the `:` character is
+barred from the shortcode grammar. This is in attempt to standardise `:` as the
+delimiter character for shortcodes.
+
+Any other character is explicitly allowed. This allows shortcodes
+containing non-Latin characters for communities of those languages.
+
+### Sending
+
+#### Custom emotes
+
+Custom emotes are sent into rooms as `<img>` tags within the `formatted_body`
+field of an
+[`m.room.message`](https://spec.matrix.org/v1.14/client-server-api/#mroommessage)
+event. Many existing clients already render `<img>` tags in message bodies when
+they render HTML, and its logical to reuse that functionality here.
+
+To allow clients to distinguish custom emotes from other inline images, a new
+attribute, `data-mx-emoticon`, is introduced to the `<img>` tag:
+
+```html
+<img data-mx-emoticon src="mxc://example.org/emote" alt="A cat holding a paper heart" title="cat_luvs_u" height="32" />
+```
+
+A client should treat an `<img>` tag as a custom emote if the custom
+`data-mx-emoticon` attribute is present. If this attribute has a value, that
+value is ignored. Some libraries may automatically add an empty value, i.e.
+`data-mx-emoticon=""`.
+
+##### `src` attribute
+
+The `src` attribute is required and MUST be a [Matrix Content (MXC)
+URI](https://spec.matrix.org/v1.14/client-server-api/#matrix-content-mxc-uris).
+Other URI schemes, such as `https`, `mailto` etc. are not allowed. Clients MUST
+NOT attempt to render images accessible through other URI schemes, as this may
+lead to unintended network requests.
+
+##### `alt` attribute
+
+The `alt` attribute MUST be present. Its value SHOULD be the `body` of the emote, or if unavailable, its shortcode.
+
+The `alt` attribute's meaning is inherited from the HTML specification:
+<https://html.spec.whatwg.org/multipage/images.html#alt>. It is primarily used
+for accessibility purposes in describing an image for visually impaired users.
+
+##### `title` attribute
+
+The `title` attribute MUST be present. Its value SHOULD be the shortcode of the
+emote.
+
+The `title` attribute's meaning is inherited from the HTML specification:
+<https://html.spec.whatwg.org/multipage/dom.html#attr-title>. It is primarily
+used for advisory information, such as tooltips. This could allow users viewing
+a message to quickly find the shortcode of a given emote in order to send it in
+their own messages.
+
+##### `height` attribute
+
+The `height` attribute MUST be present. This maintains backwards-compatibility
+with clients that do not support custom emotes.
+
+Clents SHOULD set `height` to "32px". This is a default that looks good on most
+devices. In practice, receiving clients are expected to override the height when
+rendering emotes based on their particular environment (the user's font size,
+etc.). Or they may choose to display messages containing only emoticons in a
+larger font.
+
+A `width` attribute is not required, in order to maintain the aspect ratio of
+non-square emotes.
+
+##### Client suggestions
+
+A client could use the `:` delimiter to signify that the user wants to send an
+emote. So, if the user enters `:emote:` in a message, the client could replace
+that text with the corresponding emote based on the shortcode. Likewise, typing
+`:` and then a character could initiate a search action through available
+emotes.
+
+If there are multiple emotes with the same shortcode available, the client could
+for example slugify the containing pack's display name and prepend it to each
+emote's shortcode with a separator character (i.e. `~`). For instance, the user
+could enter `:my-pack~emote:` to select an image with shortcode `emote` in the
+pack `my pack`.
 
 #### Stickers
-When sending a sticker, the `body` of the `m.sticker` event should be set to the `body` defined for that
-image, or if absent, its shortcode.
 
-The `info` object of the `m.sticker` event should be set to the `info` object of the image, or if absent,
-an empty object.
+When sending a sticker, the `body` field of the `m.sticker` event SHOULD be set
+to the `body` defined for that image, or if absent, its shortcode.
+
+The `info` object of the `m.sticker` event SHOULD be set to the `info` object of
+the image, or if absent, an empty object.
 
 ## Security Considerations
 
 This MSC considers that image packs, and the images contained within them, are
-not encrypted. That means media included in image packs cannot be hidden from the
-homeserver. That is a privacy and security concern.
+not encrypted. That means media included in image packs cannot be hidden from
+the homeserver. That is a privacy and security concern.
 
 In addition, a homeserver could deduce from traffic patterns that an encrypted
-event contains a certain emoticon by correlating the time an event was sent with
-other local, participating user's access requests to a particular piece of media.
-This is not a new concern, as the same attack can be performed for links sent in
-a chat with URL previews enabled in clients. In addition, caching of images across
-clients can help with reducing the need to download the media again.
+event contains a certain emote by correlating the time an event was sent with
+other local, participating user's access requests to a particular piece of
+media. This is not a new concern, as the same attack can be performed for links
+sent in a chat with URL previews enabled in clients. In addition, caching of
+images across clients can help with reducing the need to download the media
+again.
 
 Encrypting image packs is dependent on encrypted state events being implemented
-in the protocol; potentially by MSC3414 or another MSC.
+in the protocol; potentially by
+[MSC3414](https://github.com/matrix-org/matrix-spec-proposals/pull/3414) or
+another MSC.
 
-Once encrypted state events are implemented, images could be encrypted before upload
-with a symmetric key included within the encrypted state event. Then, said key will
-be sent within the `<img>` tag emoticons are sent in, allowing other clients to download
-and decrypt the media. [This matrix-spec
-issue](https://github.com/matrix-org/matrix-doc/issues/2418) calls for standardising
-this behaviour for any kind of inline image.
+Once encrypted state events are implemented, images could be encrypted before
+upload with a symmetric key included within the encrypted state event. Then,
+said key would be sent within the `<img>` tag emotes are sent in, allowing
+other clients to download and decrypt the media. [This matrix-spec
+issue](https://github.com/matrix-org/matrix-doc/issues/2418) calls for
+standardising this behaviour for any kind of inline image.
 
-Encrypted emoticons sent in *non-E2EE* rooms would leak these keys, but this may be deemed
-acceptable as many emoticons would not be leaked. Plus, it still raises the barrier for
-homeserver operators to implement tooling to browse messages in E2EE rooms.
+Encrypted emotes sent in *non-E2EE* rooms would leak these keys, but this may
+be deemed acceptable as many emotes would not be leaked. Plus, it still
+raises the barrier for homeserver operators to implement tooling to browse
+messages in E2EE rooms.
 
 Ultimately end-to-end encryption of image packs or emoticons is purposefully
 not within the scope of this MSC. That being said, clients SHOULD warn users
@@ -266,43 +419,52 @@ that images in image packs sent in E2EE rooms are not encrypted and thus
 visible to homeservers.
 
 ## Unstable prefix
-The `m.image_pack` in the account data is replaced with `im.ponies.user_emotes`. The `m.image_pack` in
-the room state is replaced with `im.ponies.room_emotes`. The `m.image_pack.rooms` is replaced with
-`im.ponies.emote_rooms`.
 
-Some existing implementations using `im.ponies.user_emotes` and `im.ponies.room_emotes` currently use
-a dict called `short` which is just a map of the shortcode to the mxc url.
-
-Some other implementations currently also call the `images` key `emoticons`.
+| **Stable identifier** | **Unstable identifier** |
+|---|---|
+| `m.image_pack` state event type | `im.ponies.room_emotes` |
+| `m.image_pack` account data event type | `im.ponies.user_emotes` |
+| `m.image_pack.rooms` account data event type | `im.ponies.emote_rooms` |
 
 ## Potential Issues
 
-### Multiple usages per pack complicates pack management client UI
-
-It's possible that allowing a pack to have multiple usages can complicate implementing UI for managing packs. 
-This was considered acceptable, as the benefit of being able to use a single pack in multiple contexts, as 
-well as this MSC originally allowing multiple usages-per-pack for much of its implementation lifespan, were 
-considered to outweigh the alternative.
-
 ### Event size limits
 
-Due to size limitations of events (65535 bytes), image packs are limted to around 400 emotes per pack. This 
-has been deemed sufficient for the vast majority of use cases.
+Due to the [size limitation of
+events](https://spec.matrix.org/v1.14/client-server-api/#size-limits) (65536
+bytes), image packs are limited to roughly 400 emotes per pack (see [this
+calculation](https://github.com/matrix-org/matrix-spec-proposals/pull/2545/files#r1705977956).
+
+This has been deemed sufficient for the vast majority of use cases.
+
+### Multiple usages per pack complicates pack management client UI
+
+It's possible that allowing a pack to have multiple usages can complicate
+implementing UI for managing packs. See [this
+thread](https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r1734825589).
+This was considered acceptable, as the benefit of being able to use a single
+pack in multiple contexts, as well as this MSC originally allowing multiple
+usages-per-pack for much of its implementation lifespan, were considered to
+outweigh the alternative.
 
 ## Alternatives
-One can easily think of near infinite ways to implement emotes. The aspect of sending an `<img>` tag
-and marking it as an emote with `data-mx-emoticon` seems to be pretty universal though, so the question
-is mainly on different emote sources. For that, a separate MSC, [MSC1951](https://github.com/matrix-org/matrix-doc/pull/1951)
-already exists, so it is reasonable to compare this one with that one:
+
+One can easily think of near infinite ways to implement emotes. The aspect of
+sending an `<img>` tag and marking it as an emote with `data-mx-emoticon` seems
+to be pretty universal though, so the question is mainly on different emote
+sources. For that, a separate MSC,
+[MSC1951](https://github.com/matrix-org/matrix-doc/pull/1951) already exists, so
+it is reasonable to compare this one with that one:
 
 ### Comparison with MSC1951
-MSC1951 defines a dedicated room as the only image pack source. This MSC, however, also allows you to bind image packs
+
+[MSC1951](https://github.com/matrix-org/matrix-spec-proposals/pull/1951) defines a dedicated room as the only image pack source. This MSC, however, also allows you to bind image packs
 to your own account, offering greater flexibility. In MSC1951 there can also only be a single image pack
 in a room. This could be problematic in e.g. bridged rooms: You set some emotes or stickers from the matrix
 side and a discord bridge would plop all the discord emotes and stickers in another pack in the same room.
 
-The original sharing-focused idea of MSC1951 is still preserved: Once room types are a thing, you could
-still easily have an image pack-only room.
+The original sharing-focused idea of MSC1951 is still preserved: you could
+easily have an image pack-only room via a new room type.
 
 MSC1951 defines a way to recommend using a pack of a different room - this MSC does not have an equivalent
 to that. Instead, this MSC allows multiple image packs for a room, typically one where you already
@@ -316,13 +478,17 @@ A simple dict of shortcode to mxc URI seems more appropriate for this.
 
 In general, MSC1951 feels like a heavier approach to image pack sources, while this MSC is more lightweight.
 
-## Looking further
-A couple of interesting points have been raised in discussions of this MSC that tangentially touch
-custom emoticons. Each warrant an MSC for themselves however, as they touch more on how `<img>` is works.
- - Figuring out how `<img>` should work with encrypted media.
- - Allow SVGs in the `<img>` tag. Current problem: Clients typically try to thumbnail the mxc URL,
-   and most media repositories can't thumbnail SVGs. Possible solution: Somehow embed the mimetype.
- - For stickers: Recommend rendering sizes / resolutions
+## Future ideas
+
+A couple of interesting points have been raised in discussions of this MSC that
+tangentially touch custom emotes. Each warrant an MSC for themselves.
+
+- Allow SVGs in the `<img>` tag. Currently clients try to thumbnail the mxc URL,
+    and most media repositories can't thumbnail SVGs. Possible solution: Somehow embed the mimetype.
+- For stickers: Recommend rendering sizes / resolutions
+- Loading placeholders for emotes and stickers (i.e. via blurhashes
+    [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448) or
+    vector paths) 
 
 ## Dependencies
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -294,8 +294,16 @@ displaying emote shortcodes and others leaving it in, the `:` character is
 barred from the shortcode grammar. This is in attempt to standardise `:` as the
 delimiter character for shortcodes.
 
-Any other character is explicitly allowed. This allows shortcodes
-containing non-Latin characters for communities of those languages.
+In addition, the space character is not allowed. This helps avoid common
+usability paper-cuts (multiple spaces between words, spaces at the beginning/end
+of a shortcode). Shortcodes containing multiple words are encouraged to use alterantive separators like hyphens or underscores.
+
+Specifically, the `U+0020` character (normal space) is disallowed. There are
+multiple other byte sequences associated with spaces in Unicode.
+
+Any other character is explicitly allowed. This allows shortcodes containing
+non-Latin characters for communities of those languages, and ensures
+forwards-compatibility with future Unicode updates.
 
 ### Sending
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -35,7 +35,7 @@ also known in short as "emotes".
 Emotes are images or text describing emotions or other things. Emoji are a
 subset of emotes, namely those found within the Unicode spec. Custom emoji,
 therefore, would actually refer to a custom emoji font; one's own rendering of
-Unicode's 🦊, 🐱, etc. This differs from new images; which is what custom
+Unicode's 🦊, 🐱, etc. This differs from new images, which is what custom
 emoticons are for.
 
 A client may of course choose to name these however they like. In the spec's
@@ -46,7 +46,7 @@ after what they are.
 #### Stickers
 
 Stickers already exist in Matrix (see the [`m.sticker` event
-type](https://spec.matrix.org/v1.14/client-server-api/#msticker). They are
+type](https://spec.matrix.org/v1.14/client-server-api/#msticker)). They are
 reusable images one can send; typically as a reaction to something sent in the
 timeline. The value this MSC brings to stickers is creating a mechanism to
 distribute them, such that a client can surface them to a user to choose and
@@ -57,7 +57,7 @@ send.
 A "shortcode" is a short, unique identifier for an emote or a sticker.
 
 A shortcode is NOT intended to be a visual description of an image, often to
-aide the visually impaired. That is more suitable to the `body` field; defined
+aide the visually impaired. That is more suitable to the `body` field, defined
 as part of an "Image object" below and on
 [`m.sticker`](https://spec.matrix.org/v1.14/client-server-api/#msticker) events.
 
@@ -76,8 +76,8 @@ property with an empty string for an image pack's `state_key`.
 
 `m.image_pack` state events contain the following keys within their `content`:
 
-* `images`: **Required, Map[String, Object]**. A map from a shortcode to an Image Object.
-* `pack` **Optional, Object**. A Pack Object.
+* `images`: **Required, Map[String, Object]**. A map from a shortcode to an [Image Object](#image-object).
+* `pack` **Optional, Object**. A [Pack Object](#pack-object).
 
 ```jsonc
 {
@@ -234,7 +234,7 @@ An example of a `m.image_pack.rooms` account data event:
 }
 ```
 
-Note that an empty object under a room ID, for example:
+An empty object under a room ID, for example:
 
 ```json
 {

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -550,6 +550,12 @@ In general, MSC1951 feels like a heavier approach to image pack sources, while t
 A couple of interesting points have been raised in discussions of this MSC that
 tangentially touch custom emotes. Each warrant an MSC for themselves.
 
+- Include a backlink to image packs from custom emotes/stickers in events,
+  allowing users to see an image pack an emote or sticker came from. See [this
+  thread](https://github.com/matrix-org/matrix-spec-proposals/pull/2545/files#r2020176546)
+  and
+  [this thread](https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r753881475)
+  for discussion on the matter.
 - Allow SVGs in the `<img>` tag. Currently clients try to thumbnail the mxc URL,
     and most media repositories can't thumbnail SVGs. Possible solution: Somehow embed the mimetype.
 - For stickers: Recommend rendering sizes / resolutions

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -252,6 +252,13 @@ a dict called `short` which is just a map of the shortcode to the mxc url.
 
 Some other implementations currently also call the `images` key `emoticons`.
 
+## Potential Issues
+
+It's possible that allowing a pack to have multiple usages can complicate implementing UI for managing packs. 
+This was considered acceptable, as the benefit of being able to use a single pack in multiple contexts, as 
+well as this MSC originally allowing multiple usages-per-pack for much of its implementation lifespan, were 
+considered to outweigh the alternative.
+
 ## Alternatives
 One can easily think of near infinite ways to implement emotes. The aspect of sending an `<img>` tag
 and marking it as an emote with `data-mx-emoticon` seems to be pretty universal though, so the question

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -310,11 +310,11 @@ A suggestion for clients of image pack ordering is as follows:
 1. User image pack (defined in the user's account data)
 2. Image pack rooms (defined in the `m.image_pack.rooms` user account data
     object)
-3. Space image packs (defined in the hierarchy of canonical spaces for the
-    current room)
-4. Room image packs (defined in the currently open room's state)
-5. Referenced room image packs (defined in the `m.image_pack.rooms` room
+3. Room image packs (defined in the currently open room's state)
+4. Referenced room image packs (defined in the `m.image_pack.rooms` room
     state event)
+5. Space image packs (defined in the hierarchy of canonical spaces for the
+    current room)
 
 Note: this MSC does not define an ordering for images within packs. That is left
 to a future MSC.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -77,7 +77,7 @@ property with an empty string for an image pack's `state_key`.
 `m.image_pack` state events contain the following keys within their `content`:
 
 * `images`: **Required, Map[String, Object]**. A map from a shortcode to an Image Object.
-* `pack`" **Optional, Object**. A Pack Object.
+* `pack` **Optional, Object**. A Pack Object.
 
 ```jsonc
 {
@@ -143,7 +143,7 @@ An image object consists of the following keys:
 - `info`: **Optional, ImageInfo**. The already specified
     [`ImageInfo`](https://spec.matrix.org/v1.14/client-server-api/#msticker_imageinfo) 
     object (from `m.sticker`).
-- `usage`: **Optional, Array of String**. An array of the usages for this
+- `usage`: **Optional, Array[String]**. An array of the usages for this
     image. The possible values match those of the `usage` key of a pack object.
 
     If present and non-empty, this overrides the usage defined at pack level for
@@ -305,7 +305,7 @@ Custom emotes are sent into rooms as `<img>` tags within the `formatted_body`
 field of an
 [`m.room.message`](https://spec.matrix.org/v1.14/client-server-api/#mroommessage)
 event. Many existing clients already render `<img>` tags in message bodies when
-they render HTML, and its logical to reuse that functionality here.
+they render HTML, and it's logical to reuse that functionality here.
 
 To allow clients to distinguish custom emotes from other inline images, a new
 attribute, `data-mx-emoticon`, is introduced to the `<img>` tag:
@@ -432,8 +432,8 @@ visible to homeservers.
 
 Due to the [size limitation of
 events](https://spec.matrix.org/v1.14/client-server-api/#size-limits) (65536
-bytes), image packs are limited to roughly 400 emotes per pack (see [this
-calculation](https://github.com/matrix-org/matrix-spec-proposals/pull/2545/files#r1705977956).
+bytes), room image packs are limited to roughly 400 emotes per pack (see [this
+calculation](https://github.com/matrix-org/matrix-spec-proposals/pull/2545/files#r1705977956)).
 
 This has been deemed sufficient for the vast majority of use cases.
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -6,14 +6,14 @@ We also need proper stickers, too!
 
 ## Terminology
 ### Emoticons
-Since there is a lot of confusion of how this relates to `m.emote`, why this isn't called custom emoji
-etc, there it is:
+Since there is a lot of confusion of how this relates to `m.emote`, why this isn't called "custom emoji"
+etc,:
 
 `m.emote` is for emotion - and it has been incorrectly named this way. `m.action` would have been more
 appropriate, as you use it to describe *actions*, not *emotions*. E.g. "/me is walking to the gym", or
 "/me is happy" and *not* "/me happy".
 
-That, however, is *not* what this MSC is about. Instead it is about emoticons, also known in short as
+That, however, is *not* what this MSC is about. Instead, it is about emoticons, also known in short as
 emotes.
 
 Emoticons are just little images or text describing emotions or other things. Emoji are a subset of
@@ -21,24 +21,24 @@ emoticons, namely those found within unicode. Custom emoji here would actually r
 font, that is your own rendering of 🦊, 🐱, etc., *not* new images. New images is what custom emoticons
 are for.
 
-Now, a client may choose to name these however they like, we already have a naming disparity between
+Now, a client may choose to name these however they like. We already have a naming disparity between
 spec and clients with groups vs communities. It is, however, imperative to name things in the spec
 accurately after what they are.
 
 ### Stickers
-Stickers already exist in Matrix. They are reusable images one can send, usually as a reaction sent
-in the timeline to something. This MSC adds a way to distribute and define a source for a client to
+Stickers already exist in Matrix. They are reusable images one can send, usually as a reaction to
+something sent in the timeline. This MSC adds a way to distribute and define a source for a client to
 send them.
 
 ## Proposal
 ### Emoticons in the formatted body
-Emoticons have at least a shortcode and an mxc uri. They are sent as `<img>` tags currently already in
-the spec, as such existing clients should already be able to render them, though not all clients currently
-handle `img` tags. To allow clients to distinguish emoticons from other inline images, a new
-property, `data-mx-emoticon`, is introduced. A client can chose to ignore the size attributes of emoticons
+Emoticons have at least a shortcode and a mxc uri. They are sent as `<img>` tags, which are currently in
+the spec. As such, many existing clients are able to render them.
+To allow clients to distinguish emoticons from other inline images, a new
+property, `data-mx-emoticon`, is introduced. A client can choose to ignore the size attributes of emoticons
 when rendering, and instead pick the size based on other circumstances. This could e.g. be used to
-display emoticons in messages with only emoticons and emoji larger than usual, which is commonly found in
-messengers. Such an `<img>` tag of a shortcode `emote` and an mxc uri `mxc://example.org/emote`
+display messages with only emoticons and emoji as larger than usual, which is commonly found in
+messengers. Such an `<img>` tag of a shortcode `emote` and a mxc uri `mxc://example.org/emote`
 could look as follows:
 
 ```html
@@ -53,13 +53,13 @@ The `height` is just a height that looks good on most devices with the normal, d
 No width is displayed as to not weirdly squish non-square emotes. In order to maintain backwards-compatibility
 with clients not supporting emotes, specifying the `height` is required.
 
-If the new `data-mx-emoticon` attribute has a value it is ignored. Due to limitations of some libraries
+If the new `data-mx-emoticon` attribute has a value, it is ignored. Due to limitations of some libraries
 the attribute may even look like `data-mx-emoticon=""`.
 
-The `src` attribute *must* be an mxc url. Other URIs, such as `https`, `mailto` etc. are not allowed.
+The `src` attribute *must* be a mxc url. Other URIs, such as `https`, `mailto` etc. are not allowed.
 
 ### Sending stickers
-To send stickers the already speced `m.sticker` is used.
+To send stickers, the already spec'd `m.sticker` is used.
 
 ### Image types
 Emoticons are recommended to have a size of about 128x128 pixels. Even though the fallback specifies
@@ -70,46 +70,54 @@ Stickers are recommended to have a size of up to 512x512 pixels.
 Furthermore, these images should either have a mimetype of `image/png`, `image/gif` or `image/webp`.
 They can be animated.
 
-Due to the low resolution of emotes, `image/jpg`/`image/jpeg` has been purposefully excluded from this
+Due to the low resolution of emotes, `image/jpg` and `image/jpeg` have been purposefully excluded from this
 list.
 
 ### Image pack event
 The image pack event has a type of `m.image_pack`. It contains a key `images`, which is a map from a
-short code to an image object. It may also contain a key `pack`, which is a pack object.
+short code to an image object. It may also contain a key `pack`, which is a pack object, described in
+the following section.
 
 #### Pack object
 The pack object consists of the following keys:
  - `display_name`: (String, optional) A display name for the pack. Defaults to the room name, if the
-   image pack event is in the room. This does not have to be unique within all packs of a room.
- - `avatar_url`: (String, optional) The mxc uri of an avatar/icon to dipslay for the pack. Defautls
-   to the room avatar, if the pack is in the room. If the room also does not have an avatar, or the
-   image pack event is not in a room, this pack does not have an avatar.
- - `usage`: (String[], optional) An array of the usages for this pack. Possible usages are `emoticon`
-   and `sticker`. If the usage is absent or empty, a usage for all possible usage types is to be assumed.
+   image pack event is in the room. This does not have to be unique from other packs in a room.
+ - `avatar_url`: (String, optional) The mxc uri of an avatar/icon to display for the pack. Defaults
+   to the room avatar, if the pack is in the room. Otherwise, the pack does not have an avatar.
+ - `usage`: (String[], optional) An array of the usages for this pack. Possible usages are `"emoticon"`
+   and `"sticker"`. If the usage is absent or empty, a usage for all possible usage types is to be assumed.
  - `attribution`: (String, optional) The attribution of this pack.
 
+Example:
+```json
+{
+  "display_name": "Awesome Pack",
+  "usage": ["emoticon"]
+}
+```
+
 #### Image object
-The image object conists of the following keys:
- - `url`: (String, requried) The mxc URL for this image
- - `body`: (String, optional) An optional body for this image, useful for the sticker body text or
-   the emote alt text. Defaults to the short code.
- - `info`: (`ImageInfo`, optional) The already speced `ImageInfo` object used for the `info` block of
+The image object consists of the following keys:
+ - `url`: (String, required) The mxc URL for this image.
+ - `body`: (String, optional) An optional text body for this image. Useful for the sticker body text or
+   the emote alt text. Defaults to the shortcode.
+ - `info`: (`ImageInfo`, optional) The already spec'd `ImageInfo` object used for the `info` block of
    `m.sticker` events.
- - `usage`: (String[], optional) An array of the usages for this image. If present and non-empty,
-   this overrides the usage defined at pack level for this particular image. This is useful to e.g.
-   have one pack contain mixed emotes and stickers. Additionally there is only a single account data
-   level image pack, meaning this is required to have a mixture of emotes and stickers available in
-   account data.
+ - `usage`: (String[], optional) An array of the usages for this image. The possible values match those
+   of the `usage` key of a pack object. If present and non-empty, this overrides the usage defined at
+   pack level for this particular image. This is useful to e.g. have one pack contain mixed emotees and
+   stickers. Additionally, as there is only a single account data level image pack, this is required to
+   have a mixture of emotes and stickers available in account data.
 
 #### Example image pack event
-Taking all this into account, an example pack event may look as following:
+Taking all of this into account, an example pack event may look like the following:
 ```json
 {
   "images": {
-    "emote": {
+    "myemote": {
       "url": "mxc://example.org/blah"
     },
-    "sticker": {
+    "mysticker": {
       "url": "mxc://example.org/sticker",
       "usage": ["sticker"]
     }
@@ -122,34 +130,35 @@ Taking all this into account, an example pack event may look as following:
 ```
 
 ### Image sources
-There are several places where a client is expected to look for these `m.image_pack` events, mainly
-in their own account data and in room states.
+There are several places where a client is expected to look for events with type `m.image_pack`, mainly
+in their own account data and in room state.
 
 #### User image packs
-Each user can have their own personal image pack defined in their own account data, with the normal
-`m.image_pack` event. The user is expected to be presented with these images in all rooms.
+Each user can have their own personal image pack defined in their account data, under the
+`m.image_pack` key. The user is expected to be presented with these images in all rooms.
 
 #### Room image packs
 A room can have an unlimited amount of image packs, by specifying the `m.image_pack` state event with
-different state keys. The user is expected to be presented with these images only in the room they
-are defined in. To enable them to be presented in all rooms, see the section below.
-An empty state key is the default pack for a room.
+different state keys. By default, the user is expected to be presented with these images only in the room they
+they are defined in. To enable them to be presented in all rooms, see the "Image pack rooms" section.
 E.g. a discord bridge could set as state key
 `de.sorunome.mx-puppet-bridge.discord` and have all the bridged emotes in said state event, keeping
 bridged emotes from matrix emotes separate.
 
 #### Space image packs
-Clients should suggest image packs of a canonical space that a room is in, if the user is also in the
-space. This should be done recursively on canonical spaces. So, if a room has a canonical space and
+Clients should suggest image packs of a room's canonical space, if the user is also in that space.
+ This should be done recursively on canonical spaces. So, if a room has a canonical space and
 that space again has a canonical space, the clients should suggest image packs of both of those spaces.
 
 #### Image pack rooms
-While room image packs are specific to a room and are only accessible within that room, image pack
-rooms should be accessible from everywhere. They do not differentiate themselves from room emotes at
-all, instead you set an event in your account data of type `m.image_pack.rooms` which outlines
-which room image pack states are globally accessible for that user. For that, a `room` key contains
-a map of room ids that map to state keys that map to an object. While this MSC does not define any
-contents for this object, having this an object means greater flexibility in case of future changes.
+While room image packs are specific to a room, they can be made accessible from anywhere by setting
+the `m.image_pack.rooms` key in a user's account data. The value is an object, with a `room` key containing
+a map of room ids to the state keys to an object. If a room id / state key combination is provided in this form,
+clients should make the corresponding room image pack globally accessible in all rooms.
+
+Note that while this MSC does not define any keys for the bottom-level object, definint it as an object means greater
+flexibility in the case of future changes.
+
 The contents of `m.image_pack.rooms` could look like the following:
 
 ```json
@@ -168,38 +177,41 @@ The contents of `m.image_pack.rooms` could look like the following:
 
 Here three emote packs are globally accessible to the user: Two defined in `!someroom:example.org`
 (one with blank state key and one with state key `de.sorunome.mx-puppet-bridge.discord`) and one in
-`!someotherroom:example.org`.
+`!someotherroom:example.org` (with a blank state key).
 
 ### Image pack source priority and deduplicating
-If a client gives image suggestions (emotes, stickers) to the user in some ordered fassion (e.g. a
+If a client gives image suggestions (emotes, stickers) to the user in some ordered fassion (e.g. an
 ordered list where you click an entry), the order of the images should be predictable between rooms.
-The ordering could look as following:
-1. User image pack (images set in your own account)
-2. Image pack rooms (rooms whos image packs you enabled to be accessible everywhere)
-3. Space image packs (packs sent in the space, if present)
-4. Room image packs (images defined in the currently open room)
+A suggestion for clients of image pack ordering is as follows:
+1. User image pack (defined in your own account data)
+2. Image pack rooms (defined in the `m.image_pack.rooms` account data object)
+3. Space image packs (defined in the hierarchy of canonical spaces for the current room)
+4. Room image packs (defined in the currently open room's state)
 
-Furthermore, clients are expected to deduplicate images based on their mxc url. This not only ensures
-that, when viewing a room that you also have in `m.image_pack.rooms`, it won't be displayed twice,
-but also if you have e.g. a bot which syncs emotes over multiple rooms, those will also be deduplicated.
+Furthermore, clients are expected to de-duplicate images so that same images are not displayed multiple
+times. Such scenarios includ e.g.:
+1. when viewing a room that has a pack defined in the `m.image_pack.rooms` account data object, and
+2. a bot which syncs emotes over multiple rooms.
+
+This could be done by deduplicating by the mxc URI.
 
 ### Sending
 #### Emoticons
-For emoticons a client could add deliminators (e.g. `:`) around around the image shortcode, meaning
+For emoticons a client could add deliminators (e.g. `:`) around the image shortcode, meaning
 that if an image has a shortcode of `emote`, the user can enter `:emote:` to send it. If there are
-multiple emoticons with the same shortcode in a room the client could e.g. slugify the packs display
-name and then have the user enter `:slug~emote:`. As slugs typically match `^[\w-]+$` that should
+multiple emoticons with the same shortcode in a room, the client could e.g. slugify the packs display
+name and then have the user enter `:slug~emote:`. As slugs typically match `^[\w-]+$`, that should
 ensure complete-ability.
 
-The alt / title text fo the `<img>` tag is expected to be the `body` of the emote, or, if absent, its
-shotcode, optionally with tacked on deliminators.
+The alt / title text for the `<img>` tag is expected to be the `body` of the emote. If absent, its
+shotcode should be used instead.
 
 #### Stickers
-When sending a sticker the `body` of the `m.sticker` event should be set to the `body` defined for that
-image, or its shortcode, if absent.
+When sending a sticker, the `body` of the `m.sticker` event should be set to the `body` defined for that
+image, or if absent, its shortcode.
 
-Furthermore, the `info` of the `m.sticker` event should be set to the `info` defined for that image,
-or a blank object, if absent.
+The `info` object of the `m.sticker` event should be set to the `info` object of the image, or if absent,
+an empty object.
 
 ## Security Considerations
 When sending an `<img>` tag in an encrypted room, the client will make a request to fetch
@@ -207,7 +219,7 @@ said image, in this case an emote. As there is no way to encrypt content behind 
 this could potentially leak part of the conversation. This is **not** a new security consideration,
 it already exists. This, however, isn't much different from posting someone a link in an e2ee chat and
 the recipient opens the link. Additionally, images, and thus emotes, are often cached by the client,
-not even necessarily leading to an http query.
+not even necessarily leading to a http query.
 
 Related issue: https://github.com/matrix-org/matrix-doc/issues/2418
 
@@ -238,7 +250,7 @@ still easily have an image pack-only room.
 
 MSC1951 defines a way to recommend using a pack of a different room - this MSC does not have an equivalent
 to that. Instead, this MSC allows multiple image packs for a room, typically one where you already
-chat in anyways. Furthermore it allows you to enable an image pack to be globally available for yourself
+chat in anyways. Furthermore, it allows you to enable an image pack to be globally available for yourself
 across all rooms you are in.
 
 The core difference is how MSC1951 and this MSC define the image packs themselves: In MSC1951 you have to
@@ -249,8 +261,8 @@ A simple dict of shortcode to mxc URI seems more appropriate for this.
 In general, MSC1951 feels like a heavier approach to image pack sources, while this MSC is more lightweight.
 
 ## Looking further
-A couple of interesting points have been raised in the discussions of this MSC tangentially touch
-custom emoticons but warrant an MSC for themselves, as they touch more on how `<img>` is working.
+A couple of interesting points have been raised in discussions of this MSC that tangentially touch
+custom emoticons. Each warrant an MSC for themselves however, as they touch more on how `<img>` is works.
  - Figuring out how `<img>` should work with encrypted media.
  - Allow SVGs in the `<img>` tag. Current problem: Clients typically try to thumbnail the mxc URL,
    and most media repositories can't thumbnail SVGs. Possible solution: Somehow embed the mimetype.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -251,11 +251,10 @@ the image packs SHOULD be predictable between rooms.
 
 Clients SHOULD implement image pack ordering as follows:
 
-1. User image pack (defined in the user's account data)
-2. Image pack rooms (defined in the `m.image_pack.rooms` user account data
+1. Image pack rooms (defined in the `m.image_pack.rooms` user account data
     object)
-3. Room image packs (defined in the currently open room's state)
-4. Space image packs (defined in the hierarchy of canonical spaces for the
+2. Room image packs (defined in the currently open room's state)
+3. Space image packs (defined in the hierarchy of canonical spaces for the
     current room)
 
 Note: this MSC does not define an ordering for images *within* packs. That is left

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -280,7 +280,8 @@ due to exceeding the event limit (e.g. emoji reactions).
 
 A shortcode MUST match the following regular expression:
 `[a-zA-Z0-9-_]+`. Note that this disallows zero-length shortcodes - not least
-because searching for, and indexing, such shortcodes is complicated.
+because searching for, and indexing, such shortcodes is complicated. Shortcodes
+are considered case-sensitive.
 
 The `:` character is specifically not included, as it has become synonymous
 across messaging platforms with searching for emotes - oftentimes typing the `:`
@@ -296,6 +297,17 @@ common usability paper-cuts (multiple spaces between words, spaces at the
 beginning/end of a shortcode). Shortcodes containing multiple words are
 encouraged to use the alternative separators provided; a hyphen (`-`) or
 an underscore (`_`).
+
+This is the same character set that is used by
+[Discord](https://support.discord.com/hc/en-us/articles/360036479811-How-to-Add-Custom-Emojis-on-Discord#:~:text=Keep%20in%20mind:-,Emoji%20names%20must%20be%20at%20least%202%20characters%20long%20and%20can%20only%20contain%20alphanumeric%20characters%20and%20underscores,-Emojis%20must%20be)
+and
+[Slack](https://docs.slack.dev/reference/methods/admin.emoji.add/#:~:text=The%20name%20of%20the%20emoji%20to%20be%20added%20%28using%20lower%2Dcase%20letters%20only%29),
+simplifying bridging.
+
+Using the [Opaque identifier
+grammar](https://spec.matrix.org/v1.17/appendices/#opaque-identifiers) was
+considered, however it is explicitly for "non-user-visible identifier", which
+this is not.
 
 The above character set does exclude characters from non-latin languages from
 being included (e.g. ブイチューバー). This is to guard against various edge cases of

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -436,10 +436,39 @@ the image, or if absent, an empty object.
 ### Room upgrades
 
 Upon upgrading a room, homeservers SHOULD transfer `m.room.image_pack` state events
-to the new room. Homeservers SHOULD also update user's account data so that any
+to the new room.
+
+Homeservers SHOULD also update user's account data so that any
 `m.image_pack.rooms` account data events are re-pointed from the old room ID to
 the newly upgraded room ID; otherwise a user's global packs will quietly grow
 stale.
+
+One possible implementation strategy is laid out below.
+
+Upon a user joining a room;
+
+1. Determine whether the room is the result of a room upgrade from a previous room.
+2. If so, retrieve the previous room's room ID.
+3. Check whether the user has an `m.image_pack.rooms` entry in their account data.
+4. If so, check whether the previous room ID is one of the entries in that data
+  structure.
+5. If it's present, check whether `m.room.image_pack` state events with the
+  referenced `state_key`s exist in the new room.
+6. If so, replace that room ID with the upgraded room IDs. Implementations should
+  handle the case of only *some* `m.room.image_pack` state keys being migrated to
+  the upgraded room.
+
+This leaves the edge case of:
+
+1. The upgraded room is created.
+2. A user joins the upgraded room.
+3. Image packs are then transferred over.
+
+Leaving the user's list of `m.image_pack.rooms` stale.
+
+Thus, when performing a room upgrade, homeserver implementations should take
+care to *first* transfer `m.room.image_pack` state events to a new room, *then*
+invite users to the new room.
 
 ## Security Considerations
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -429,7 +429,7 @@ the image, or if absent, an empty object.
 
 ### Room upgrades
 
-Upon upgrading a room, homeservers SHOULD transfer `m.image_pack` state events
+Upon upgrading a room, homeservers SHOULD transfer `m.room.image_pack` state events
 to the new room. Homeservers SHOULD also update user's account data so that any
 `m.image_pack.rooms` account data events are re-pointed from the old room ID to
 the newly upgraded room ID; otherwise a user's global packs will quietly grow

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -160,8 +160,7 @@ Taking all of this into account, a full image pack event may look like:
       "url": "mxc://example.org/blah"
     },
     "mysticker": {
-      "url": "mxc://example.org/sticker",
-      "usage": ["sticker"]
+      "url": "mxc://example.org/sticker"
     }
   },
   "pack": {

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -411,6 +411,14 @@ to the `body` defined for that image, or if absent, its shortcode.
 The `info` object of the `m.sticker` event SHOULD be set to the `info` object of
 the image, or if absent, an empty object.
 
+### Room upgrades
+
+Upon upgrading a room, homeservers SHOULD transfer `m.image_pack` state events
+to the new room. Homeservers SHOULD also update user's account data so that any
+`m.image_pack.rooms` account data events are re-pointed from the old room ID to
+the newly upgraded room ID; otherwise a user's global packs will quietly grow
+stale.
+
 ## Security Considerations
 
 ### Encrypted image packs

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -136,7 +136,7 @@ An image object consists of the following keys:
 - `body`: **Optional, String**. A textual representation or associated 
     description of the image.
 - `info`: **Optional, ImageInfo**. The already specified
-    [`ImageInfo`](https://spec.matrix.org/v1.14/client-server-api/#msticker_imageinfo) 
+    [`ImageInfo`](https://spec.matrix.org/v1.18/client-server-api/#msticker_imageinfo) 
     object (from `m.sticker`).
 
 An example of an image object:
@@ -332,7 +332,7 @@ failing the shortcode grammar when they are received over federation (via
 redact/soft-fail events that don't follow the shortcode grammar if they wish.
 
 Clients should note that events with malformed shortcode grammar can be
-delivered to them by the homeserver. Clients SHOULD to try and show emotes and
+delivered to them by the homeserver. Clients SHOULD try and show emotes and
 stickers in the timeline, as well as image packs that contain them, even if they
 have incorrect shortcode grammar. This allows users to see them and fix them. On
 the flip side, clients SHOULD enforce this grammar when creating or editing

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -249,7 +249,7 @@ If a client gives image suggestions (emotes, stickers) to the user in some
 ordered fashion (e.g. an ordered list where you click an entry), the order of
 the image packs SHOULD be predictable between rooms.
 
-A suggestion for clients of image pack ordering is as follows:
+Clients SHOULD implement image pack ordering as follows:
 
 1. User image pack (defined in the user's account data)
 2. Image pack rooms (defined in the `m.image_pack.rooms` user account data
@@ -258,7 +258,7 @@ A suggestion for clients of image pack ordering is as follows:
 4. Space image packs (defined in the hierarchy of canonical spaces for the
     current room)
 
-Note: this MSC does not define an ordering for images within packs. That is left
+Note: this MSC does not define an ordering for images *within* packs. That is left
 to a future MSC.
 
 ### Image properties

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -397,9 +397,9 @@ Clents SHOULD set `height` to "32px". This is a default intended to look good on
 most devices, and is for the benefit of legacy clients that do not treat custom
 emotes differently from other inline images.
 
-Clients implementing this MSC are expected to override the height when rendering
-emotes, based on their particular environment (the user's font size, etc.). Or
-they may choose to display messages containing only emoticons in a larger font.
+Clients implementing this MSC SHOULD override the height when rendering emotes
+based on their particular environment (the user's font size, etc.). They also
+MAY choose to display messages containing only emoticons in a larger font.
 
 A `width` attribute is not required, in order to maintain the aspect ratio of
 non-square emotes.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -435,40 +435,11 @@ the image, or if absent, an empty object.
 
 ### Room upgrades
 
-Upon upgrading a room, homeservers SHOULD transfer `m.room.image_pack` state events
-to the new room.
-
-Homeservers SHOULD also update user's account data so that any
-`m.image_pack.rooms` account data events are re-pointed from the old room ID to
-the newly upgraded room ID; otherwise a user's global packs will quietly grow
-stale.
-
-One possible implementation strategy is laid out below.
-
-Upon a user joining a room;
-
-1. Determine whether the room is the result of a room upgrade from a previous room.
-2. If so, retrieve the previous room's room ID.
-3. Check whether the user has an `m.image_pack.rooms` entry in their account data.
-4. If so, check whether the previous room ID is one of the entries in that data
-  structure.
-5. If it's present, check whether `m.room.image_pack` state events with the
-  referenced `state_key`s exist in the new room.
-6. If so, replace that room ID with the upgraded room IDs. Implementations should
-  handle the case of only *some* `m.room.image_pack` state keys being migrated to
-  the upgraded room.
-
-This leaves the edge case of:
-
-1. The upgraded room is created.
-2. A user joins the upgraded room.
-3. Image packs are then transferred over.
-
-Leaving the user's list of `m.image_pack.rooms` stale.
-
-Thus, when performing a room upgrade, homeserver implementations should take
-care to *first* transfer `m.room.image_pack` state events to a new room, *then*
-invite users to the new room.
+Homeserver implementations may wish to transfer relevant state events and
+account data entries upon room upgrade. This is deliberately left to a future
+MSC to tackle (e.g.
+[MSC4433](https://github.com/matrix-org/matrix-spec-proposals/pull/4433)) to
+reduce the implementation scope of this proposal.
 
 ## Security Considerations
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -274,7 +274,7 @@ based on user preferences.
 
 ### Shortcode grammar
 
-A shortcode's length MUST not exceed 100 bytes. This is to prevent a
+A shortcode's length MUST NOT exceed 100 bytes. This is to prevent a
 sufficiently long shortcode from being impossible to insert into subsequent events
 due to exceeding the event limit (e.g. emoji reactions).
 
@@ -298,7 +298,7 @@ encouraged to use the alternative separators provided; a hyphen (`-`) or
 an underscore (`_`).
 
 The above character set does exclude characters from non-latin languages from
-being included (e.g. ブイチューバー). This is guard against various edge cases of
+being included (e.g. ブイチューバー). This is to guard against various edge cases of
 including all of Unicode (control characters, zalgo, future unicode updates,
 etc.) leading to complicated implementations. It is assumed that users of other
 languages are able to type latin characters when necessary.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -320,17 +320,21 @@ etc.) leading to complicated implementations. It is assumed that users of other
 languages are able to type latin characters when necessary.
 
 A future MSC could add the concept of "aliases" to images - secondary names,
-which would be any Unicode character, making searching for them with non-latin
-characters easier. 
+These restrictions MAY be enforced by homeservers when `m.room.image_pack` events
+are sent by clients into a room (through [`PUT
+/_matrix/client/v3/rooms/{roomId}/state/{eventType}/{stateKey}`](https://spec.matrix.org/v1.17/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey)).
 
-These restrictions MUST be enforced by servers on the Client-Server API, but MUST
-NOT be enforced over the Federation API (i.e. when validating events received
-over federation). This avoids a split-brain in the room. Servers MAY opt to
-locally redact events that don't follow the shortcode grammar.
+`m.room.image_pack` events MUST NOT be rejected or dropped by homeservers for
+failing the shortcode grammar when they are received over federation (via
+`/send`, `/backfill` or any other mechanism). Servers MAY opt to locally
+redact/soft-fail events that don't follow the shortcode grammar if they wish.
 
-Clients SHOULD enforce this grammar as well when creating or editing image
-packs. Clients SHOULD ignore/hide image packs that contain an image with an
-invalid shortcode.
+Clients should note that events with malformed shortcode grammar can be
+delivered to them by the homeserver. Clients SHOULD to try and show emotes and
+stickers in the timeline, as well as image packs that contain them, even if they
+have incorrect shortcode grammar. This allows users to see them and fix them. On
+the flip side, clients SHOULD enforce this grammar when creating or editing
+image packs.
 
 ### Sending
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -313,13 +313,15 @@ grammar](https://spec.matrix.org/v1.17/appendices/#opaque-identifiers) was
 considered, however it is explicitly for "non-user-visible identifier", which
 this is not.
 
-The above character set does exclude characters from non-latin languages from
-being included (e.g. ブイチューバー). This is to guard against various edge cases of
+The above character set does exclude characters from non-English languages (e.g. ブイチューバー). This is to guard against various edge cases of
 including all of Unicode (control characters, zalgo, future unicode updates,
 etc.) leading to complicated implementations. It is assumed that users of other
-languages are able to type latin characters when necessary.
+languages are able to type ascii characters when necessary.
 
 A future MSC could add the concept of "aliases" to images - secondary names,
+which would be any Unicode character, making searching for them with characters
+from other languages easier.
+
 These restrictions MAY be enforced by homeservers when `m.room.image_pack` events
 are sent by clients into a room (through [`PUT
 /_matrix/client/v3/rooms/{roomId}/state/{eventType}/{stateKey}`](https://spec.matrix.org/v1.17/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey)).

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -67,21 +67,21 @@ Part of the joy of custom emotes (and stickers) is to be able to organise them
 into packs and share these packs with others. This proposal defines a mechanism
 for doing so.
 
-#### `m.image_pack` state event
+#### `m.room.image_pack` state event
 
-Image packs are defined by a new state event with type `m.image_pack`. The
+Image packs are defined by a new state event with type `m.room.image_pack`. The
 `state_key` is simply a unique identifier for the pack itself. It is not
 intended to be surfaced to users. This proposal does not associate any special
 property with an empty string for an image pack's `state_key`.
 
-`m.image_pack` state events contain the following keys within their `content`:
+`m.room.image_pack` state events contain the following keys within their `content`:
 
 * `images`: **Required, Map[String, Object]**. A map from a shortcode ([grammar](#shortcode-grammar)) to an [Image Object](#image-object).
 * `pack` **Optional, Object**. A [Pack Object](#pack-object).
 
 ```jsonc
 {
-  "type": "m.image_pack",
+  "type": "m.room.image_pack",
   "state_key": "Blobcats",
   "content": {
     "images": {
@@ -93,6 +93,10 @@ property with an empty string for an image pack's `state_key`.
   // ...
 }
 ```
+
+The event type "m.room.image_pack" was chosen to match other room-level state
+event types, such as `m.room.topic`, `m.room.name`, `m.room.canonical_alias`,
+etc.
 
 #### Pack object
 
@@ -171,7 +175,7 @@ Taking all of this into account, a full image pack event may look like:
 #### User and room image packs
 
 A room itself can have an unlimited amount of image packs by specifying the
-`m.image_pack` state event with different state keys. By default, the user
+`m.room.image_pack` state event with different state keys. By default, the user
 SHOULD be presented with these images only when interacting in the room that
 the packs are defined in.
 
@@ -486,7 +490,7 @@ left in.
 
 | **Stable identifier** | **Unstable identifier** |
 |---|---|
-| `m.image_pack` state event type | `im.ponies.room_emotes` |
+| `m.room.image_pack` state event type | `im.ponies.room_emotes` |
 | `m.image_pack.rooms` account data event type | `im.ponies.emote_rooms` |
 
 ## Potential Issues

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -94,6 +94,9 @@ property with an empty string for an image pack's `state_key`.
 }
 ```
 
+`images` contains information about each individual image in the pack, whereas
+`pack` contains metadata about the image pack as a whole.
+
 The event type "m.room.image_pack" was chosen to match other room-level state
 event types, such as `m.room.topic`, `m.room.name`, `m.room.canonical_alias`,
 etc.

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -182,8 +182,8 @@ SHOULD be presented with these images only when interacting in the room that
 the packs are defined in.
 
 For a user to enable a room image pack to be presented in all rooms, the room ID
-and the image pack's specific `state_key` can be added to a `m.image_pack.rooms`
-account data event.
+(and optionally the image pack's specific `state_key`) can be added to a
+`m.image_pack.rooms` account data event.
 
 #### `m.image_pack.rooms` account data event
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -217,6 +217,9 @@ An example of a `m.image_pack.rooms` account data event:
 }
 ```
 
+Clients should be aware that users may not be in a room referenced by this
+event, and MAY wish to show appropriate UX around this.
+
 An empty object under a room ID, for example:
 
 ```json
@@ -227,12 +230,9 @@ An empty object under a room ID, for example:
 }
 ```
 
-translates to *all image packs that a room defines*, rather than *no image
-packs*. This is intended as an optimisation to reduce event size versus
-listing the (potentially many) packs a room may have.
-
-Clients should be aware that users may not be in the room referenced by this
-event, and MAY wish to show appropriate UX around this.
+currently has no defined meaning. A future MSC may define one, such as "all
+packs in this room". (This MSC previously defined that exact meaning, but no
+client appeared to implement it, leading to the decision to remove it.)
 
 #### Space image packs
 

--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -182,20 +182,19 @@ SHOULD be presented with these images only when interacting in the room that
 the packs are defined in.
 
 For a user to enable a room image pack to be presented in all rooms, the room ID
-can be added to a `m.image_pack.rooms` account data event.
+and the image pack's specific `state_key` can be added to a `m.image_pack.rooms`
+account data event.
 
 #### `m.image_pack.rooms` account data event
 
-The `m.image_pack.rooms` account data event consists of the following:
+The `m.image_pack.rooms` account data event consists of the following fields:
 
 - `rooms` **Required, Map[String, Map[String, Object]]**. A map of room ID to
     another map: from `state_key` to an empty object.
 
 This data structure allows specifying a single room image pack given the pack's
-room ID and `state_key`.
-
-Clients should make the corresponding room image packs globally accessible in all
-rooms.
+room ID and `state_key`. Clients should make the corresponding room image packs
+globally accessible in all rooms.
 
 While this MSC does not define any keys for the bottom-level object, defining it
 as an object means greater flexibility in the case of future changes. For


### PR DESCRIPTION
> [!WARNING]
> This proposal is edited by one or more PRs post-acceptance. Use the "rendered" link instead of this PR's diff to see the final MSC text.

----

[Rendered](https://github.com/matrix-org/matrix-doc/blob/main/proposals/2545-emotes.md)

Signed-off-by: Sorunome <mail@sorunome.de>

Author: @Sorunome
Shepherd: @anoadragon453

## Future MSCs
 - Image pack cross-room referencing / suggesting (https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r753830655)
 - Additional metadata for stickers and emotes to find their pack (https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r753881475)
 - Image pack ordering (https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r910188726)
 - Multiple shortcodes for a single image (https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r598354072)
 - E2EE support (https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r677009720)
 - Image-Pack rooms (needing a room type) (https://github.com/matrix-org/matrix-spec-proposals/pull/2545#discussion_r910190308)

## Differences between historical implementations and the current MSC

See [this comment](https://github.com/matrix-org/matrix-spec-proposals/pull/2545#issuecomment-4144315200) for a high-level overview of the changes since the previous set of implementations and today's MSC.

Implementation authors are recommended to re-read the MSC in general, as it has changed significantly in the past year as the spec was finalised.

## Current implementations
### Emote rendering (rendering of the `<img>` tag)
 - element-web
 - revolution (even handles `data-mx-emoticon`)
 - nheko
 - fluffychat (even handles `data-mx-emoticon`)
 - neochat
 - cinny
### Sending, using the mentioned events here
 - revolution (emoticons)
 - fluffychat (emoticons, stickers)
 - neochat (emoticons, at least partial)
 - nheko (emoticons, stickers)
 - cinny (emoticons, stickers)
 - kazv (stickers)

### Bridges
 - mx-puppet-discord
 - matrix-appservice-discord (partially, sending `data-mx-emoticon` only)

## Implementation PRs
### FluffyChat
Data model: https://gitlab.com/famedly/company/frontend/libraries/matrix_api_lite/-/merge_requests/26
SDK: https://gitlab.com/famedly/company/frontend/famedlysdk/-/merge_requests/726
Emoticons: https://gitlab.com/famedly/fluffychat/-/merge_requests/433
Stickers: https://gitlab.com/famedly/fluffychat/-/merge_requests/452

### Nheko
Stickers:  https://github.com/Nheko-Reborn/nheko/pull/648
Sticker editor: https://github.com/Nheko-Reborn/nheko/pull/669
Choosing emoticons: https://github.com/Nheko-Reborn/nheko/commit/ea6b19b3077dad0280e32aa762137728432e01f4

### Cinny
Emoticons and Stickers: https://github.com/cinnyapp/cinny/pull/686

### kazv
Creating and sending stickers: https://lily-is.land/kazv/kazv/-/merge_requests/71

---

SCT Stuff:

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/2545#issuecomment-2895228031)

[MSC Checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/2545#issuecomment-2895234488)
