### PR TITLE
Fix some numbers in the spec text.

### DIFF
--- a/changelogs/client_server/newsfragments/2554.clarification
+++ b/changelogs/client_server/newsfragments/2554.clarification
@@ -1,0 +1,1 @@
+Fix some numbers in the specification to match their explanation text.

--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -513,7 +513,7 @@ received the other party's part. Thus an attacker essentially only has one attem
 attack the Diffie-Hellman exchange, and hence we can verify fewer bits while still
 achieving a high degree of security: if we verify n bits, then an attacker has a 1 in
 2\ :sup:`n` chance of success.  For example, if we verify 40 bits, then an attacker has
-a 1 in 1,099,511,627,776 chance (or less than 1 in 1012 chance) of success. A failed
+a 1 in 1,099,511,627,776 chance (or less than 1 in 10\ :sup:`12` chance) of success. A failed
 attack would result in a mismatched Short Authentication String, alerting users to the
 attack.
 

--- a/specification/modules/tags.rst
+++ b/specification/modules/tags.rst
@@ -55,7 +55,7 @@ The tag namespace is defined as follows:
   display name directly). These non-namespaced tags are supported for historical reasons. New tags should use
   one of the defined namespaces above.
 
-Two special names are listed in the specification:
+Three special names are listed in the specification:
 The following tags are defined in the ``m.*`` namespace:
 
 * ``m.favourite``: The user's favourite rooms. These should be shown with higher precedence than other rooms.

--- a/specification/modules/tags.rst
+++ b/specification/modules/tags.rst
@@ -55,7 +55,7 @@ The tag namespace is defined as follows:
   display name directly). These non-namespaced tags are supported for historical reasons. New tags should use
   one of the defined namespaces above.
 
-Three special names are listed in the specification:
+Several special names are listed in the specification:
 The following tags are defined in the ``m.*`` namespace:
 
 * ``m.favourite``: The user's favourite rooms. These should be shown with higher precedence than other rooms.


### PR DESCRIPTION
Odds were not written as an exponent.
Special tag names count was not updated.

Fixes #2550

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>