### PR TITLE
Remove claim that profile info is exclusively managed by the server

### DIFF
--- a/changelogs/client_server/newsfragments/2574.clarification
+++ b/changelogs/client_server/newsfragments/2574.clarification
@@ -1,0 +1,1 @@
+Remove claims that the homeserver is exclusively responsible for profile information in membership events.

--- a/event-schemas/schema/m.room.member
+++ b/event-schemas/schema/m.room.member
@@ -48,10 +48,10 @@ properties:
   content:
     properties:
       avatar_url:
-        description: 'The avatar URL for this user, if any. This is added by the homeserver.'
+        description: 'The avatar URL for this user, if any.'
         type: string
       displayname:
-        description: 'The display name for this user, if any. This is added by the homeserver.'
+        description: 'The display name for this user, if any.'
         type:
           - "string"
           - "null"


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2496