### PR TITLE
Clarify the auth_chain and state requirements for /send_join

### DIFF
--- a/api/server-server/definitions/send_join_response.yaml
+++ b/api/server-server/definitions/send_join_response.yaml
@@ -1,0 +1,55 @@
+# Copyright 2018 New Vector Ltd
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+type: object
+title: Room State
+description: The state for the room.
+properties:
+  origin:
+    type: string
+    description: The resident server's DNS name.
+  auth_chain:
+    type: array
+    description: |-
+      The auth chain. Note that events have a different format depending on
+      the room version - check the `room version specification`_ for precise
+      event formats.
+    items:
+      type: object
+      title: PDU
+      description: |-
+        The `PDUs <#pdus>`_ that make up the auth chain. The event format varies depending
+        on the room version - check the `room version specification`_ for precise event formats.
+      schema:
+        type: object
+        properties: []
+      example:
+        $ref: "../examples/minimal_pdu.json"
+  state:
+    type: array
+    description: |-
+      The room state. The event format varies depending on the room version -
+      check the `room version specification`_ for precise event formats.
+    items:
+      type: object
+      title: PDU
+      description: |-
+        The `PDUs <#pdus>`_ for the fully resolved state of the room. The event format varies depending
+        on the room version - check the `room version specification`_ for precise event formats.
+      schema:
+        type: object
+        properties: []
+      example:
+        $ref: "../examples/minimal_pdu.json"
+required: ["auth_chain", "state", "origin"]

--- a/api/server-server/definitions/send_join_response.yaml
+++ b/api/server-server/definitions/send_join_response.yaml
@@ -22,9 +22,10 @@ properties:
   auth_chain:
     type: array
     description: |-
-      The auth chain. Note that events have a different format depending on
-      the room version - check the `room version specification`_ for precise
-      event formats.
+      The auth chain for the entire current room state prior to the join event.
+
+      Note that events have a different format depending on the room version - check the
+      `room version specification`_ for precise event formats.
     items:
       type: object
       title: PDU
@@ -39,8 +40,10 @@ properties:
   state:
     type: array
     description: |-
-      The room state. The event format varies depending on the room version -
-      check the `room version specification`_ for precise event formats.
+      The resolved current room state prior to the join event.
+
+      The event format varies depending on the room version - check the `room version specification`_
+      for precise event formats.
     items:
       type: object
       title: PDU

--- a/api/server-server/joins-v1.yaml
+++ b/api/server-server/joins-v1.yaml
@@ -262,47 +262,7 @@ paths:
               - type: integer
                 description: The value ``200``.
                 example: 200
-              - type: object
-                title: Room State
-                description: The state for the room.
-                properties:
-                  origin:
-                    type: string
-                    description: The resident server's DNS name.
-                  auth_chain:
-                    type: array
-                    description: |-
-                      The auth chain. Note that events have a different format depending on
-                      the room version - check the `room version specification`_ for precise
-                      event formats.
-                    items:
-                      type: object
-                      title: PDU
-                      description: |-
-                        The `PDUs <#pdus>`_ that make up the auth chain. The event format varies depending
-                        on the room version - check the `room version specification`_ for precise event formats.
-                      schema:
-                        type: object
-                        properties: []
-                      example:
-                        $ref: "examples/minimal_pdu.json"
-                  state:
-                    type: array
-                    description: |-
-                      The room state. The event format varies depending on the room version -
-                      check the `room version specification`_ for precise event formats.
-                    items:
-                      type: object
-                      title: PDU
-                      description: |-
-                        The `PDUs <#pdus>`_ for the fully resolved state of the room. The event format varies depending
-                        on the room version - check the `room version specification`_ for precise event formats.
-                      schema:
-                        type: object
-                        properties: []
-                      example:
-                        $ref: "examples/minimal_pdu.json"
-                required: ["auth_chain", "state", "origin"]
+              - $ref: "./definitions/send_join_response.yaml"
           examples:
             application/json: [
               200,

--- a/api/server-server/joins-v2.yaml
+++ b/api/server-server/joins-v2.yaml
@@ -127,47 +127,7 @@ paths:
           description: |-
             The full state for the room, having accepted the join event.
           schema:
-            type: object
-            title: Room State
-            description: The state for the room.
-            properties:
-              origin:
-                type: string
-                description: The resident server's DNS name.
-              auth_chain:
-                type: array
-                description: |-
-                  The auth chain. Note that events have a different format depending on
-                  the room version - check the `room version specification`_ for precise
-                  event formats.
-                items:
-                  type: object
-                  title: PDU
-                  description: |-
-                    The `PDUs <#pdus>`_ that make up the auth chain. The event format varies depending
-                    on the room version - check the `room version specification`_ for precise event formats.
-                  schema:
-                    type: object
-                    properties: []
-                  example:
-                    $ref: "examples/minimal_pdu.json"
-              state:
-                type: array
-                description: |-
-                  The room state. The event format varies depending on the room version -
-                  check the `room version specification`_ for precise event formats.
-                items:
-                  type: object
-                  title: PDU
-                  description: |-
-                    The `PDUs <#pdus>`_ for the fully resolved state of the room. The event format varies depending
-                    on the room version - check the `room version specification`_ for precise event formats.
-                  schema:
-                    type: object
-                    properties: []
-                  example:
-                    $ref: "examples/minimal_pdu.json"
-            required: ["auth_chain", "state", "origin"]
+            $ref: "./definitions/send_join_response.yaml"
           examples:
             application/json: {
               "origin": "matrix.org",

--- a/changelogs/server_server/newsfragments/2575.clarification
+++ b/changelogs/server_server/newsfragments/2575.clarification
@@ -1,0 +1,1 @@
+Clarify the state/auth chain requirements for ``/send_join``.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2467
Fixes https://github.com/matrix-org/matrix-doc/issues/2464

**This should be reviewed commit-by-commit.**

This is based on looking at Synapse, not actually testing it. Within the send_join handling functions, an "event context" is acquired [here](https://github.com/matrix-org/synapse/blob/d14c4d6b6d02e8c55a6647ce0f0b3b44356d6173/synapse/handlers/federation.py#L1472) which then later uses the previous state (populated [here](https://github.com/matrix-org/synapse/blob/d14c4d6b6d02e8c55a6647ce0f0b3b44356d6173/synapse/state/__init__.py#L286-L289) in the event context) [here](https://github.com/matrix-org/synapse/blob/d14c4d6b6d02e8c55a6647ce0f0b3b44356d6173/synapse/handlers/federation.py#L1494-L1501) to return a response. Within the event context, the previous state IDs are populated [here](https://github.com/matrix-org/synapse/blob/d14c4d6b6d02e8c55a6647ce0f0b3b44356d6173/synapse/state/__init__.py#L351).