### PR TITLE
Fix EncryptedFile lacking mimetype

### DIFF
--- a/specification/modules/end_to_end_encryption.rst
+++ b/specification/modules/end_to_end_encryption.rst
@@ -299,6 +299,7 @@ hashes    {string: string} **Required.** A map from an algorithm name to a hash
                            ``sha256``.
 v         string           **Required.** Version of the encrypted attachments
                            protocol. Must be ``v2``.
+mimetype  string           The mimetype of the file, e.g. ``image/jpeg``
 ========= ================ =====================================================
 
 ``JWK``


### PR DESCRIPTION
The example already had the mimetype parameter, but the definition lacked it.

Signed-off-by: Sorunome <mail@sorunome.de>