### PR TITLE
MSC2582: Remove mimetype from EncryptedFile object

### DIFF
--- a/proposals/2582-remove-mimetype-from-encrypted-file.md
+++ b/proposals/2582-remove-mimetype-from-encrypted-file.md
@@ -1,0 +1,11 @@
+# Remove `mimetype` from `EncryptedFile` object
+
+
+## Proposal
+The example in the spec currently lists `mimetype` in the examples for `EncryptedFile` but not in
+the object definition. As that is duplicate information of the `info` block of file events, the
+mimetype should just be removed alltogether.
+
+
+## Potential issues
+Some clients might depend on this?

--- a/proposals/2582-remove-mimetype-from-encrypted-file.md
+++ b/proposals/2582-remove-mimetype-from-encrypted-file.md
@@ -2,7 +2,7 @@
 
 
 ## Proposal
-The example in the spec currently lists `mimetype` in the examples for `EncryptedFile` but not in
+The example in the spec currently lists `mimetype` in the [examples for `EncryptedFile`](https://matrix.org/docs/spec/client_server/r0.6.1#extensions-to-m-message-msgtypes) but not in
 the object definition. As that is duplicate information of the `info` block of file events, the
 mimetype should just be removed alltogether.
 

--- a/proposals/2582-remove-mimetype-from-encrypted-file.md
+++ b/proposals/2582-remove-mimetype-from-encrypted-file.md
@@ -8,4 +8,5 @@ mimetype should just be removed alltogether.
 
 
 ## Potential issues
-Some clients might depend on this?
+Some clients might depend on this.  However, as of August 2021, all known clients have
+been confirmed to not use this.


### PR DESCRIPTION
[Rendered](https://github.com/Sorunome/matrix-doc/blob/soru/remove-mimetype-from-encrypted-file/proposals/2582-remove-mimetype-from-encrypted-file.md)

Signed-off-by: Sorunome <mail@sorunome.de>

Implementations:
- Element Android: vector-im/element-android#3273
- Element iOS: matrix-org/matrix-ios-sdk#1125
- Element Web: matrix-org/matrix-react-sdk#6591

Link to relevant spec: https://spec.matrix.org/unstable/client-server-api/#extensions-to-mroommessage-msgtypes