### PR TITLE
capabilities.yaml: drop an extraneous title

### DIFF
--- a/api/client-server/capabilities.yaml
+++ b/api/client-server/capabilities.yaml
@@ -96,7 +96,6 @@ paths:
                         example: "1"
                       available:
                         type: object
-                        title: AvailableRoomVersions
                         description: |-
                           A detailed description of the room versions the server supports.
                         additionalProperties:

--- a/changelogs/client_server/newsfragments/2592.clarification
+++ b/changelogs/client_server/newsfragments/2592.clarification
@@ -1,0 +1,1 @@
+c2s: fix disconnected data structure in the documentation on server capabilities.

--- a/changelogs/client_server/newsfragments/2592.clarification
+++ b/changelogs/client_server/newsfragments/2592.clarification
@@ -1,1 +1,1 @@
-c2s: fix disconnected data structure in the documentation on server capabilities.
+Fix definitions for room version capabilities.


### PR DESCRIPTION
AvailableRoomVersions sticks itself as a property type, preempting
the mention of RoomVersionStability in the generated text.