### PR TITLE
Clarify link to OpenID Connect specification

### DIFF
--- a/api/client-server/openid.yaml
+++ b/api/client-server/openid.yaml
@@ -62,7 +62,7 @@ paths:
         200:
           description: |-
             OpenID token information. This response is nearly compatible with the
-            response documented in the `OpenID 1.0 Specification <http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse>`_
+            response documented in the `OpenID Connect 1.0 Specification <http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse>`_
             with the only difference being the lack of an ``id_token``. Instead,
             the Matrix homeserver's name is provided.
           examples:

--- a/changelogs/client_server/newsfragments/2605.clarification
+++ b/changelogs/client_server/newsfragments/2605.clarification
@@ -1,0 +1,1 @@
+Clarify link to OpenID Connect specification.


### PR DESCRIPTION
OpenID Connect and OpenID are different things. This seems to be talking about
the former.