### PR TITLE
Remove room_id from /sync examples

### DIFF
--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -379,7 +379,6 @@ paths:
                       "state": {
                         "events": [
                           {
-                            "room_id": "!726s6s6q:example.com",
                             "$ref": "definitions/event-schemas/examples/m.room.member"
                           }
                         ]
@@ -387,11 +386,9 @@ paths:
                       "timeline": {
                         "events": [
                           {
-                            "room_id": "!726s6s6q:example.com",
                             "$ref": "definitions/event-schemas/examples/m.room.member"
                           },
                           {
-                            "room_id": "!726s6s6q:example.com",
                             "$ref": "definitions/event-schemas/examples/m.room.message$m.text"
                           }
                         ],

--- a/changelogs/client_server/newsfragments/2629.clarification
+++ b/changelogs/client_server/newsfragments/2629.clarification
@@ -1,0 +1,1 @@
+Remove ``room_id`` from ``/sync`` examples.


### PR DESCRIPTION
I think this should also be more explicit in the documentation for the sync endpoint, but I'm not sure, how to do that. One way would be to add a note box with "Be aware, that events returned by this endpoint do **not** include a room_id since that would duplicate the `room_id` -> Room mapping."

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>