### PR TITLE
various key backups fixes

### DIFF
--- a/api/client-server/definitions/room_key_backup.yaml
+++ b/api/client-server/definitions/room_key_backup.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 The Matrix.org Foundation C.I.C.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: object
+title: RoomKeyBackup
+description: "The backed up keys for a room."
+properties:
+  sessions:
+    type: object
+    description: "A map of session IDs to key data."
+    additionalProperties:
+      allOf:
+        - $ref: "key_backup_data.yaml"
+    example: {
+      "sessionid1": {
+        "first_message_index": 1,
+        "forwarded_count": 0,
+        "is_verified": true,
+        "session_data": {
+          "ephemeral": "base64+ephemeral+key",
+          "ciphertext": "base64+ciphertext+of+JSON+data",
+          "mac": "base64+mac+of+ciphertext"
+        }
+      }
+    }
+required:
+  - sessions

--- a/api/client-server/key_backup.yaml
+++ b/api/client-server/key_backup.yaml
@@ -130,7 +130,7 @@ paths:
                 example: "anopaquestring"
               version:
                 type: string
-                description: The backup version
+                description: The backup version.
                 example: "1"
             required:
               - algorithm
@@ -212,7 +212,7 @@ paths:
                 example: "anopaquestring"
               version:
                 type: string
-                description: The backup version
+                description: The backup version.
                 example: "1"
             required:
               - algorithm
@@ -450,7 +450,7 @@ paths:
           type: string
           name: version
           description: |-
-            The backup from which to retrieve the key
+            The backup from which to retrieve the key.
           required: true
           x-example: "1"
         - in: path
@@ -645,7 +645,7 @@ paths:
           type: string
           name: version
           description: |-
-            The backup from which to retrieve the key
+            The backup from which to retrieve the key.
           required: true
           x-example: "1"
         - in: path
@@ -702,7 +702,7 @@ paths:
           type: string
           name: version
           description: |-
-            The backup from which to delete the key
+            The backup from which to delete the key.
           required: true
           x-example: "1"
         - in: path
@@ -846,8 +846,8 @@ paths:
           type: string
           name: version
           description: |-
-            The backup from which to retrieve the keys. If omitted, the keys are
-            retrieved from the current backup.
+            The backup from which to retrieve the keys.
+          required: true
           x-example: "1"
       responses:
         200:

--- a/api/client-server/key_backup.yaml
+++ b/api/client-server/key_backup.yaml
@@ -569,22 +569,7 @@ paths:
           description: "The backup data"
           name: backupData
           schema:
-            type: object
-            properties:
-              sessions:
-                type: object
-                description: |-
-                  A map of session IDs to key data.
-                additionalProperties:
-                  allOf:
-                    - $ref: "definitions/key_backup_data.yaml"
-                example: {
-                  "sessionid1": {
-                    "ephemeral": "base64+ephemeral+key",
-                    "ciphertext": "base64+ciphertext+of+JSON+data",
-                    "mac": "base64+mac+of+ciphertext"
-                  }
-                }
+            $ref: "definitions/room_key_backup.yaml"
       responses:
         200:
           description: The update succeeded
@@ -661,21 +646,7 @@ paths:
             ``sessions`` property will be returned (``{"sessions": {}}``).
           schema:
             type: object
-            properties:
-              sessions:
-                type: object
-                description: |-
-                  A map of session IDs to key data.
-                additionalProperties:
-                  allOf:
-                    - $ref: "definitions/key_backup_data.yaml"
-                example: {
-                  "sessionid1": {
-                    "ephemeral": "base64+ephemeral+key",
-                    "ciphertext": "base64+ciphertext+of+JSON+data",
-                    "mac": "base64+mac+of+ciphertext"
-                  }
-                }
+            $ref: "definitions/room_key_backup.yaml"
         404:
           description: |-
             The backup was not found.
@@ -761,7 +732,7 @@ paths:
           required: true
           x-example: "1"
         - in: body
-          description: "The backup data"
+          description: "The backup data."
           name: backupData
           schema:
             type: object
@@ -769,23 +740,28 @@ paths:
               rooms:
                 type: object
                 description: |-
-                  A map of room IDs to session IDs to key data.
+                  A map of room IDs to room key backup data.
                 additionalProperties:
-                  type: object
-                  additionalProperties:
-                    allOf:
-                      - $ref: "definitions/key_backup_data.yaml"
+                  allOf:
+                    - $ref: "definitions/room_key_backup.yaml"
                 example: {
                   "!room:example.org": {
                     "sessions": {
                       "sessionid1": {
-                        "ephemeral": "base64+ephemeral+key",
-                        "ciphertext": "base64+ciphertext+of+JSON+data",
-                        "mac": "base64+mac+of+ciphertext"
+                        "first_message_index": 1,
+                        "forwarded_count": 0,
+                        "is_verified": true,
+                        "session_data": {
+                          "ephemeral": "base64+ephemeral+key",
+                          "ciphertext": "base64+ciphertext+of+JSON+data",
+                          "mac": "base64+mac+of+ciphertext"
+                        }
                       }
                     }
                   }
                 }
+            required:
+              - rooms
       responses:
         200:
           description: The update succeeded
@@ -860,19 +836,22 @@ paths:
               rooms:
                 type: object
                 description: |-
-                  A map of room IDs to session IDs to key data.
+                  A map of room IDs to room key backup data.
                 additionalProperties:
-                  type: object
-                  additionalProperties:
-                    allOf:
-                      - $ref: "definitions/key_backup_data.yaml"
+                  allOf:
+                    - $ref: "definitions/room_key_backup.yaml"
                 example: {
                   "!room:example.org": {
                     "sessions": {
                       "sessionid1": {
-                        "ephemeral": "base64+ephemeral+key",
-                        "ciphertext": "base64+ciphertext+of+JSON+data",
-                        "mac": "base64+mac+of+ciphertext"
+                        "first_message_index": 1,
+                        "forwarded_count": 0,
+                        "is_verified": true,
+                        "session_data": {
+                          "ephemeral": "base64+ephemeral+key",
+                          "ciphertext": "base64+ciphertext+of+JSON+data",
+                          "mac": "base64+mac+of+ciphertext"
+                        }
                       }
                     }
                   }

--- a/changelogs/client_server/2639.clarification
+++ b/changelogs/client_server/2639.clarification
@@ -1,0 +1,1 @@
+Fixed some errors in the key backup spec.


### PR DESCRIPTION
Rendered: starting at https://13733-24998719-gh.circle-artifacts.com/0/scripts/gen/client_server/unstable.html#put-matrix-client-r0-room-keys-keys-roomid-sessionid

- make version required for `GET /room_keys/keys` required [1]
- make `GET`/`PUT` `/_matrix/client/r0/room_keys/keys/` format correct
- add some full stops
- pull room backups into a common definition file

[1]Thanks to nico for noticing.

The other `GET /room_keys/keys/*` endpoints already had it marked as required, but apparently not this one.  It seems the MSC did say that it was optional, although that doesn't make any sense because you can't decrypt the backup without knowing which version it belongs to, and nothing that's returned doesn't tell you the endpoint.  The synapse implementation treats it as required.