### PR TITLE
Clarify that prev_content is part of unsigned, always

### DIFF
--- a/changelogs/client_server/newsfragments/2648.clarification
+++ b/changelogs/client_server/newsfragments/2648.clarification
@@ -1,0 +1,1 @@
+Clarify that ``prev_content`` is part of ``unsigned``, always.

--- a/event-schemas/schema/core-event-schema/sync_state_event.yaml
+++ b/event-schemas/schema/core-event-schema/sync_state_event.yaml
@@ -19,11 +19,6 @@ allOf:
 description: In addition to the Room Event fields, State Events have the following
   additional fields.
 properties:
-  prev_content:
-    description: Optional. The previous ``content`` for this event. If there is no
-      previous content, this key will be missing.
-    title: EventContent
-    type: object
   state_key:
     description: A unique key which defines the overwriting semantics for this piece
       of room state. This value is often a zero-length string. The presence of this
@@ -33,6 +28,16 @@ properties:
       as room members. With the exception of a few events, state events set with a
       given user's ID as the state key MUST only be set by that user.
     type: string
+  unsigned:
+    description: Optional extra information about the event.
+    properties:
+      prev_content:
+        description: Optional. The previous ``content`` for this event. If there is no
+          previous content, this key will be missing.
+        title: EventContent
+        type: object
+    title: UnsignedData
+    type: object
 required:
 - state_key
 title: State Event

--- a/event-schemas/schema/m.room.member
+++ b/event-schemas/schema/m.room.member
@@ -28,8 +28,8 @@ description: |-
 
   The ``membership`` for a given user can change over time. The table below represents the various changes
   over time and how clients and servers must interpret those changes. Previous membership can be retrieved
-  from the ``prev_content`` object on an event. If not present, the user's previous membership must be assumed
-  as ``leave``.
+  from the ``prev_content`` object inside an event's ``unsigned`` object. If not present, the user's
+  previous membership must be assumed as ``leave``.
 
   .. TODO: Improve how this table is written? We use a csv-table to get around vertical header restrictions.
 

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1553,21 +1553,21 @@ State Event Fields
 
 In addition to the fields of a Room Event, State Events have the following fields.
 
-+--------------+--------------+-------------------------------------------------------------+
-| Key          | Type         | Description                                                 |
-+==============+==============+=============================================================+
-| state_key    | string       | **Required.** A unique key which defines the overwriting    |
-|              |              | semantics for this piece of room state. This value is often |
-|              |              | a zero-length string. The presence of this key makes this   |
-|              |              | event a State Event. State keys starting with an ``@`` are  |
-|              |              | reserved for referencing user IDs, such as room members.    |
-|              |              | With the exception of a few events, state events set with   |
-|              |              | a given user's ID as the state key MUST only be set by that |
-|              |              | user.                                                       |
-+--------------+--------------+-------------------------------------------------------------+
-| prev_content | EventContent | Optional. The previous ``content`` for this event. If there |
-|              |              | is no previous content, this key will be missing.           |
-+--------------+--------------+-------------------------------------------------------------+
++-------------------+--------------+-------------------------------------------------------------+
+| Key               | Type         | Description                                                 |
++===================+==============+=============================================================+
+| state_key         | string       | **Required.** A unique key which defines the overwriting    |
+|                   |              | semantics for this piece of room state. This value is often |
+|                   |              | a zero-length string. The presence of this key makes this   |
+|                   |              | event a State Event. State keys starting with an ``@`` are  |
+|                   |              | reserved for referencing user IDs, such as room members.    |
+|                   |              | With the exception of a few events, state events set with   |
+|                   |              | a given user's ID as the state key MUST only be set by that |
+|                   |              | user.                                                       |
++-------------------+--------------+-------------------------------------------------------------+
+| prev_content      | EventContent | Optional. The previous ``content`` for this event. If there |
+| (inside unsigned) |              | is no previous content, this key will be missing.           |
++-------------------+--------------+-------------------------------------------------------------+
 
 
 Size limits


### PR DESCRIPTION
Fixes #877.

Signed-off-by: Jonas Platte <jplatte@posteo.de>