### PR TITLE
Various small fixes in e2e spec

### DIFF
--- a/changelogs/client_server/newsfragments/2647.clarification
+++ b/changelogs/client_server/newsfragments/2647.clarification
@@ -1,1 +1,1 @@
-Improve consistency and clarity of event schema ``title``s.
+Improve consistency and clarity of event schema ``title``\ s.

--- a/changelogs/client_server/newsfragments/2653.clarification
+++ b/changelogs/client_server/newsfragments/2653.clarification
@@ -1,0 +1,1 @@
+Fix some errors in the end-to-end encryption spec.

--- a/event-schemas/schema/m.key.verification.accept
+++ b/event-schemas/schema/m.key.verification.accept
@@ -13,11 +13,6 @@ properties:
         description: |-
           An opaque identifier for the verification process. Must be the same as
           the one used for the ``m.key.verification.start`` message.
-      method:
-        type: string
-        enum: ["m.sas.v1"]
-        description: |-
-          The verification method to use.
       key_agreement_protocol:
         type: string
         description: |-

--- a/specification/modules/secrets.rst
+++ b/specification/modules/secrets.rst
@@ -161,11 +161,11 @@ encrypted as follows:
 ============ =========== =======================================================
 Parameter    Type        Description
 ============ =========== =======================================================
-iv           String      **Required.** The 16-byte initialization vector,
+iv           string      **Required.** The 16-byte initialization vector,
                          encoded as base64.
-ciphertext   String      **Required.** The AES-CTR-encrypted data, encoded as
+ciphertext   string      **Required.** The AES-CTR-encrypted data, encoded as
                          base64.
-mac          String      **Required.** The MAC, encoded as base64.
+mac          string      **Required.** The MAC, encoded as base64.
 ============ =========== =======================================================
 
 For the purposes of allowing clients to check whether a user has correctly
@@ -185,10 +185,10 @@ name         string      **Required.** The name of the key.
 algorithm    string      **Required.** The encryption algorithm to be used for
                          this key. Currently, only
                          ``m.secret_storage.v1.aes-hmac-sha2`` is supported.
-passphrase   string      See `deriving keys from passphrases`_ section for a
+passphrase   object      See `deriving keys from passphrases`_ section for a
                          description of this property.
-iv           String      The 16-byte initialization vector, encoded as base64.
-mac          String      The MAC of the result of encrypting 32 bytes of 0,
+iv           string      The 16-byte initialization vector, encoded as base64.
+mac          string      The MAC of the result of encrypting 32 bytes of 0,
                          encoded as base64.
 ============ =========== =======================================================
 


### PR DESCRIPTION
- use the same capitalization of `string` as is used elsewhere
- `passphrase` is an `object`, not a `string`
- `method` field doesn't exist for `key.verification.accept` (fixes https://github.com/matrix-org/matrix-doc/issues/2651)
- also fix another changelog entry (do I need a changelog for a changelog fix?)