### PR TITLE
MSC2675: Serverside aggregations of message relationships

### DIFF
--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -153,7 +153,7 @@ To iterate over the aggregations for an event (optionally filtering by
 relation type and target event type):
 
 ```
-GET /_matrix/client/v1/rooms/{roomID}/aggregations/{eventID}[/{relationType}][/{eventType}][?from=token][&to=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}[/{rel_type}[/{event_type}]][?from=token][&to=token][&limit=amount]
 ```
 
 This is just non-normative example of what the aggregation for this

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -176,7 +176,7 @@ The endpoint does not have any trailing slashes.
 The `from`, `to` and `limit` query parameters are used for pagination, and work
 just like described for the `/messages` endpoint.
 
-Trying to iterate over an relation type which does not use an aggregation key
+Trying to iterate over a relation type which does not use an aggregation key
 (i.e. `m.replace` and `m.reference`) should fail with 400 and error
 `M_INVALID_REL_TYPE`.
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -335,7 +335,9 @@ not visible to them.
  * Information about relations sent from ignored users must never be sent to
    the client, either in aggregations or discrete relation events.
    This is to let you block someone from harassing you with emoji reactions
-   (or using edits as a side-channel to harass you).
+   (or using edits as a side-channel to harass you). Therefor, it is possible
+   that different users will see different aggregations (a different last edit,
+   or a different reaction count) on an event.
 
 ## Limitations
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -40,7 +40,7 @@ events to relate to each other.  Together, these proposals replace
 
 Relation events can be aggregated per `rel_type` by the server.
 The format of the aggregated value (hereafter called "aggregation")
-in the bundle depends on the relation type.
+depends on the relation type.
 
 Some `rel_type`s might additionally group the aggregations by the `key` property
 in the relation and aggregate to an array,

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -94,7 +94,7 @@ For relation types that aggregate to an array, future MSCs could opt to
 paginate within each group using Matrix's defined pagination idiom of
 `next_batch` and `chunk` - respectively giving a pagination token if there are
 more aggregations, and an array of elements in the list. Only the first page
-is bundled, pagination of subsequent pages happens through the `/aggregations`
+is bundled; pagination of subsequent pages happens through the `/aggregations`
 API that is defined in this MSC. The maximum amount of aggregations bundled
 before the list is truncated is determined freely by the server.
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -249,14 +249,14 @@ Since the server has to be able to aggregate relation events, structural
 information about relations must be visible to the server, and so the
 `m.relates_to` field must be included in the plaintext.
 
+A future MSC may define a method for encrypting certain parts of the
+`m.relates_to` field that may contain sensitive information.
+
 When sending relation events whose [visibility is derived from the target event](#relation-visibility),
 clients should ensure that the end-to-end encryption keys for the encrypted
 relation events is shared with all devices that could see the target event,
 even if those relation events are encrypted with a different key than
 the target event, and even if the receiving user has since left the room.
-
-A future MSC may define a method for encrypting certain parts of the
-`m.relates_to` field that may contain sensitive information.
 
 ### Redactions
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -49,7 +49,7 @@ others might aggregate to a single object or any other value really.
 #### Bundled aggregations
 
 Other than during non-gappy incremental syncs, timeline events that have other
-events relate to it should bundle the aggregation of those related events
+events relate to them should include the aggregation of those related events
 in the `m.relations` property of their unsigned data.  These are called
 bundled aggregations, and by sending a summary of the relations,
 avoids us having to always send lots of individual relation events

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -153,7 +153,7 @@ To iterate over the aggregations for an event (optionally filtering by
 relation type and target event type):
 
 ```
-GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}[/{rel_type}[/{event_type}]][?from=token][&to=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}/{rel_type}[/{event_type}][?from=token][&to=token][&limit=amount]
 ```
 
 ```json

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -38,7 +38,7 @@ events to relate to each other.  Together, these proposals replace
 
 ### Aggregations
 
-Relation events can be aggregated per relation type (`rel_type`) by the server.
+Relation events can be aggregated per relation type by the server.
 The format of the aggregated value (hereafter called "aggregation")
 depends on the relation type.
 
@@ -90,7 +90,7 @@ to the client.
 
 Aggregations are never bundled into state events.
 
-Here's an example of what that can look like for some ficticious `rel_type`s:
+Here's an example of what that can look like for some ficticious relation types:
 
 ```json
 {
@@ -118,7 +118,7 @@ with events they return:
 Deprecated APIs like `/initialSync` and `/events/{eventId}` are *not* required
 to bundle aggregations.
 
-The bundled aggregations are grouped according to their `rel_type`.
+The bundled aggregations are grouped according to their relation type.
 
 For relation types that aggregate to an array, future MSCs could opt to 
 paginate within each group using Matrix's defined pagination idiom of

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -134,8 +134,8 @@ same as the one described here for the server.
 ### Querying relations
 
 A single event can have lots of associated relations, and we do not want to
-overload the client by including them all bundled with the related-to event
-like we do for aggregations. Instead, we also provide a new `/relations` API in
+overload the client by, for example, including them all bundled with the
+related-to event. Instead, we also provide a new `/relations` API in
 order to paginate over the relations, which behaves in a similar way to
 `/messages`, except using `next_batch` and `prev_batch` names
 (in line with `/sync` API).

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -236,7 +236,7 @@ common case for rapidly fixing a typo in a msg which is still in flight!)
 
 ### Ignore relation events for which the target is not visible to us.
 
-Clients should ignore relation events for which the target event is
+Clients can ignore relation events for which the target event is
 not visible to them.
 
 ### How do you handle ignored users?

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -96,7 +96,7 @@ before the list is truncated is determined freely by the server.
 For instance, the below example shows an event with five bundled relations:
 one replace, one reference and three thumbsup reaction annotations,
 with more aggregated reactions available to paginate in
-through `/aggregations` as `next_batch` is present..
+through `/aggregations` as `next_batch` is present.
 
 These are just non-normative examples of what the aggregation for these
 relation types could look like, and their MSCs might end up with

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -239,7 +239,7 @@ The visibility for relation events is dependent on the `rel_type`, with two opti
     event would be visible to a user, then the visibility of target event
     should not be considered and the relation event should be visible.
     This option means that events can still be visible to a user after
-    they have left the room, and has implications
+    the user left the room, and has implications
     for [End-to-end encryption](#end-to-end-encryption).
     [`m.replace`](https://github.com/matrix-org/matrix-doc/pull/2676) and [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) relation events have this visilibilty, see those respective MSCs.
   - Visibility is the same as a non-relation event.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -147,7 +147,7 @@ GET /_matrix/client/r0/rooms/{roomID}/aggregations/{eventID}[/{relationType}][/{
 ```
 
 This is just non-normative example of what the aggregation for this
-relation types could look like, but its MSCs might end up with
+relation types could look like, and its MSCs might end up with
 a different shape, take this with a grain of salt.
 
 ```json

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -140,7 +140,9 @@ overload the client by, for example, including them all bundled with the
 related-to event. Instead, we also provide a new `/relations` API in
 order to paginate over the relations, which behaves in a similar way to
 `/messages`, except using `next_batch` and `prev_batch` names
-(in line with `/sync` API).
+(in line with `/sync` API). Tokens from `/sync` or `/messages` can be
+passed to `/relations` to only get relating events from a section of
+the timeline.
 
 The `/relations` API returns the discrete relation events
 associated with an event that the server is aware of
@@ -150,7 +152,7 @@ You can filter by a given relation type and optionally the event type of the
 relating event:
 
 ```
-GET /_matrix/client/v1/rooms/{roomID}/relations/{event_id}/{rel_type}[/{event_type}][?from=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{roomID}/relations/{event_id}/{rel_type}[/{event_type}][?from=token][&to=token][&limit=amount]
 ```
 
 ```json
@@ -162,6 +164,7 @@ GET /_matrix/client/v1/rooms/{roomID}/relations/{event_id}/{rel_type}[/{event_ty
       "content": { }
     }
   ],
+  "prev_batch": "some_token",
   "next_batch": "some_token",
 }
 ```

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -109,7 +109,7 @@ through `/aggregations` as `next_batch` is present.
 
 These are just non-normative examples of what the aggregation for these
 relation types could look like, and their MSCs might end up with
-a different shape, take these with a grain of salt.
+a different shape, so take these with a grain of salt.
 
 ```json
 {

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -230,9 +230,16 @@ the client-server API) for relations events are adjusted in this MSC.
 The visibility for relation events is dependent on the `rel_type`, with two options:
  
   - Visibility is derived from the visibility of the target event (the event
-    referred to by the `event_id` in the relation); the relation should only be
-    visible if the relation target is visible. This option means that events
-    can still be visible to a user after they have left the room. This has implications
+    referred to by the `event_id` in the relation) under some circumstances:
+    the relation should be visible if the relation target event is visible to
+    a user but the relation event would not be visible according to regular
+    event history visibility rules (e.g. the user has since left in a room with
+    joined or invite room history visibility).
+    If according to regular event room history visibility rules, the relation
+    event would be visible to a user, then the visibility of target event
+    should not be considered and the relation event should be visible.
+    This option means that events can still be visible to a user after
+    they have left the room, and has implications
     for [End-to-end encryption](#end-to-end-encryption).
     [`m.replace`](https://github.com/matrix-org/matrix-doc/pull/2676) and [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) relation events have this visilibilty, see those respective MSCs.
   - Visibility is the same as a non-relation event.
@@ -313,6 +320,11 @@ Particularly, please remember to let users edit unsent messages (as this is a
 common case for rapidly fixing a typo in a msg which is still in flight!)
 
 ## Edge cases
+
+### Ignore relation events for which the target is not visible to us.
+
+Clients should ignore relation events for which the target event is
+not visible to them.
 
 ### How do you handle ignored users?
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -308,9 +308,9 @@ referred to should be de-aggregated from the relations of the target of the
 relation.  Similar to a relation, when the sending of the redaction fails or
 is cancelled, the relation should be aggregated again.
 
-Clients can locally relate pending events by their `transaction_id`.
-When the target event receives its `event_id` (either receives the remote echo,
-or receives the `event_id` from the `/send` response,
+One possible way clients can locally relate pending events is by their
+`transaction_id`. When the target event receives its `event_id` (either receives
+the remote echo, or receives the `event_id` from the `/send` response,
 whichever comes first), the target event id (`m.relates_to`.`event_id`) of
 any relations in the send queue will
 need to be set the newly received `event_id`.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -263,10 +263,11 @@ A future MSC may define a method for encrypting certain parts of the
 `m.relates_to` field that may contain sensitive information.
 
 When sending relation events whose [visibility is derived from the target event](#relation-visibility),
-clients should ensure that the end-to-end encryption keys for the encrypted
-relation events is shared with all devices that could see the target event,
-even if those relation events are encrypted with a different key than
-the target event, and even if the receiving user has since left the room.
+clients should ensure that the end-to-end encryption key for the encrypted
+relation event is shared with all devices that could see the target event
+if those relation events are encrypted with a different key than
+the target event (e.g. after key rotation), even if the receiving user has
+since left the room.
 
 ### Redactions
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -288,7 +288,7 @@ This is in line with other APIs like `/context` and `/messages`.
 For the best possible user experience, clients should also include unsent
 relations into the client-side aggregation. When adding a relation to the send
 queue, clients should locally aggregate it into the relations of the target
-event, ideally regardless of the target event having an `event_id`
+event, ideally regardless of the target event having received an `event_id`
 already or still being pending. If the client gives up on sending the relation
 for some reason, the relation should be de-aggregated from the relations of
 the target event. If the client offers the user a possibility of manually

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -148,20 +148,25 @@ The `/relations` API returns the discrete relation events
 associated with an event that the server is aware of
 in standard topological order. Note that events may be missing,
 see [limitations](#servers-might-not-be-aware-of-all-relations-of-an-event).
-You can filter by a given relation type and optionally the event type of the
+You can optionally filter by a given relation type and the event type of the
 relating event:
 
 ```
-GET /_matrix/client/v1/rooms/{roomID}/relations/{event_id}/{rel_type}[/{event_type}][?from=token][&to=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{roomID}/relations/{event_id}[/{rel_type}[/{event_type}]][?from=token][&to=token][&limit=amount]
 ```
 
-```json
+```
 {
   "chunk": [
     {
       "type": "m.reaction",
       "sender": "...",
-      "content": { }
+      "content": {
+        "m.relates_to": {
+          "rel_type": "m.annotation",
+          ...
+        }
+      }
     }
   ],
   "prev_batch": "some_token",

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -76,7 +76,7 @@ Example [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) agg
 ]
 ```
 
-#### Bundled aggregations
+#### Bundling
 
 Other than during non-gappy incremental syncs, timeline events that have other
 events relate to them should include the aggregation of those related events
@@ -121,7 +121,7 @@ The format of `m.relations` (here with ficticious relation types) is as follows:
 }
 ```
 
-### Client-side aggregation
+#### Client-side aggregation
 
 Bundled aggregations on an event give a snapshot of what relations were know
 at the time the event was received. When relations are received through `/sync`,
@@ -135,7 +135,7 @@ same as the one described here for the server.
 
 A single event can have lots of associated relations, and we do not want to
 overload the client by including them all bundled with the related-to event
-like we do for aggregations. Instead, we provide a new `/relations` API in
+like we do for aggregations. Instead, we also provide a new `/relations` API in
 order to paginate over the relations, which behaves in a similar way to
 `/messages`, except using `next_batch` and `prev_batch` names
 (in line with `/sync` API).

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -209,7 +209,7 @@ The `from` and `limit` query parameters are used for pagination, and work
 just like described for the `/messages` endpoint.
 
 Trying to iterate over a relation type which does not use an aggregation key
-(i.e. `m.replace` and `m.reference`) should fail with 400 and error
+(eg. `m.replace` and `m.reference`) should fail with 400 and error
 `M_INVALID_REL_TYPE`.
 
 ### Querying relations

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -148,7 +148,7 @@ To iterate over the aggregations for an event (optionally filtering by
 relation type and target event type):
 
 ```
-GET /_matrix/client/r0/rooms/{roomID}/aggregations/{eventID}[/{relationType}][/{eventType}][?from=token][&to=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{roomID}/aggregations/{eventID}[/{relationType}][/{eventType}][?from=token][&to=token][&limit=amount]
 ```
 
 This is just non-normative example of what the aggregation for this
@@ -194,7 +194,7 @@ see [limitations](#servers-might-not-be-aware-of-all-relations-of-an-event).  Yo
 filter by a given type of relation and event type:
 
 ```
-GET /_matrix/client/r0/rooms/{roomID}/relations/{eventID}[/{relationType}[/{eventType}]][?from=token][&to=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{roomID}/relations/{eventID}[/{relationType}[/{eventType}]][?from=token][&to=token][&limit=amount]
 ```
 
 ```json
@@ -335,8 +335,13 @@ and paginated as per the normal Matrix pagination model.
 This was originally part of this MSC but left out to limit the scope
 to what is implemented at the time of writing.
 
-## No unstable prefix
+## Prefix
 
-Implementations of this MSC should not use any prefix,
-as this MSC tries to document relation support without a prefix already
-being used in the wider matrix ecosystem.
+While this MSC is not considered stable, the endpoints become:
+
+ - `GET /_matrix/client/unstable/rooms/{roomID}/aggregations/{eventID}[/{relationType}][/{eventType}]`
+ - `GET /_matrix/client/unstable/rooms/{roomID}/relations/{eventID}[/{relationType}[/{eventType}]]`
+
+None of the newly introduced identifiers should use a prefix though, as this MSC
+tries to document relation support already being used in
+the wider matrix ecosystem.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -223,11 +223,37 @@ adds the related-to event in `original_event` property of the response.
 This way the full history (e.g. also the first, original event) of the event
 is obtained without further requests. See that MSC for further details.
 
+### Relation visilibity
+
+The visibility rules (whether or not a user should receive a given event through
+the client-server API) for relations events are adjusted in the MSC.
+The visibility for relation events is dependent on the `rel_type`, with two options:
+ 
+  - Visibility is derived from the visibility of the target event (the event
+    referred to by the `event_id` in the relation); the relation should only be
+    visible if the relation target is visible. This option means that events
+    can still be visible to a user after they have left the room. This has implications
+    for [End-to-end encryption](#end-to-end-encryption).
+    [`m.replace`](https://github.com/matrix-org/matrix-doc/pull/2676) and [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) relation events have this visilibilty, see those respective MSCs.
+  - Visibility is the same as a non-relation event.
+    [`m.thread`](https://github.com/matrix-org/matrix-doc/pull/3440) relation events have this visilibilty, see the respective MSC.
+
+Visibility derived from the visibility of the target event is the default;
+if the MSC introducing the relation type doesn't specify any other visibility this is assumed.
+
+The change of visilibilty rules will require a new room version.
+
 ### End to end encryption
 
 Since the server has to be able to aggregate relation events, structural
 information about relations must be visible to the server, and so the
 `m.relates_to` field must be included in the plaintext.
+
+When sending relation events whose [visibility is derived from the target event](#relation-visibility),
+clients should share the end-to-end encryption keys for the encrypted
+relation events with all devices that could see the target event, even
+if those relation events are encrypted with a different key than
+the target event, and even if the user for a device has left the room since.
 
 A future MSC may define a method for encrypting certain parts of the
 `m.relates_to` field that may contain sensitive information.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -250,10 +250,10 @@ information about relations must be visible to the server, and so the
 `m.relates_to` field must be included in the plaintext.
 
 When sending relation events whose [visibility is derived from the target event](#relation-visibility),
-clients should share the end-to-end encryption keys for the encrypted
-relation events with all devices that could see the target event, even
-if those relation events are encrypted with a different key than
-the target event, and even if the user for a device has left the room since.
+clients should ensure that the end-to-end encryption keys for the encrypted
+relation events is shared with all devices that could see the target event,
+even if those relation events are encrypted with a different key than
+the target event, and even if the receiving user has since left the room.
 
 A future MSC may define a method for encrypting certain parts of the
 `m.relates_to` field that may contain sensitive information.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -94,8 +94,9 @@ API that is defined in this MSC. The maximum amount of aggregations bundled
 before the list is truncated is determined freely by the server.
 
 For instance, the below example shows an event with five bundled relations:
-three thumbsup reaction annotations, one replace, and a truncated list
-of references, of which only one is bundled (because `next_batch` is present).
+one replace, one reference and three thumbsup reaction annotations,
+with more aggregated reactions available to paginate in
+through `/aggregations` as `next_batch` is present..
 
 These are just non-normative examples of what the aggregation for these
 relation types could look like, and their MSCs might end up with
@@ -106,6 +107,18 @@ a different shape, take these with a grain of salt.
     ...,
     "unsigned": {
         "m.relations": {
+            "m.replace": {
+                "event_id": "$edit_event_id",
+                "origin_server_ts": 1562763768320,
+                "sender": "@bruno1:localhost"
+            },
+            "m.reference": {
+                "chunk": [
+                    {
+                        "event_id": "$some_event_id"
+                    }
+                ],
+            },
             "m.annotation": {
                 "chunk": [
                   {
@@ -114,20 +127,8 @@ a different shape, take these with a grain of salt.
                       "origin_server_ts": 1562763768320,
                       "count": 3
                   }
+                  "next_batch": "abc123",
                 ]
-            },
-            "m.reference": {
-                "chunk": [
-                    {
-                        "event_id": "$some_event_id"
-                    }
-                ],
-                "next_batch": "abc123",
-            },
-            "m.replace": {
-                "event_id": "$edit_event_id",
-                "origin_server_ts": 1562763768320,
-                "sender": "@bruno1:localhost"
             }
         }
     }

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -38,7 +38,7 @@ events to relate to each other.  Together, these proposals replace
 
 ### Aggregations
 
-Relation events can be aggregated per `rel_type` by the server.
+Relation events can be aggregated per relation type (`rel_type`) by the server.
 The format of the aggregated value (hereafter called "aggregation")
 depends on the relation type.
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -234,11 +234,6 @@ common case for rapidly fixing a typo in a msg which is still in flight!)
 
 ## Edge cases
 
-### Ignore relation events for which the target is not visible to us.
-
-Clients can ignore relation events for which the target event is
-not visible to them.
-
 ### How do you handle ignored users?
 
  * Information about relations sent from ignored users must never be sent to

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -48,12 +48,14 @@ others might aggregate to a single object or any other value really.
 
 #### Bundled aggregations
 
-Other than during non-gappy incremental syncs, events that have other events
-relate to it should bundle the aggregation of those related events
+Other than during non-gappy incremental syncs, timeline events that have other
+events relate to it should bundle the aggregation of those related events
 in the `m.relations` property of their unsigned data.  These are called
 bundled aggregations, and by sending a summary of the relations,
 avoids us having to always send lots of individual relation events
 to the client.
+
+State events never bundle aggregations.
 
 Here's an example of what that can look like for some ficticious `rel_type`s:
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -172,7 +172,8 @@ GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}/{rel_type}[/{even
 Again, this is a non-normative example of the aggregation for an
 `m.annotation` relation type.
 
-The endpoint does not have any trailing slashes.
+Note that endpoint does not have any trailing slashes: `GET /_matrix/client/v1/rooms/{roomID}/aggregations/{eventID}/`
+would return aggregations of relations with an *empty* `rel_type`, which is nonsensical.
 
 The `from` and `limit` query parameters are used for pagination, and work
 just like described for the `/messages` endpoint.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -75,7 +75,7 @@ The following client-server APIs should bundle aggregations
 with events they return:
 
   - `GET /rooms/{roomId}/messages`
-  - `GET /rooms/{roomId}/context`
+  - `GET /rooms/{roomId}/context/{eventId}`
   - `GET /rooms/{roomId}/event/{eventId}`
   - `GET /sync`, only for room sections in the response where `limited` field
     is `true`; this amounts to all rooms in the response if 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -143,11 +143,12 @@ order to paginate over the relations, which behaves in a similar way to
 The `/relations` API returns the discrete relation events
 associated with an event that the server is aware of
 in standard topological order. Note that events may be missing,
-see [limitations](#servers-might-not-be-aware-of-all-relations-of-an-event).  You can optionally
-filter by a given type of relation and event type:
+see [limitations](#servers-might-not-be-aware-of-all-relations-of-an-event).
+You can filter by a given relation type and optionally the event type of the
+relating event:
 
 ```
-GET /_matrix/client/v1/rooms/{roomID}/relations/{eventID}[/{relationType}[/{eventType}]][?from=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{roomID}/relations/{event_id}/{rel_type}[/{event_type}][?from=token][&limit=amount]
 ```
 
 ```json

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -42,7 +42,7 @@ Relation events can be aggregated per relation type (`rel_type`) by the server.
 The format of the aggregated value (hereafter called "aggregation")
 depends on the relation type.
 
-Some `rel_type`s might additionally group the aggregations by the `key` property
+Some relation types might group the aggregations by the `key` property
 in the relation and aggregate to an array,
 others might aggregate to a single object or any other value really.
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -174,6 +174,16 @@ a different shape, so take these with a grain of salt.
 }
 ```
 
+### Client-side aggregation
+
+Bundled aggregations on an event give a snapshot of what relations were know
+at the time the event was received. When relations are received through `/sync`,
+clients should locally aggregate (as they might have done already before
+supporting this MSC) the relation on top of any bundled aggregation the server
+might have sent along previously with the target event, to get an up to date
+view of the aggregations for the target event. The aggregation algorithm is the
+same as the one described here for the server.
+
 ### Querying aggregations
 
 The `/aggregations` API lets you iterate over aggregations for the relations
@@ -274,15 +284,6 @@ still return any existing relation events, and aggregations respectively.
 This is in line with other APIs like `/context` and `/messages`.
 
 ### Local echo
-
-As clients only receive discrete relation events through `/sync`,
-they need to locally aggregate these relation events for their parent event,
-on top of any server-side aggregation that might have already happened,
-to get a complete picture of the aggregations for a given parent event,
-as a client might not be aware of all relations for an event. Local aggregation
-should thus also take the `m.relation` data in the `unsigned` of the parent
-event into account if it has been sent already. The aggregation algorithm is the
-same as the one described here for the server.
 
 For the best possible user experience, clients should also include unsent
 relations into the local aggregation. When adding a relation to the send

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -93,6 +93,10 @@ is bundled, pagination of subsequent pages happens through the `/aggregations`
 API that is defined in this MSC. The maximum amount of aggregations bundled
 before the list is truncated is determined freely by the server.
 
+Note that the client *can* determine the page size when calling
+`/aggregations` through the `limit` request parameter, the offset is solely
+determined by the `next_batch` token.
+
 For instance, the below example shows an event with five bundled relations:
 one replace, one reference and three thumbsup reaction annotations,
 with more aggregated reactions available to paginate in

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -153,7 +153,7 @@ To iterate over the aggregations for an event (optionally filtering by
 relation type and relation event type):
 
 ```
-GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}/{rel_type}[/{event_type}][?from=token][&to=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}/{rel_type}[/{event_type}][?from=token][&limit=amount]
 ```
 
 ```json
@@ -166,7 +166,6 @@ GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}/{rel_type}[/{even
     }
   ],
   "next_batch": "some_token",
-  "prev_batch": "some_token"
 }
 ```
 
@@ -175,7 +174,7 @@ Again, this is a non-normative example of the aggregation for an
 
 The endpoint does not have any trailing slashes.
 
-The `from`, `to` and `limit` query parameters are used for pagination, and work
+The `from` and `limit` query parameters are used for pagination, and work
 just like described for the `/messages` endpoint.
 
 Trying to iterate over a relation type which does not use an aggregation key
@@ -198,7 +197,7 @@ see [limitations](#servers-might-not-be-aware-of-all-relations-of-an-event).  Yo
 filter by a given type of relation and event type:
 
 ```
-GET /_matrix/client/v1/rooms/{roomID}/relations/{eventID}[/{relationType}[/{eventType}]][?from=token][&to=token][&limit=amount]
+GET /_matrix/client/v1/rooms/{roomID}/relations/{eventID}[/{relationType}[/{eventType}]][?from=token][&limit=amount]
 ```
 
 ```json
@@ -211,13 +210,12 @@ GET /_matrix/client/v1/rooms/{roomID}/relations/{eventID}[/{relationType}[/{even
     }
   ],
   "next_batch": "some_token",
-  "prev_batch": "some_token"
 }
 ```
 
 The endpoint does not have any trailing slashes.
 
-The `from`, `to` and `limit` query parameters are used for pagination, and work
+The `from` and `limit` query parameters are used for pagination, and work
 just like described for the `/messages` endpoint.
 
 Note that [MSC2676](https://github.com/matrix-org/matrix-doc/pull/2676)

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -226,33 +226,6 @@ adds the related-to event in `original_event` property of the response.
 This way the full history (e.g. also the first, original event) of the event
 is obtained without further requests. See that MSC for further details.
 
-### Relation visibility
-
-The visibility rules (whether or not a user should receive a given event through
-the client-server API) for relations events are adjusted in this MSC.
-The visibility for relation events is dependent on the `rel_type`, with two options:
- 
-  - Visibility is derived from the visibility of the target event (the event
-    referred to by the `event_id` in the relation) under some circumstances:
-    the relation should be visible if the relation target event is visible to
-    a user but the relation event would not be visible according to regular
-    event history visibility rules (e.g. the user has since left in a room with
-    joined or invite room history visibility).
-    If according to regular event room history visibility rules, the relation
-    event would be visible to a user, then the visibility of target event
-    should not be considered and the relation event should be visible.
-    This option means that events can still be visible to a user after
-    the user left the room, and has implications
-    for [End-to-end encryption](#end-to-end-encryption).
-    [`m.replace`](https://github.com/matrix-org/matrix-doc/pull/2676) and [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) relation events have this visilibilty, see those respective MSCs.
-  - Visibility is the same as a non-relation event.
-    [`m.thread`](https://github.com/matrix-org/matrix-doc/pull/3440) relation events have this visilibilty, see the respective MSC.
-
-Visibility derived from the visibility of the target event is the default for relation events;
-if the MSC introducing the relation type doesn't specify any other visibility this is assumed.
-
-The change of visilibilty rules will require a new room version.
-
 ### End to end encryption
 
 Since the server has to be able to aggregate relation events, structural
@@ -261,13 +234,6 @@ information about relations must be visible to the server, and so the
 
 A future MSC may define a method for encrypting certain parts of the
 `m.relates_to` field that may contain sensitive information.
-
-When sending relation events whose [visibility is derived from the target event](#relation-visibility),
-clients should ensure that the end-to-end encryption key for the encrypted
-relation event is shared with all devices that could see the target event
-if those relation events are encrypted with a different key than
-the target event (e.g. after key rotation), even if the receiving user has
-since left the room.
 
 ### Redactions
 
@@ -340,6 +306,16 @@ not visible to them.
    or a different reaction count) on an event.
 
 ## Limitations
+
+### Relations can be missed while not being in the room
+
+Relation events behave no different from other events in terms of room history visibility,
+which means that some relations might not be visible to a user while he is not a invited
+or has not joined the room. These events would thus also not be included in the aggregations.
+This can cause for example that a user sees an incomplete
+edit history or reaction count upon (re)joining a room.
+
+[MSC3570](https://github.com/matrix-org/matrix-doc/pull/3570) proposes to remove this limitation.
 
 ### Servers might not be aware of all relations of an event
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -223,10 +223,10 @@ adds the related-to event in `original_event` property of the response.
 This way the full history (e.g. also the first, original event) of the event
 is obtained without further requests. See that MSC for further details.
 
-### Relation visilibity
+### Relation visibility
 
 The visibility rules (whether or not a user should receive a given event through
-the client-server API) for relations events are adjusted in the MSC.
+the client-server API) for relations events are adjusted in this MSC.
 The visibility for relation events is dependent on the `rel_type`, with two options:
  
   - Visibility is derived from the visibility of the target event (the event

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -310,12 +310,13 @@ not visible to them.
 ### Relations can be missed while not being in the room
 
 Relation events behave no different from other events in terms of room history visibility,
-which means that some relations might not be visible to a user while he is not a invited
-or has not joined the room. These events would thus also not be included in the aggregations.
-This can cause for example that a user sees an incomplete
-edit history or reaction count upon (re)joining a room.
+which means that some relations might not be visible to a user while they are not invited
+or has not joined the room. This can cause a user to see an incomplete edit history or reaction count
+based on discrete relation events upon (re)joining a room.
 
-[MSC3570](https://github.com/matrix-org/matrix-doc/pull/3570) proposes to remove this limitation.
+Ideally the server would not include these events in aggregations, as it would mean breaking
+the room history visibility rules, but this MSC defers addressing this limitation and
+specifying the exact server behaviour to [MSC3570](https://github.com/matrix-org/matrix-doc/pull/3570).
 
 ### Servers might not be aware of all relations of an event
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -150,7 +150,7 @@ The `/aggregations` API lets you iterate over aggregations for the relations
 of a given event.
 
 To iterate over the aggregations for an event (optionally filtering by
-relation type and target event type):
+relation type and relation event type):
 
 ```
 GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}/{rel_type}[/{event_type}][?from=token][&to=token][&limit=amount]

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -183,11 +183,10 @@ A future MSC may define a method for encrypting certain parts of the
 ### Redactions
 
 Redacted relations should not be taken into consideration in
-bundled aggregations or aggregations returned from `/aggregations`,
-nor should they be returned from `/relations`.
+bundled aggregations, nor should they be returned from `/relations`.
 
-Requesting `/relations` or `/aggregations` on a redacted event should
-still return any existing relation events, and aggregations respectively.
+Requesting `/relations` on a redacted event should
+still return any existing relation events.
 This is in line with other APIs like `/context` and `/messages`.
 
 ### Local echo
@@ -265,7 +264,7 @@ full DAG over federation to assure itself that it is aware of all relations.
 
 ### Event type based aggregation and filtering won't work well in encrypted rooms
 
-The `/relations` and `/aggregations` endpoint allow filtering by event type,
+The `/relations` endpoint allows filtering by event type,
 which for encrypted rooms will be `m.room.encrypted`, rendering this filtering
 less useful for encrypted rooms. Aggregations that take the event type into
 account of the relation will suffer from the same limitation.
@@ -298,7 +297,6 @@ to what is implemented at the time of writing.
 
 While this MSC is not considered stable, the endpoints become:
 
- - `GET /_matrix/client/unstable/rooms/{roomID}/aggregations/{eventID}[/{relationType}][/{eventType}]`
  - `GET /_matrix/client/unstable/rooms/{roomID}/relations/{eventID}[/{relationType}[/{eventType}]]`
 
 None of the newly introduced identifiers should use a prefix though, as this MSC

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -227,11 +227,6 @@ Since the server has to be able to aggregate relation events, structural
 information about relations must be visible to the server, and so the
 `m.relates_to` field must be included in the plaintext.
 
-The `/relations` and `/aggregations` endpoint allow filtering by event type,
-which for encrypted rooms will be `m.room.encrypted`, rendering this filtering
-less useful for encrypted rooms. Aggregations that take the event type into
-account of the relation will suffer from the same limitation.
-
 A future MSC may define a method for encrypting certain parts of the
 `m.relates_to` field that may contain sensitive information.
 
@@ -308,6 +303,13 @@ have an equivalent of the `/relations` API, so has no way but to fetch the
 full DAG over federation to assure itself that it is aware of all relations.
 
 [MSC2836](https://github.com/matrix-org/matrix-doc/blob/kegan/msc/threading/proposals/2836-threading.md#making-relationships) also makes mention of this issue.
+
+### Event type based aggregation and filtering won't work well in encrypted rooms
+
+The `/relations` and `/aggregations` endpoint allow filtering by event type,
+which for encrypted rooms will be `m.room.encrypted`, rendering this filtering
+less useful for encrypted rooms. Aggregations that take the event type into
+account of the relation will suffer from the same limitation.
 
 ## Future extensions
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -50,8 +50,11 @@ others might aggregate to a single object or any other value really.
 
 Other than during non-gappy incremental syncs, timeline events that have other
 events relate to them should include the aggregation of those related events
-in the `m.relations` property of their unsigned data.  These are called
-bundled aggregations, and by sending a summary of the relations,
+in the `m.relations` property of their unsigned data.  This process is
+referred to as "bundling", and the aggregated relations included via
+this mechanism are called "bundled aggregations".
+
+By sending a summary of the relations, bundling
 avoids us having to always send lots of individual relation events
 to the client.
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -269,8 +269,9 @@ full DAG over federation to assure itself that it is aware of all relations.
 
 The `/relations` endpoint allows filtering by event type,
 which for encrypted rooms will be `m.room.encrypted`, rendering this filtering
-less useful for encrypted rooms. Aggregations that take the event type into
-account of the relation will suffer from the same limitation.
+less useful for encrypted rooms.  Aggregation algorithms that take the type of
+the relating events they aggregate into account will suffer from the same
+limitation.
 
 ## Future extensions
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -48,7 +48,8 @@ others might aggregate to a single object or any other value really.
 
 Here are some non-normative examples of what aggregations can look like:
 
-Example [`m.thread`](https://github.com/matrix-org/matrix-doc/pull/3440) aggregation:
+Example aggregation for [`m.thread`](https://github.com/matrix-org/matrix-doc/pull/3440) (which
+aggregates all relations into a single object):
 ```
 {
   "latest_event": {

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -202,8 +202,8 @@ GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}/{rel_type}[/{even
 Again, this is a non-normative example of the aggregation for an
 `m.annotation` relation type.
 
-Note that endpoint does not have any trailing slashes: `GET /_matrix/client/v1/rooms/{roomID}/aggregations/{eventID}/`
-would return aggregations of relations with an *empty* `rel_type`, which is nonsensical.
+Note that endpoint does not have any trailing slashes: `GET /_matrix/client/v1/rooms/{roomID}/aggregations/$abc/m.reaction/`
+would return aggregations of relations with an *empty* `event_type`, which is nonsensical.
 
 The `from` and `limit` query parameters are used for pagination, and work
 just like described for the `/messages` endpoint.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -286,22 +286,22 @@ This is in line with other APIs like `/context` and `/messages`.
 ### Local echo
 
 For the best possible user experience, clients should also include unsent
-relations into the local aggregation. When adding a relation to the send
-queue, clients should locally aggregate it into the relations of the parent
-event, ideally regardless of the parent event having an `event_id` already or
-still being pending. If the client gives up on sending the relation for some
-reason, the relation should be de-aggregated from the relations of the parent
-event. If the client offers the user a possibility of manually retrying to
-send the relation, it should be re-aggregated when the user does so.
+relations into the client-side aggregation. When adding a relation to the send
+queue, clients should locally aggregate it into the relations of the target
+event, ideally regardless of the target event having an `event_id`
+already or still being pending. If the client gives up on sending the relation
+for some reason, the relation should be de-aggregated from the relations of
+the target event. If the client offers the user a possibility of manually
+retrying to send the relation, it should be re-aggregated when the user does so.
 
 De-aggregating a relation refers to rerunning the aggregation for a given
-parent event while not considering the de-aggregated event any more.
+target event while not considering the de-aggregated event any more.
 
 Upon receiving the remote echo for any relations, a client is likely to remove
 the pending event from the send queue. Here, it should also de-aggregate the
-pending event from the parent event's relations, and re-aggregate the received
-remote event from `/sync` to make sure the local aggregation happens with the
-same event data as on the server.
+pending event from the target event's relations, and re-aggregate the received
+remote event from `/sync` to make sure the client-side aggregation happens with
+the same event data as on the server.
 
 When adding a redaction for a relation to the send queue, the relation
 referred to should be de-aggregated from the relations of the target of the

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -46,6 +46,36 @@ Some relation types might group the aggregations by the `key` property
 in the relation and aggregate to an array,
 others might aggregate to a single object or any other value really.
 
+Here are some non-normative examples of what aggregations can look like:
+
+Example [`m.thread`](https://github.com/matrix-org/matrix-doc/pull/3440) aggregation:
+```
+{
+  "latest_event": {
+    "content": { ... },
+    ...
+  },
+  "count": 7,
+  "current_user_participated": true
+}
+```
+
+Example [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) aggregation:
+```
+[
+  {
+      "key": "👍",
+      "origin_server_ts": 1562763768320,
+      "count": 3
+  },
+  {
+      "key": "👎",
+      "origin_server_ts": 1562763768320,
+      "count": 2
+  }
+]
+```
+
 #### Bundled aggregations
 
 Other than during non-gappy incremental syncs, timeline events that have other

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -58,7 +58,7 @@ By sending a summary of the relations, bundling
 avoids us having to always send lots of individual relation events
 to the client.
 
-State events never bundle aggregations.
+Aggregations are never bundled into state events.
 
 Here's an example of what that can look like for some ficticious `rel_type`s:
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -88,7 +88,9 @@ By sending a summary of the relations, bundling
 avoids us having to always send lots of individual relation events
 to the client.
 
-Aggregations are never bundled into state events.
+Aggregations are never bundled into state events. This is a current
+implementation detail that could be revisited later,
+rather than a specific design decision.
 
 The following client-server APIs should bundle aggregations
 with events they return:

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -60,7 +60,8 @@ Example [`m.thread`](https://github.com/matrix-org/matrix-doc/pull/3440) aggrega
 }
 ```
 
-Example [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) aggregation:
+Example aggregation for [`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) (which
+aggregates relations into a list of objects, grouped by `key`).
 ```
 [
   {

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -156,10 +156,6 @@ relation type and target event type):
 GET /_matrix/client/v1/rooms/{room_id}/aggregations/{event_id}[/{rel_type}[/{event_type}]][?from=token][&to=token][&limit=amount]
 ```
 
-This is just non-normative example of what the aggregation for this
-relation types could look like, and its MSCs might end up with
-a different shape, take this with a grain of salt.
-
 ```json
 {
   "chunk": [
@@ -173,6 +169,9 @@ a different shape, take this with a grain of salt.
   "prev_batch": "some_token"
 }
 ```
+
+Again, this is a non-normative example of the aggregation for an
+`m.annotation` relation type.
 
 The endpoint does not have any trailing slashes.
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -238,7 +238,7 @@ The visibility for relation events is dependent on the `rel_type`, with two opti
   - Visibility is the same as a non-relation event.
     [`m.thread`](https://github.com/matrix-org/matrix-doc/pull/3440) relation events have this visilibilty, see the respective MSC.
 
-Visibility derived from the visibility of the target event is the default;
+Visibility derived from the visibility of the target event is the default for relation events;
 if the MSC introducing the relation type doesn't specify any other visibility this is assumed.
 
 The change of visilibilty rules will require a new room version.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -94,7 +94,8 @@ API that is defined in this MSC. The maximum amount of aggregations bundled
 before the list is truncated is determined freely by the server.
 
 For instance, the below example shows an event with five bundled relations:
-three thumbsup reaction annotations, one replace, and one reference.
+three thumbsup reaction annotations, one replace, and a truncated list
+of references, of which only one is bundled (because `next_batch` is present).
 
 These are just non-normative examples of what the aggregation for these
 relation types could look like, and their MSCs might end up with

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -43,7 +43,7 @@ The format of the aggregated value (hereafter called "aggregation")
 depends on the relation type.
 
 Some relation types might group the aggregations by the `key` property
-in the relation and aggregate to an array,
+in the relation and aggregate to an array, while
 others might aggregate to a single object or any other value really.
 
 Here are some non-normative examples of what aggregations can look like:

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -109,15 +109,26 @@ Deprecated APIs like `/initialSync` and `/events/{eventId}` are *not* required
 to bundle aggregations.
 
 The bundled aggregations are grouped according to their relation type.
-The format of `m.relations` (here with ficticious relation types) is as follows:
+The format of `m.relations` (here with *non-normative* examples of
+the [`m.replace`](https://github.com/matrix-org/matrix-doc/pull/2676) and
+[`m.annotation`](https://github.com/matrix-org/matrix-doc/pull/2677) relation
+types) is as follows:
 
 ```json
 {
   "event_id": "abc",
   "unsigned": {
     "m.relations": {
-      "some_rel_type": { "some_aggregated_prop": true },
-      "other_rel_type": { "other_aggregated_prop": 5 },
+      "m.annotation": {
+        "key": "👍",
+        "origin_server_ts": 1562763768320,
+        "count": 3
+      },
+      "m.replace": {
+        "event_id": "$edit_event_id",
+        "origin_server_ts": 1562763768320,
+        "sender": "@alice:localhost"
+      },
     }
   }
 }

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -174,7 +174,8 @@ GET /_matrix/client/v1/rooms/{roomID}/relations/{event_id}[/{rel_type}[/{event_t
 }
 ```
 
-The endpoint does not have any trailing slashes.
+The endpoint does not have any trailing slashes. It requires authentication
+and is not rate-limited.
 
 The `from` and `limit` query parameters are used for pagination, and work
 just like described for the `/messages` endpoint.

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -239,12 +239,10 @@ referred to should be de-aggregated from the relations of the target of the
 relation.  Similar to a relation, when the sending of the redaction fails or
 is cancelled, the relation should be aggregated again.
 
-One possible way clients can locally relate pending events is by their
-`transaction_id`. When the target event receives its `event_id` (either receives
-the remote echo, or receives the `event_id` from the `/send` response,
-whichever comes first), the target event id (`m.relates_to`.`event_id`) of
-any relations in the send queue will
-need to be set the newly received `event_id`.
+If the target event is still pending and hasn't received its `event_id` yet,
+clients can locally relate relation events to their target by using
+`transaction_id` like they already do for detecting remote echos when sending
+events.
 
 ## Edge cases
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -246,9 +246,6 @@ whichever comes first), the target event id (`m.relates_to`.`event_id`) of
 any relations in the send queue will
 need to be set the newly received `event_id`.
 
-Particularly, please remember to let users edit unsent messages (as this is a
-common case for rapidly fixing a typo in a msg which is still in flight!)
-
 ## Edge cases
 
 ### How do you handle ignored users?

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -268,7 +268,7 @@ potentially doesn't have the full DAG of the room. The federation API doens't
 have an equivalent of the `/relations` API, so has no way but to fetch the
 full DAG over federation to assure itself that it is aware of all relations.
 
-[MSC2836](https://github.com/matrix-org/matrix-doc/blob/kegan/msc/threading/proposals/2836-threading.md#making-relationships) also makes mention of this issue.
+[MSC2836](https://github.com/matrix-org/matrix-doc/pull/2836) provided a proposal for following relationships over federation in the "Querying relationships over federation" section via a `/_matrix/federation/v1/event_relationships` API
 
 ### Event type based aggregation and filtering won't work well in encrypted rooms
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -244,7 +244,7 @@ common case for rapidly fixing a typo in a msg which is still in flight!)
  * Information about relations sent from ignored users must never be sent to
    the client, either in aggregations or discrete relation events.
    This is to let you block someone from harassing you with emoji reactions
-   (or using edits as a side-channel to harass you). Therefor, it is possible
+   (or using edits as a side-channel to harass you). Therefore, it is possible
    that different users will see different aggregations (a different last edit,
    or a different reaction count) on an event.
 

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -254,7 +254,7 @@ common case for rapidly fixing a typo in a msg which is still in flight!)
 
 Relation events behave no different from other events in terms of room history visibility,
 which means that some relations might not be visible to a user while they are not invited
-or has not joined the room. This can cause a user to see an incomplete edit history or reaction count
+or have not joined the room. This can cause a user to see an incomplete edit history or reaction count
 based on discrete relation events upon (re)joining a room.
 
 Ideally the server would not include these events in aggregations, as it would mean breaking

--- a/proposals/2675-aggregations-server.md
+++ b/proposals/2675-aggregations-server.md
@@ -125,7 +125,7 @@ The format of `m.relations` (here with ficticious relation types) is as follows:
 
 #### Client-side aggregation
 
-Bundled aggregations on an event give a snapshot of what relations were know
+Bundled aggregations on an event give a snapshot of what relations were known
 at the time the event was received. When relations are received through `/sync`,
 clients should locally aggregate (as they might have done already before
 supporting this MSC) the relation on top of any bundled aggregation the server


### PR DESCRIPTION
[Rendered](https://github.com/uhoreg/matrix-doc/blob/aggregations-helpers/proposals/2675-aggregations-server.md)

Replaces #1849 along with #2674, #2676, and #2677

[FCP proposal](https://github.com/matrix-org/matrix-doc/pull/2675#issuecomment-988110870)

----

Synapse implementation:
* [`/relations` endpoint](https://github.com/matrix-org/synapse/blob/221595414751f7b8fd0c79772c5ac4ffefeca10a/synapse/rest/client/relations.py#L157-L243)
* [Bundled aggregations](https://github.com/matrix-org/synapse/blob/221595414751f7b8fd0c79772c5ac4ffefeca10a/synapse/events/utils.py#L437-L523)