### PR TITLE
MSC2676: Message editing

### DIFF
--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -119,10 +119,8 @@ What happens when we edit a reply?
    can assume that any client which can handle edits can also display replies
    natively.
 
-   XXX: make Element do this
-
 What power level do you need to be able to edit other people's messages, and how
-does it fit in with fedeation event auth rules?
+does it fit in with federation event auth rules?
  * 50, by default?
 
     XXX: Synapse doesn't impose this currently - it lets anyone send an edit,

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -41,11 +41,11 @@ For instance, an `m.room.message` which replaces an existing event looks like:
         "msgtype": "m.text",
         "m.new_content": {
             "body": "Hello! My name is bar",
-            "msgtype": "m.text",
+            "msgtype": "m.text"
         },
         "m.relates_to": {
             "rel_type": "m.replace",
-            "event_id": "$some_event_id",
+            "event_id": "$some_event_id"
         }
     }
 }

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -1,4 +1,4 @@
-# MSCxxxx: Message editing
+# MSC2676: Message editing
 
 Users may wish to edit previously sent messages, for example to correct typos.
 This can be done by sending a new message with an indication that it replaces
@@ -8,13 +8,13 @@ This proposal is one in a series of proposals that defines a mechanism for
 events to relate to each other.  Together, these proposals replace
 [MSC1849](https://github.com/matrix-org/matrix-doc/pull/1849).
 
-* [MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx) defines a
+* [MSC2674](https://github.com/matrix-org/matrix-doc/pull/2674) defines a
   standard shape for indicating events which relate to other events.
-* [MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx) defines APIs to
+* [MSC2675](https://github.com/matrix-org/matrix-doc/pull/2675) defines APIs to
   let the server calculate the aggregations on behalf of the client, and so
   bundle the related events with the original event where appropriate.
 * This proposal defines how users can edit messages using this mechanism.
-* [MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx) defines how
+* [MSC2677](https://github.com/matrix-org/matrix-doc/pull/2677) defines how
   users can annotate events, such as reacting to events with emoji, using this
   mechanism.
 
@@ -22,10 +22,10 @@ events to relate to each other.  Together, these proposals replace
 
 A new `rel_type` of `m.replace` is defined for use with the `m.relates_to`
 field as defined in
-[MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx).  This is
+[MSC2674](https://github.com/matrix-org/matrix-doc/pull/2674).  This is
 intended primarily for handling edits, and lets you define an event which
 replaces an existing event.  When aggregated (as in
-[MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx)), returns the
+[MSC2675](https://github.com/matrix-org/matrix-doc/pull/2675)), returns the
 most recent replacement event (as determined by `origin_server_ts`). The
 replacement event must contain an `m.new_content` which defines the replacement
 content (allowing the normal `body` fields to be used for a fallback for

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -51,6 +51,13 @@ For instance, an `m.room.message` which replaces an existing event looks like:
 }
 ```
 
+The `m.new_content` includes any fields that would normally be found in an
+event's `content` field, such as `formatted_body`.  In addition, the `msgtype`
+field need not be the same as in the original event.  For example, if a user
+intended to send a message beginning with "/me", but their client sends an
+`m.emote` event instead, they could edit the message to send be an `m.text`
+event as they had originally intended.
+
 Permalinks to edited events should capture the event ID that the sender is
 viewing at that point (which might be an edit ID).  The client viewing the
 permalink should resolve this ID to the source event ID, and then display the
@@ -112,7 +119,7 @@ What happens when we edit a reply?
    can assume that any client which can handle edits can also display replies
    natively.
 
-   XXX: make Riot do this
+   XXX: make Element do this
 
 What power level do you need to be able to edit other people's messages, and how
 does it fit in with fedeation event auth rules?

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -224,18 +224,6 @@ edit should not be included in the server-side aggregation).
 
 ### Server behaviour
 
-Whenever a homeserver would return an event via the Client-Server API, it
-should check for any valid, applicable `m.replace` event, and if one is found, it
-should first modify the `content` of the original event according to the
-`m.new_content` of the most recent edit (as determined by
-`origin_server_ts`, falling back to a lexicographic ordering of `event_id`).
-
-An exception applies to [`GET
-/_matrix/client/v3/rooms/{roomId}/event/{eventId}`](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3roomsroomideventeventid),
-which should return the *unmodified* event (though the relationship should
-still be "bundled", as described
-below.
-
 #### Server-side aggregation of `m.replace` relationships
 
 Note that there can be multiple events with an `m.replace` relationship to a
@@ -271,6 +259,30 @@ If the original event is redacted, any `m.replace` relationship should **not**
 be bundled with it (whether or not any subsequent edits are themselves
 redacted). Note that this behaviour is specific to the `m.replace`
 relationship.
+
+#### Server-side replacement of content
+
+Whenever an `m.replace` is to be bundled with an event as above, the server should
+also modify the `content` of the original event according
+to the `m.new_content` of the most recent edit (as determined by
+`origin_server_ts`, falling back to a lexicographic ordering of `event_id`).
+
+An exception applies to [`GET
+/_matrix/client/v3/rooms/{roomId}/event/{eventId}`](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3roomsroomideventeventid),
+which should return the *unmodified* event (though the relationship should
+still be bundled, as described above.
+
+The endpoints where this behaviour takes place is the same as those where
+aggregations are bundled, with the exception of
+`/room/{roomId}/event/{eventId}`. This includes:
+
+  * `GET /rooms/{roomId}/messages`
+  * `GET /rooms/{roomId}/context/{eventId}`
+  * `GET /rooms/{roomId}/relations/{eventId}`
+  * `GET /rooms/{roomId}/relations/{eventId}/{relType}`
+  * `GET /rooms/{roomId}/relations/{eventId}/{relType}/{eventType}`
+  * `GET /sync` when the relevant section has a `limited` value of `true`
+  * `POST /search` for any matching events under `room_events`.
 
 ### Client behaviour
 

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -236,11 +236,13 @@ below.
 #### Server-side aggregation of `m.replace` relationships
 
 Note that there can be multiple events with an `m.replace` relationship to a
-given event (for example, if an event is edited multiple times).  Homeservers
-should aggregate `m.replace` relationships as in
-[MSC2675](https://github.com/matrix-org/matrix-doc/pull/2675). The aggregation
+given event (for example, if an event is edited multiple times). These should
+be [aggregated](https://spec.matrix.org/v1.3/client-server-api/#aggregations)
+by the homeserver.
+
+The format of the aggregation for `m.replace` simply gives
 gives the `event_id`, `origin_server_ts`, and `sender` of the most recent
-replacement event (as determined by `origin_server_ts`).
+replacement event (determined as above).
 
 This aggregation is bundled into the `unsigned/m.relations` property of any
 event that is the target of an `m.replace` relationship. For example:

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -18,6 +18,32 @@ events to relate to each other.  Together, these proposals replace
   users can annotate events, such as reacting to events with emoji, using this
   mechanism.
 
+## Background
+
+Element-Web (then Riot-Web) and Synapse both implemented initial support for
+message editing, following the proposals of MSC1849, in May 2019
+([matrix-react-sdk](https://github.com/matrix-org/matrix-react-sdk/pull/2952),
+[synapse](https://github.com/matrix-org/synapse/pull/5209)). Element-Android
+and Element-iOS also added implementations around that time. Unfortunately,
+those implementations presented the feature as "production-ready", despite it
+not yet having been adopted into the Matrix specification.
+
+The current situation is therefore that client or server implementations hoping
+to interact with Element users must simply follow the examples of that
+implementation. In other words, message edits form part of the *de-facto* spec
+despite not being formalised in the written spec. This is clearly a regrettable
+situation. Hopefully, processes have improved over the last three years so that
+this situation will not arise again.  Nevertheless there is little we can do
+now other than formalise the status quo.
+
+This MSC, along with the others mentioned above, therefore seeks primarily to
+do that. Although there is plenty of scope for improvement, we consider that
+better done in *future* MSCs, based on a shared understaning of the *current*
+implementation.
+
+In short, this MSC prefers fidelity to the current implementations over
+elegance of design.
+
 ## Proposal
 
 ### `m.replace` event relationship type

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -132,7 +132,7 @@ For example, an encrypted replacement event might look like this:
 
 Note that there is no `m.relates_to` property in the encrypted payload. (Any such
 property would be ignored.) Likewise, there is no `m.new_content` in the
-plaintext body. (Again, any such property would be ignored.)
+cleartext body. (Again, any such property would be ignored.)
 
 For clarity: the payload must be encrypted as normal, ratcheting the Megolm session
 as normal. The original Megolm ratchet entry should **not** be re-used.
@@ -270,7 +270,7 @@ to the `m.new_content` of the most recent edit (determined as above).
 An exception applies to [`GET
 /_matrix/client/v3/rooms/{roomId}/event/{eventId}`](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3roomsroomideventeventid),
 which should return the *unmodified* event (though the relationship should
-still be bundled, as described above.
+still be bundled, as described above).
 
 The endpoints where this behaviour takes place is the same as those where
 aggregations are bundled, with the exception of

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -231,9 +231,10 @@ given event (for example, if an event is edited multiple times). These should
 be [aggregated](https://spec.matrix.org/v1.3/client-server-api/#aggregations)
 by the homeserver.
 
-The format of the aggregation for `m.replace` simply gives
-gives the `event_id`, `origin_server_ts`, and `sender` of the most recent
-replacement event (determined as above).
+The format of the aggregation for `m.replace` simply gives gives the
+`event_id`, `origin_server_ts`, and `sender` of the most recent replacement
+event (as determined by `origin_server_ts`, falling back to a lexicographic
+ordering of `event_id`).
 
 This aggregation is bundled into the `unsigned/m.relations` property of any
 event that is the target of an `m.replace` relationship. For example:
@@ -264,8 +265,7 @@ relationship.
 
 Whenever an `m.replace` is to be bundled with an event as above, the server should
 also modify the `content` of the original event according
-to the `m.new_content` of the most recent edit (as determined by
-`origin_server_ts`, falling back to a lexicographic ordering of `event_id`).
+to the `m.new_content` of the most recent edit (determined as above).
 
 An exception applies to [`GET
 /_matrix/client/v3/rooms/{roomId}/event/{eventId}`](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3roomsroomideventeventid),

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -279,10 +279,11 @@ invalid edit events that may be received.
 
 ### Permalinks
 
-Permalinks to edited events should capture the event ID that the sender is
-viewing at that point (which might be an edit ID). The client viewing the
-permalink should resolve this ID to the source event ID, and then display the
-most recent version of that event.
+Permalinks to edited events should capture the event ID that the creator of the
+permalink is viewing at that point (which might be a message edit event).
+
+The client viewing the permalink should resolve this ID to the original event
+ID, and then display the most recent version of that event.
 
 ### Redactions
 

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -130,9 +130,11 @@ For example, an encrypted replacement event might look like this:
 }
 ```
 
-Note that there is no `m.relates_to` property in the encrypted payload. (Any such
-property would be ignored.) Likewise, there is no `m.new_content` in the
-cleartext body. (Again, any such property would be ignored.)
+Note that:
+ * There is no `m.relates_to` property in the encrypted payload. (Any such
+   property would be ignored.)
+ * There is no `m.new_content` property in the cleartext `content` of the
+   `m.room.encrypted` event. (Again, any such property would be ignored.)
 
 For clarity: the payload must be encrypted as normal, ratcheting the Megolm session
 as normal. The original Megolm ratchet entry should **not** be re-used.

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -52,12 +52,71 @@ For instance, an `m.room.message` which replaces an existing event might look li
 }
 ```
 
-The `m.new_content` can include any fields that would normally be found in an
-event's `content` field, such as `formatted_body`.  In addition, the `msgtype`
-field need not be the same as in the original event. For example, if a user
-intended to send a message beginning with "/me", but their client sends an
-`m.emote` event instead, they could edit the message to send be an `m.text`
-event as they had originally intended.
+The `m.new_content` can include any properties that would normally be found in
+an event's `content` property, such as `formatted_body`.
+
+Note that the `msgtype` property of `m.room.message` events need not be the
+same as in the original event. For example, if a user intended to send a
+message beginning with "/me", but their client sends an `m.emote` event
+instead, they could edit the message to send be an `m.text` event as they had
+originally intended.
+
+#### Applying `m.new_content`
+
+When updating an existing event for an `m.replace` relating event, the old
+`content` property is replaced entirely by the `m.new_content`, with the
+exception of `m.relates_to`, which is left *unchanged*. For example, given a
+pair of events:
+
+```json
+{
+    "event_id": "$original_event",
+    "type": "m.room.message",
+    "content": {
+        "body": "I *really* like cake",
+        "msgtype": "m.text",
+        "formatted_body": "I <em>really</em> like cake",
+    }
+}
+```
+
+```json
+{
+    "event_id": "$edit_event",
+    "type": "m.room.message",
+    "content": {
+        "body": "* I *really* like *chocolate* cake",
+        "msgtype": "m.text",
+        "m.new_content": {
+            "body": "I *really* like *chocolate* cake",
+            "msgtype": "m.text",
+            "com.example.extension_property": "chocolate"
+        },
+        "m.relates_to": {
+            "rel_type": "m.replace",
+            "event_id": "$original_event_id"
+        }
+    }
+}
+```
+
+... then the end result is an event as shown below. Note that `formatted_body`
+is now absent, because it was absent in the replacement event, but
+`m.relates_to` remains unchanged (ie, absent).
+
+```json
+{
+    "event_id": "$original_event",
+    "type": "m.room.message",
+    "content": {
+        "body": "I *really* like *chocolate* cake",
+        "msgtype": "m.text",
+        "com.example.extension_property": "chocolate"
+    }
+}
+```
+
+### Permalinks
 
 Permalinks to edited events should capture the event ID that the sender is
 viewing at that point (which might be an edit ID).  The client viewing the

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -225,7 +225,7 @@ Whenever a homeserver would return an event via the Client-Server API, it
 should check for any valid, applicable `m.replace` event, and if one is found, it
 should first modify the `content` of the original event according to the
 `m.new_content` of the most recent edit (as determined by
-`origin_server_ts`, falling back to `event_id`).
+`origin_server_ts`, falling back to a lexicographic ordering of `event_id`).
 
 An exception applies to [`GET
 /_matrix/client/v3/rooms/{roomId}/event/{eventId}`](https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3roomsroomideventeventid),

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -134,6 +134,9 @@ Note that there is no `m.relates_to` property in the encrypted payload. (Any suc
 property would be ignored.) Likewise, there is no `m.new_content` in the
 plaintext body. (Again, any such property would be ignored.)
 
+For clarity: the payload must be encrypted as normal, ratcheting the Megolm session
+as normal. The original Megolm ratchet entry should **not** be re-used.
+
 #### Applying `m.new_content`
 
 When applying a replacement, the `content` property of the original event is
@@ -257,7 +260,7 @@ event that is the target of an `m.replace` relationship. For example:
       "m.replace": {
         "event_id": "$latest_edit_event_id",
         "origin_server_ts": 1649772304313,
-        "sender": "@editing_user:localhost
+        "sender": "@editing_user:localhost"
       }
     }
   }

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -83,12 +83,6 @@ Such an event, with `rel_type: m.replace`, is referred to as a "message edit".
 The `m.new_content` can include any properties that would normally be found in
 an event's `content` property, such as `formatted_body`.
 
-Note that the `msgtype` property of `m.room.message` events need not be the
-same as in the original event. For example, if a user intended to send a
-message beginning with "/me", but their client sends an `m.emote` event
-instead, they could edit the message to send be an `m.text` event as they had
-originally intended.
-
 Whenever a homeserver would return an event via the Client-Server API, it
 should check for any applicable `m.replace` event, and if one is found, it
 should first modify the `content` of the original event according to the
@@ -159,6 +153,13 @@ is now absent, because it was absent in the replacement event, but
     }
 }
 ```
+
+Note that the `msgtype` property of `m.room.message` events need not be the
+same as in the original event. For example, if a user intended to send a
+message beginning with "/me", but their client sends an `m.emote` event
+instead, they could edit the message to send be an `m.text` event as they had
+originally intended.
+
 
 ### Permalinks
 

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -108,7 +108,7 @@ or similar).
 
 #### Applying `m.new_content`
 
-When applying a replacement, the `content` property of the origial event is
+When applying a replacement, the `content` property of the original event is
 replaced entirely by the `m.new_content`, with the exception of `m.relates_to`,
 which is left *unchanged*. For example, given a pair of events:
 
@@ -183,7 +183,7 @@ calls. See [Future considerations](#future-considerations).
 
 ### Server-side aggregation of `m.replace` relationships
 
-Note that there can be multiple event with an `m.replace` relationship to a
+Note that there can be multiple events with an `m.replace` relationship to a
 given event (for example, if an event is edited multiple times).  Homeservers
 should aggregate `m.replace` relationships as in
 [MSC2675](https://github.com/matrix-org/matrix-doc/pull/2675). The aggregation

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -134,7 +134,10 @@ example, an encrypted replacement event might look like this:
 
 When applying a replacement, the `content` property of the original event is
 replaced entirely by the `m.new_content`, with the exception of `m.relates_to`,
-which is left *unchanged*. For example, given a pair of events:
+which is left *unchanged*. Any `m.relates_to` property within `m.new_content`
+is ignored.
+
+For example, given a pair of events:
 
 ```json
 {

--- a/proposals/2676-message-editing.md
+++ b/proposals/2676-message-editing.md
@@ -38,7 +38,7 @@ now other than formalise the status quo.
 
 This MSC, along with the others mentioned above, therefore seeks primarily to
 do that. Although there is plenty of scope for improvement, we consider that
-better done in *future* MSCs, based on a shared understaning of the *current*
+better done in *future* MSCs, based on a shared understanding of the *current*
 implementation.
 
 In short, this MSC prefers fidelity to the current implementations over

--- a/proposals/xxxx-message-editing.md
+++ b/proposals/xxxx-message-editing.md
@@ -1,0 +1,137 @@
+# MSCxxxx: Message editing
+
+Users may wish to edit previously sent messages, for example to correct typos.
+This can be done by sending a new message with an indication that it replaces
+the previously sent message.
+
+This proposal is one in a series of proposals that defines a mechanism for
+events to relate to each other.  Together, these proposals replace
+[MSC1849](https://github.com/matrix-org/matrix-doc/pull/1849).
+
+* [MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx) defines a
+  standard shape for indicating events which relate to other events.
+* [MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx) defines APIs to
+  let the server calculate the aggregations on behalf of the client, and so
+  bundle the related events with the original event where appropriate.
+* This proposal defines how users can edit messages using this mechanism.
+* [MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx) defines how
+  users can annotate events, such as reacting to events with emoji, using this
+  mechanism.
+
+## Proposal
+
+A new `rel_type` of `m.replace` is defined for use with the `m.relates_to`
+field as defined in
+[MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx).  This is
+intended primarily for handling edits, and lets you define an event which
+replaces an existing event.  When aggregated (as in
+[MSCxxxx](https://github.com/matrix-org/matrix-doc/pull/xxxx)), returns the
+most recent replacement event (as determined by `origin_server_ts`). The
+replacement event must contain an `m.new_content` which defines the replacement
+content (allowing the normal `body` fields to be used for a fallback for
+clients who do not understand replacement events).
+
+For instance, an `m.room.message` which replaces an existing event looks like:
+
+```json
+{
+    "type": "m.room.message",
+    "content": {
+        "body": "s/foo/bar/",
+        "msgtype": "m.text",
+        "m.new_content": {
+            "body": "Hello! My name is bar",
+            "msgtype": "m.text",
+        },
+        "m.relates_to": {
+            "rel_type": "m.replace",
+            "event_id": "$some_event_id",
+        }
+    }
+}
+```
+
+Permalinks to edited events should capture the event ID that the sender is
+viewing at that point (which might be an edit ID).  The client viewing the
+permalink should resolve this ID to the source event ID, and then display the
+most recent version of that event.
+
+### Redactions
+
+When a message using a `rel_type` of `m.replace` is redacted, it removes that
+edit revision.
+
+In the UI, the act of redacting an edited message in the timeline should
+remove the message entirely from the timeline.  It can do this by redacting the
+original msg, while ensuring that clients locally discard any edits to a
+redacted message on receiving a redaction.
+
+When a specific revision of an event is redacted, the client should manually
+refresh the parent event via `/events` to grab whatever the replacement
+revision is.
+
+## Edge Cases
+
+How do you handle racing edits?
+ * The edits could form a DAG of relations for robustness.
+    * Tie-break between forward DAG extremities based on origin_ts
+    * this should be different from the target event_id in the relations, to
+      make it easier to know what is being replaced.
+    * hard to see who is responsible for linearising the DAG when receiving.
+      Nasty for the client to do it, but the server would have to buffer,
+      meaning relations could get stuck if an event in the DAG is unavailable.
+ * ...or do we just always order by on origin_ts, and rely on a social problem
+   for it not to be abused?
+    * problem is that other relation types might well need a more robust way of
+      ordering. XXX: can we think of any?
+    * could add the DAG in later if it's really needed?
+    * the abuse vector is for a malicious moderator to edit a message with origin_ts
+      of MAX_INT. the mitigation is to redact such malicious messages, although this
+      does mean the original message ends up being vandalised... :/
+ * Conclusion: let's do it for origin_ts as a first cut, but use event shapes which
+   could be switched to DAG in future is/as needed.  Good news is that it only
+   affects the server implementation; the clients can trust the server to linearise
+   correctly.
+
+What can we edit?
+ * Only non-state events for now.
+ * We can't change event types, or anything else which is in an E2E payload
+ * We can't change relation types either.
+
+How do diffs work on edits if you are missing intermediary edits?
+ * We just have to ensure that the UI for visualising diffs makes it clear
+   that diffs could span multiple edits rather than strictly be per-edit-event.
+
+What happens when we edit a reply?
+ * We just send an m.replace which refers to the m.reference target; nothing
+   special is needed.  i.e. you cannot change who the event is replying to.
+ * The edited reply should ditch the fallback representation of the reply itself
+   however from `m.new_content` (specifically the `<mx-reply>` tag in the
+   HTML, and the chevron prefixed text in the plaintext which we don't know
+   whether to parse as we don't know whether this is a reply or not), as we
+   can assume that any client which can handle edits can also display replies
+   natively.
+
+   XXX: make Riot do this
+
+What power level do you need to be able to edit other people's messages, and how
+does it fit in with fedeation event auth rules?
+ * 50, by default?
+
+    XXX: Synapse doesn't impose this currently - it lets anyone send an edit,
+    but then filters them out of bundled data.
+
+"Editing other people's messages is evil; we shouldn't allow it"
+ * Sorry, we have to bridge with systems which support cross-user edits.
+ * When it happens, we should make it super clear in the timeline that a message
+   was edited by a specific user.
+ * We do not recommend that native Matrix clients expose this as a feature.
+
+## Future considerations
+
+In future we may wish to consider ordering replacements (or relations in
+general) via a DAG rather than using `origin_server_ts` to determine ordering -
+particularly to mitigate potential abuse of edits applied by moderators.
+Whatever, care must be taken by the server to ensure that if there are multiple
+replacement events, the server must consistently choose the same one as all
+other servers.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-doc/blob/main/proposals/2676-message-editing.md)

Replaces matrix-org/matrix-spec-proposals#1849 along with matrix-org/matrix-spec-proposals#2674, matrix-org/matrix-spec-proposals#2675, and matrix-org/matrix-spec-proposals#2677

Fixes: https://github.com/matrix-org/matrix-spec/issues/184

FCP proposal: https://github.com/matrix-org/matrix-spec-proposals/pull/2676#issuecomment-1129177764

As the document says: this is intended to match the implementations currently in place in Synapse and Element-Web.