### PR TITLE
Allow `/make_join` to return a 404

### DIFF
--- a/api/server-server/joins-v1.yaml
+++ b/api/server-server/joins-v1.yaml
@@ -162,6 +162,16 @@ paths:
               "error": "Your homeserver does not support the features required to join this room",
               "room_version": "3"
             }
+        404:
+          description: |-
+            The room that the joining server is attempting to join is unknown
+            to the receiving server.
+          examples:
+            application/json: {
+              "errcode": "M_NOT_FOUND",
+              "error": "Unknown room",
+            }
+  
   "/send_join/{roomId}/{eventId}":
     put:
       summary: Submit a signed join event to a resident server

--- a/changelogs/server_server/newsfragments/2688.clarification
+++ b/changelogs/server_server/newsfragments/2688.clarification
@@ -1,0 +1,1 @@
+Specify that `GET /_matrix/federation/v1/make_join/{roomId}/{userId}` can return a 404 if the room is unknown.


### PR DESCRIPTION
Specify that `GET /_matrix/federation/v1/make_join/{roomId}/{userId}` can return a 404 if the room is unknown.

Synapse already does this for rooms it doesn't know about, so I'm claiming this is a clarification. Change my mind.