### PR TITLE
Attempt to clarify how the `state` restriction works for lazy-loading

### DIFF
--- a/api/client-server/sync.yaml
+++ b/api/client-server/sync.yaml
@@ -42,12 +42,15 @@ paths:
         full state of rooms is requested, to aid discovering the user's avatar &
         displayname.
 
-        Like other members, the user's own membership event is eligible
+        Further, like other members, the user's own membership event is eligible
         for being considered redundant by the server. When a sync is ``limited``,
         the server MUST return membership events for events in the gap
         (between ``since`` and the start of the returned timeline), regardless
-        as to whether or not they are redundant.  This ensures that joins/leaves
+        as to whether or not they are redundant. This ensures that joins/leaves
         and profile changes which occur during the gap are not lost.
+
+        Note that the default behaviour of ``state`` is to include all membership
+        events, alongside other state, when lazy-loading is not enabled.
       operationId: sync
       security:
         - accessToken: []

--- a/changelogs/client_server/newsfragments/2754.clarification
+++ b/changelogs/client_server/newsfragments/2754.clarification
@@ -1,0 +1,1 @@
+Clarify the behaviour of ``state`` for ``/sync`` with lazy-loading.


### PR DESCRIPTION
The "Like other members..." paragraph was confusing to people as it implied that it affected non-lazy-loading clients, which is technically true but also not. Clients can filter the `state` section of a sync without lazy-loading, but with lazy-loading they don't get a choice. Why a client would filter out membership events is beyond the scope of this PR.

The idea behind the diff is to try and link the paragraph previous to the confusing one, as it was originally intended when this was being added to the spec in the first place. A further clarifying statement is also introduced to try and de-confuse any remaining thoughts after reading the thing.

Overall I'm not super convinced this solves the problem, but it's at least a step towards sanity?