### PR TITLE
MSC2758: Proposal for a common identifier grammar

### DIFF
--- a/proposals/2758-textual-id-grammar.md
+++ b/proposals/2758-textual-id-grammar.md
@@ -22,7 +22,7 @@ past include:
  * event types
  * [`m.room.message` `msgtypes`](https://matrix.org/docs/spec/client_server/r0.6.0#m-room-message-msgtypes)
  * `app_id` for [`POST /_matrix/client/r0/pushers/set`](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-pushers-set).
- * `rule_id`s, `actions` and `tweak`s for [push rules](https://matrix.org/docs/spec/client_server/r0.6.0#push-rules).
+ * `rule_ids`, `actions` and `tweaks` for [push rules](https://matrix.org/docs/spec/client_server/r0.6.0#push-rules).
  * [E2E messaging algoritm names](https://matrix.org/docs/spec/client_server/r0.6.0#messaging-algorithm-names).
 
 ## Proposal
@@ -44,7 +44,7 @@ The grammar is defined as follows:
    the Java Package Naming conventions of using a reversed domain name, for
    example `com.example.identifier`.
 
-This grammar is indented for use entirely by internal identifiers, and *not*
+This grammar is intended for use entirely by internal identifiers, and *not*
 for user-visible strings.
 
 ### Rationale

--- a/proposals/2758-textual-id-grammar.md
+++ b/proposals/2758-textual-id-grammar.md
@@ -34,8 +34,8 @@ today.
 
 The grammar is defined as follows:
 
- * The length of an identifier may not be less than one character or more than
-   255 characters.
+ * An identifier may not be less than one character or more than 255 characters
+   in length.
  * Identifiers must start with one of the characters `[a-z]`, and be entirely
    composed of the characters `[a-z]`, `[0-9]`, `-`, `_` and `.`.
  * Identifiers starting with the characters `m.` are reserved for use by the

--- a/proposals/2758-textual-id-grammar.md
+++ b/proposals/2758-textual-id-grammar.md
@@ -41,8 +41,10 @@ The grammar is defined as follows:
  * Identifiers starting with the characters `m.` are reserved for use by the
    formal matrix specification.
  * Implementations wishing to implement unspecified identifiers should follow
-   the Java Package Naming conventions of using a reversed domain name, for
-   example `com.example.identifier`.
+   the Java Package Naming convention of starting with a reversed domain
+   name (with a dot after the domain name part). For example, for the 
+   organisation `example.com`, a valid identifier would be
+   `com.example.identifier`.
 
 This grammar is intended for use entirely by internal identifiers, and *not*
 for user-visible strings.

--- a/proposals/2758-textual-id-grammar.md
+++ b/proposals/2758-textual-id-grammar.md
@@ -23,7 +23,7 @@ past include:
  * [`m.room.message` `msgtypes`](https://matrix.org/docs/spec/client_server/r0.6.0#m-room-message-msgtypes)
  * `app_id` for [`POST /_matrix/client/r0/pushers/set`](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-pushers-set).
  * `rule_ids`, `actions` and `tweaks` for [push rules](https://matrix.org/docs/spec/client_server/r0.6.0#push-rules).
- * [E2E messaging algoritm names](https://matrix.org/docs/spec/client_server/r0.6.0#messaging-algorithm-names).
+ * [E2E messaging algorithm names](https://matrix.org/docs/spec/client_server/r0.6.0#messaging-algorithm-names).
 
 ## Proposal
 
@@ -51,4 +51,4 @@ for user-visible strings.
 
  * Avoiding non-ascii characters sidesteps any issues with homoglyphs or
    altenative encodings of the same characters.
- * Avoiding upper-case character sidesteps any concerns over case-sensistivity.
+ * Avoiding upper-case character sidesteps any concerns over case-sensitivity.

--- a/proposals/2758-textual-id-grammar.md
+++ b/proposals/2758-textual-id-grammar.md
@@ -1,0 +1,54 @@
+# MSC2758: Common grammar for textual identifiers
+
+The matrix specification uses textual identifiers for a wide range of
+concepts. Examples include "event types" and "room versions".
+
+In the past, these identifiers have often lacked a formal grammar, leaving
+servers and clients to make assumptions about questions such as which
+characters are permitted, minimum and maximum lengths, etc.
+
+This proposal suggests a common grammar which can be used as a basis for
+*future* identifier types, to reduce the work involved in future specification
+work.
+
+No attempt is made here to bring existing identifiers into line; however
+examples of identifiers which might have benefitted from such a grammar in the
+past include:
+
+ * [`capabilities`](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-capabilities)
+   identifiers.
+ * authentication types for the [User-Interactive Authentication mechanism](https://matrix.org/docs/spec/client_server/r0.6.0#user-interactive-authentication-api).
+ * login types for [`/_matrix/client/r0/login`](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-login).
+ * event types
+ * [`m.room.message` `msgtypes`](https://matrix.org/docs/spec/client_server/r0.6.0#m-room-message-msgtypes)
+ * `app_id` for [`POST /_matrix/client/r0/pushers/set`](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-pushers-set).
+ * `rule_id`s, `actions` and `tweak`s for [push rules](https://matrix.org/docs/spec/client_server/r0.6.0#push-rules).
+ * [E2E messaging algoritm names](https://matrix.org/docs/spec/client_server/r0.6.0#messaging-algorithm-names).
+
+## Proposal
+
+We define a "common namespaced identifier grammar". This can then be referenced
+by other parts of the grammar, in much the same way as [Unpadded
+Base64](https://matrix.org/docs/spec/appendices#unpadded-base64) is defined
+today.
+
+The grammar is defined as follows:
+
+ * The length of an identifier may not be less than one character or more than
+   255 characters.
+ * Identifiers must start with one of the characters `[a-z]`, and be entirely
+   composed of the characters `[a-z]`, `[0-9]`, `-`, `_` and `.`.
+ * Identifiers starting with the characters `m.` are reserved for use by the
+   formal matrix specification.
+ * Implementations wishing to implement unspecified identifiers should follow
+   the Java Package Naming conventions of using a reversed domain name, for
+   example `com.example.identifier`.
+
+This grammar is indented for use entirely by internal identifiers, and *not*
+for user-visible strings.
+
+### Rationale
+
+ * Avoiding non-ascii characters sidesteps any issues with homoglyphs or
+   altenative encodings of the same characters.
+ * Avoiding upper-case character sidesteps any concerns over case-sensistivity.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-doc/blob/rav/proposals/textual_identifier_grammar/proposals/2758-textual-id-grammar.md)