### PR TITLE
Suppress bullets inside table of contents

### DIFF
--- a/scripts/css/nature.css
+++ b/scripts/css/nature.css
@@ -290,3 +290,6 @@ div.admonition-example {
     border: 1px solid #ccc;
 }
 
+div#table-of-contents ul {
+    list-style-type: none;
+}


### PR DESCRIPTION
This PR is supposed to suppress bullets inside the table of contents, so we get:

<img width="382" alt="Screen Shot 2020-10-06 at 2 08 14 PM" src="https://user-images.githubusercontent.com/432915/95260377-73fc1800-07dd-11eb-9b1f-69d40c29c536.png">

instead of

<img width="373" alt="Screen Shot 2020-10-06 at 2 06 41 PM" src="https://user-images.githubusercontent.com/432915/95260236-3c8d6b80-07dd-11eb-9598-c52779327f56.png">

I wasn't sure where best to include the rule.

Also, the scripts/css/nature.css file includes some trailing whitespace, which my editor removes by default. I turned that off, so as to have a minimal diff here, but what do people think about this? Is it OK to include whitespace changes like that in PRs (assuming we don't want trailing whitespace)?