### PR TITLE
Make score and reason optional in content reporting API (MSC2414)

### DIFF
--- a/api/client-server/report_content.yaml
+++ b/api/client-server/report_content.yaml
@@ -55,7 +55,6 @@ paths:
               "score": -100,
               "reason": "this makes me sad"
             }
-            required: ['score', 'reason']
             properties:
               score:
                 type: integer

--- a/changelogs/client_server/newsfragments/2807.feature
+++ b/changelogs/client_server/newsfragments/2807.feature
@@ -1,0 +1,1 @@
+Make ``reason`` and ``score`` parameters optional in the content reporting API (MSC2414).


### PR DESCRIPTION
Updates the spec per [MSC2414](https://github.com/matrix-org/matrix-doc/pull/2414).