### PR TITLE
Allow guests to get the members for a room (MSC2689)

### DIFF
--- a/changelogs/client_server/newsfragments/2808.feature
+++ b/changelogs/client_server/newsfragments/2808.feature
@@ -1,0 +1,1 @@
+Allow guests to get the list of members for a room (MSC2689).

--- a/specification/modules/guest_access.rst
+++ b/specification/modules/guest_access.rst
@@ -54,6 +54,7 @@ retrieving events:
 * `GET /rooms/:room_id/event/:event_id <#get-matrix-client-%CLIENT_MAJOR_VERSION%-rooms-roomid-event-eventid>`_
 * `GET /rooms/:room_id/state/:event_type/:state_key <#get-matrix-client-%CLIENT_MAJOR_VERSION%-rooms-roomid-state-eventtype-statekey>`_
 * `GET /rooms/:room_id/messages <#get-matrix-client-%CLIENT_MAJOR_VERSION%-rooms-roomid-messages>`_
+* `GET /rooms/:room_id/members <#get-matrix-client-%CLIENT_MAJOR_VERSION%-rooms-roomid-members>`_
 * `GET /rooms/:room_id/initialSync <#get-matrix-client-%CLIENT_MAJOR_VERSION%-rooms-roomid-initialsync>`_
 * `GET /sync <#get-matrix-client-%CLIENT_MAJOR_VERSION%-sync>`_
 * `GET /events`__ as used for room previews.


### PR DESCRIPTION
Updates the spec per [MSC2689](https://github.com/matrix-org/matrix-doc/pull/2689).