### PR TITLE
Clarify m.room.redaction, remove duplicate entry

### DIFF
--- a/api/client-server/redaction.yaml
+++ b/api/client-server/redaction.yaml
@@ -36,9 +36,12 @@ paths:
 
         This cannot be undone.
 
-        Any user with a power level greater than or equal to the ``redact`` power level
-        of the room may redact events there. Additionally, server administrators may
-        redact messages sent by their server.
+        Any user with a power level greater than or equal to the ``m.room.redaction``
+        event power level may send redaction events in the room. If the user's power
+        level greater is also greater than or equal to the ``redact`` power level
+        of the room, the user may redact events sent by other users.
+
+        Server administrators may redact events sent by users on their server.
       operationId: redactEvent
       security:
         - accessToken: []

--- a/api/client-server/redaction.yaml
+++ b/api/client-server/redaction.yaml
@@ -36,9 +36,9 @@ paths:
 
         This cannot be undone.
 
-        Users may redact their own events, and any user with a power level
-        greater than or equal to the ``redact`` power level of the room may
-        redact events there.
+        Any user with a power level greater than or equal to the ``redact`` power level
+        of the room may redact events there. Additionally, server administrators may
+        redact messages sent by their server.
       operationId: redactEvent
       security:
         - accessToken: []

--- a/changelogs/client_server/newsfragments/2814.clarification
+++ b/changelogs/client_server/newsfragments/2814.clarification
@@ -1,0 +1,1 @@
+Clarify description of m.room.redaction event.

--- a/event-schemas/schema/m.room.power_levels
+++ b/event-schemas/schema/m.room.power_levels
@@ -25,10 +25,11 @@ description: |-
   ``events_default`` are 0.
 
   The power level required to invite a user to the room, kick a user from the
-  room, ban a user from the room, or redact an event, is defined by ``invite``,
-  ``kick``, ``ban``, and ``redact``, respectively. Each of these levels defaults
-  to 50 if they are not specified in the ``m.room.power_levels`` event, or if
-  the room contains no ``m.room.power_levels`` event.
+  room, ban a user from the room, or redact an event sent by another user, is
+  defined by ``invite``, ``kick``, ``ban``, and ``redact``, respectively. Each
+  of these levels defaults to 50 if they are not specified in the
+  ``m.room.power_levels`` event, or if the room contains no ``m.room.power_levels``
+  event.
 
   .. NOTE::
 
@@ -65,7 +66,7 @@ properties:
         description: The level required to kick a user. Defaults to 50 if unspecified.
         type: integer
       redact:
-        description: The level required to redact an event. Defaults to 50 if unspecified.
+        description: The level required to redact an event sent by another user. Defaults to 50 if unspecified.
         type: integer
       state_default:
         description: |-

--- a/event-schemas/schema/m.room.redaction
+++ b/event-schemas/schema/m.room.redaction
@@ -1,7 +1,7 @@
 ---
 allOf:
   - $ref: core-event-schema/room_event.yaml
-description: 'Events can be redacted by either room or server admins. Redacting an event means that all keys not required by the protocol are stripped off, allowing admins to remove offensive or illegal content that may have been attached to any event. This cannot be undone, allowing server owners to physically delete the offending data.  There is also a concept of a moderator hiding a message event, which can be undone, but cannot be applied to state events. The event that has been redacted is specified in the ``redacts`` event level key.'
+description: 'Redacting an event means that all keys not required by the protocol are stripped off, allowing messages to be hidden or allowing admins to remove offensive or illegal content. Users may redact their own events, and any user with a power level greater than or equal to the redact power level of the room may redact events in that room. Redactions cannot be undone. The event that has been redacted is specified in the ``redacts`` event level key.'
 properties:
   content:
     properties:

--- a/event-schemas/schema/m.room.redaction
+++ b/event-schemas/schema/m.room.redaction
@@ -1,7 +1,7 @@
 ---
 allOf:
   - $ref: core-event-schema/room_event.yaml
-description: 'Redacting an event means that all keys not required by the protocol are stripped off, allowing messages to be hidden or allowing admins to remove offensive or illegal content. Users may redact their own events, and any user with a power level greater than or equal to the redact power level of the room may redact events in that room. Redactions cannot be undone. The event that has been redacted is specified in the ``redacts`` event level key.'
+description: 'This event is created by the server to describe which event has been redacted, by whom, and optionally why. The event that has been redacted is specified in the ``redacts`` event level key. Redacting an event means that all keys not required by the protocol are stripped off, allowing messages to be hidden or allowing admins to remove offensive or illegal content.'
 properties:
   content:
     properties:

--- a/specification/client_server_api.rst
+++ b/specification/client_server_api.rst
@@ -1551,8 +1551,6 @@ prefixed with ``m.``
 
 {{m_room_power_levels_event}}
 
-{{m_room_redaction_event}}
-
 Historical events
 +++++++++++++++++
 


### PR DESCRIPTION
Fixes #2171
Fixes #2172

As far as I can tell server admins cannot redact events in rooms where they don't have the proper power level so I have removed mention of that.

I have also removed

> There is also a concept of a moderator hiding a message event, which can be undone, but cannot be applied to state events.

which doesn't seem to be a thing that exists.