### PR TITLE
Mark Content-Disposition header required in /download/{serverName}/{mediaId}/{fileName}

### DIFF
--- a/api/client-server/content-repo.yaml
+++ b/api/client-server/content-repo.yaml
@@ -213,6 +213,7 @@ paths:
                 The ``fileName`` requested or the name of the file that was previously
                 uploaded, if set.
               type: "string"
+              required: true
           schema:
             type: file
             # This is a workaround for us not being able to say the response is required.


### PR DESCRIPTION
Am I understanding correctly that `fileName` is a fallback for the uploaded file's original name (if there is none) and since it is required, server implementations are required to have a `Content-Disposition` header in the response?