### PR TITLE
Fix definition of historical user IDs

### DIFF
--- a/specification/appendices/identifier_grammar.rst
+++ b/specification/appendices/identifier_grammar.rst
@@ -190,7 +190,7 @@ history includes events with a ``sender`` which does not conform. In order to
 handle these rooms successfully, clients and servers MUST accept user IDs with
 localparts from the expanded character set::
 
-  extended_user_id_char = %x21-39 / %x3B-7E  ; all ascii printing chars except :
+  extended_user_id_char = %x20-39 / %x3B-7E  ; all ascii printing chars except :
 
 Mapping from other character sets
 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
Spaces are allowed by Synapse and a space is a printable ASCII character.

Signed-off-by: Tulir Asokan &lt;tulir@maunium.net&gt;

P.S.: I might have created a user ID with spaces and joined some rooms with it a couple of months back. Conduit doesn't like such rooms 😿