### PR TITLE
Update link to extensible events MSC

### DIFF
--- a/changelogs/client_server/newsfragments/2878.clarification
+++ b/changelogs/client_server/newsfragments/2878.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/specification/modules/instant_messaging.rst
+++ b/specification/modules/instant_messaging.rst
@@ -121,7 +121,7 @@ the tag and its contents and therefore may wish to exclude the tag entirely.
 
 .. Note::
    A future iteration of the specification will support more powerful and extensible
-   message formatting options, such as the proposal `MSC1225 <https://github.com/matrix-org/matrix-doc/issues/1225>`_.
+   message formatting options, such as the proposal `MSC1767 <https://github.com/matrix-org/matrix-doc/pull/1767>`_.
 
 {{msgtype_events}}
 


### PR DESCRIPTION
Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

Please tell me, if this needs a news fragment or not. This is kind of an edge case between style fix and spec clarification.

I'm also not sure, if that Note should be there, but at least it should not point to a closed MSC imo, so this just points the link at the replacement MSC.