### PR TITLE
Make 'messages' a required JSON body field in /sendToDevice

### DIFF
--- a/api/client-server/to_device.yaml
+++ b/api/client-server/to_device.yaml
@@ -79,6 +79,7 @@ paths:
                       }
                     }
                   }
+            required: ["messages"]
       responses:
         200:
           description:

--- a/changelogs/client_server/newsfragments/2928.clarification
+++ b/changelogs/client_server/newsfragments/2928.clarification
@@ -1,0 +1,1 @@
+Mark `messages` as a required JSON body field in `PUT /_matrix/client/r0/sendToDevice/{eventType}/{txnId}` calls.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2927