### PR TITLE
Support changelogs

### DIFF
--- a/changelogs/client_server/newsfragments/2387.new
+++ b/changelogs/client_server/newsfragments/2387.new
@@ -1,1 +1,1 @@
-Add key backup (``/room_keys/*``) endpoints.
+Add key backup (`/room_keys/*`) endpoints.

--- a/changelogs/client_server/newsfragments/2399.feature
+++ b/changelogs/client_server/newsfragments/2399.feature
@@ -1,1 +1,1 @@
-Document how clients can advise recipients that it is withholding decryption keys as per `MSC2399 <https://github.com/matrix-org/matrix-doc/pull/2399>`_.
+Document how clients can advise recipients that it is withholding decryption keys as per [MSC2399](https://github.com/matrix-org/matrix-doc/pull/2399).

--- a/changelogs/client_server/newsfragments/2536.feature
+++ b/changelogs/client_server/newsfragments/2536.feature
@@ -1,1 +1,1 @@
-Add cross-signing properties to the response of ``POST /keys/query`` per [MSC1756](https://github.com/matrix-org/matrix-doc/pull/1756).
+Add cross-signing properties to the response of `POST /keys/query` per [MSC1756](https://github.com/matrix-org/matrix-doc/pull/1756).

--- a/changelogs/client_server/newsfragments/2536.new
+++ b/changelogs/client_server/newsfragments/2536.new
@@ -1,1 +1,1 @@
-Add ``POST /keys/device_signing/upload`` and ``POST /keys/signatures/upload`` per [MSC1756](https://github.com/matrix-org/matrix-doc/pull/1756).
+Add `POST /keys/device_signing/upload` and `POST /keys/signatures/upload` per [MSC1756](https://github.com/matrix-org/matrix-doc/pull/1756).

--- a/changelogs/client_server/newsfragments/2591.clarification
+++ b/changelogs/client_server/newsfragments/2591.clarification
@@ -1,1 +1,1 @@
-Fix issues with ``age`` and ``unsigned`` being shown in the wrong places.
+Fix issues with `age` and `unsigned` being shown in the wrong places.

--- a/changelogs/client_server/newsfragments/2609.removal
+++ b/changelogs/client_server/newsfragments/2609.removal
@@ -1,1 +1,1 @@
-Remove unimplemented ``m.login.oauth2`` and ``m.login.token`` user-interactive authentication mechanisms.
+Remove unimplemented `m.login.oauth2` and `m.login.token` user-interactive authentication mechanisms.

--- a/changelogs/client_server/newsfragments/2629.clarification
+++ b/changelogs/client_server/newsfragments/2629.clarification
@@ -1,1 +1,1 @@
-Remove ``room_id`` from ``/sync`` examples.
+Remove `room_id` from `/sync` examples.

--- a/changelogs/client_server/newsfragments/2647.clarification
+++ b/changelogs/client_server/newsfragments/2647.clarification
@@ -1,1 +1,1 @@
-Improve consistency and clarity of event schema ``title``\ s.
+Improve consistency and clarity of event schema `title` s.

--- a/changelogs/client_server/newsfragments/2709.feature
+++ b/changelogs/client_server/newsfragments/2709.feature
@@ -1,1 +1,1 @@
-Add a ``device_id`` parameter to login fallback per `MSC2604 <https://github.com/matrix-org/matrix-doc/pull/2604>`_.
+Add a `device_id` parameter to login fallback per [MSC2604](https://github.com/matrix-org/matrix-doc/pull/2604).

--- a/changelogs/client_server/newsfragments/2754.clarification
+++ b/changelogs/client_server/newsfragments/2754.clarification
@@ -1,1 +1,1 @@
-Clarify the behaviour of ``state`` for ``/sync`` with lazy-loading.
+Clarify the behaviour of `state` for `/sync` with lazy-loading.

--- a/changelogs/client_server/newsfragments/2795.feature
+++ b/changelogs/client_server/newsfragments/2795.feature
@@ -1,1 +1,1 @@
-Added support for ``reason`` on all membership events and related endpoints as per `MSC2367 <https://github.com/matrix-org/matrix-doc/pull/2367>`_.
+Added support for `reason` on all membership events and related endpoints as per [MSC2367](https://github.com/matrix-org/matrix-doc/pull/2367).

--- a/changelogs/client_server/newsfragments/2796.feature
+++ b/changelogs/client_server/newsfragments/2796.feature
@@ -1,1 +1,1 @@
-Add a 404 ``M_NOT_FOUND`` error to push rule endpoints as per `MSC2663 <https://github.com/matrix-org/matrix-doc/pull/2663>`_.
+Add a 404 `M_NOT_FOUND` error to push rule endpoints as per [MSC2663](https://github.com/matrix-org/matrix-doc/pull/2663).

--- a/changelogs/client_server/newsfragments/2807.feature
+++ b/changelogs/client_server/newsfragments/2807.feature
@@ -1,1 +1,1 @@
-Make ``reason`` and ``score`` parameters optional in the content reporting API (MSC2414).
+Make `reason` and `score` parameters optional in the content reporting API (MSC2414).

--- a/changelogs/server_server/newsfragments/2536.feature
+++ b/changelogs/server_server/newsfragments/2536.feature
@@ -1,9 +1,9 @@
 Add cross-signing:
 
-- Add properties to the response of ``GET /user/keys`` and ``GET
-  /user/devices/{userId}``.
-- The ``m.device_list_update`` EDU is sent when a device gets a new signature.
-- A new ``m.signing_key_update`` EDU is sent when a user's cross-signing keys
+- Add properties to the response of `GET /user/keys` and `GET
+  /user/devices/{userId}`.
+- The `m.device_list_update` EDU is sent when a device gets a new signature.
+- A new `m.signing_key_update` EDU is sent when a user's cross-signing keys
   are changed.
 
 per [MSC1756](https://github.com/matrix-org/matrix-doc/pull/1756).

--- a/changelogs/server_server/newsfragments/2688.clarification
+++ b/changelogs/server_server/newsfragments/2688.clarification
@@ -1,1 +1,1 @@
-Specify that ``GET /_matrix/federation/v1/make_join/{roomId}/{userId}`` can return a 404 if the room is unknown.
+Specify that `GET /_matrix/federation/v1/make_join/{roomId}/{userId}` can return a 404 if the room is unknown.

--- a/config.toml
+++ b/config.toml
@@ -39,7 +39,7 @@ privacy_policy = "https://matrix.org/legal/privacy-notice"
 # must be one of "unstable", "current", "historical"
 # this is used to decide whether to show a banner pointing to the current release
 status = "unstable"
-current_version_url = "https://spec.matrix.org/latest"
+current_version_url = "https://matrix.org/docs/spec/"
 
 # User interface configuration
 [params.ui]

--- a/content/changelog.md
+++ b/content/changelog.md
@@ -1,0 +1,47 @@
+---
+title: Changelog
+type: docs
+weight: 1000
+---
+
+{{% changelog/changelog-description %}}
+
+{{% changelog/changelog-changes %}}
+
+<h2 id="historical-versions" class="no-numbers">Historical versions</h2>
+
+Before version 1.1, versioning was applied at the level of individual API specifications. This section includes links to these versions of the APIs.
+
+* **Client-Server API**
+  -   [r0.6.1](https://matrix.org/docs/spec/client_server/r0.6.1.html)
+  -   [r0.6.0](https://matrix.org/docs/spec/client_server/r0.6.0.html)
+  -   [r0.5.0](https://matrix.org/docs/spec/client_server/r0.5.0.html)
+  -   [r0.4.0](https://matrix.org/docs/spec/client_server/r0.4.0.html)
+  -   [r0.3.0](https://matrix.org/docs/spec/client_server/r0.3.0.html)
+  -   [r0.2.0](https://matrix.org/docs/spec/client_server/r0.2.0.html)
+  -   [r0.1.0](https://matrix.org/docs/spec/client_server/r0.1.0.html)
+  -   [r0.0.1](https://matrix.org/docs/spec/r0.0.1/client_server.html)
+  -   [r0.0.0](https://matrix.org/docs/spec/r0.0.0/client_server.html)
+  -   [Legacy](https://matrix.org/docs/spec/legacy/#client-server-api):
+      The last draft before the spec was formally released in version
+      r0.0.0.
+
+* **Server-Server API**
+  -   [r0.1.4](https://matrix.org/docs/spec/server_server/r0.1.4.html)
+  -   [r0.1.3](https://matrix.org/docs/spec/server_server/r0.1.3.html)
+  -   [r0.1.2](https://matrix.org/docs/spec/server_server/r0.1.2.html)
+  -   [r0.1.1](https://matrix.org/docs/spec/server_server/r0.1.1.html)
+  -   [r0.1.0](https://matrix.org/docs/spec/server_server/r0.1.0.html)
+
+* **Application Service API**
+  -   [r0.1.1](https://matrix.org/docs/spec/application_service/r0.1.1.html)
+  -   [r0.1.0](https://matrix.org/docs/spec/application_service/r0.1.0.html)
+
+* **Identity Service API**
+  -   [r0.3.0](https://matrix.org/docs/spec/identity_service/r0.3.0.html)
+  -   [r0.2.1](https://matrix.org/docs/spec/identity_service/r0.2.1.html)
+  -   [r0.2.0](https://matrix.org/docs/spec/identity_service/r0.2.0.html)
+  -   [r0.1.0](https://matrix.org/docs/spec/identity_service/r0.1.0.html)
+
+* **Push Gateway API**
+  -   [r0.1.0](https://matrix.org/docs/spec/push_gateway/r0.1.0.html)

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -45,8 +45,7 @@
     {{ $status := .Site.Params.version.status }}
 
     {{ if ne $status "unstable"}}
-        {{ $version_pieces := slice .Site.Params.version.major_version .Site.Params.version.minor_version .Site.Params.version.patch_version}}
-        {{ $ret = delimit $version_pieces "." }}
+        {{ $ret = .Site.Params.version.number }}
         {{ $ret = delimit (slice "version" $ret) " " }}
     {{ end }}
 

--- a/layouts/shortcodes/changelog/changelog-changes.html
+++ b/layouts/shortcodes/changelog/changelog-changes.html
@@ -3,7 +3,7 @@
   This template is used to render the set of changes in the changelog page.
 
   If this version of the spec is unstable, it expects to find a
-  "changelog/newsfragments" directory containing all unreleased changes,
+  "changelogs/<api>/newsfragments" directory containing all unreleased changes,
   and renders them all.
 
   Otherwise it expects to find a "changelog/releases" directory, under which

--- a/layouts/shortcodes/changelog/changelog-changes.html
+++ b/layouts/shortcodes/changelog/changelog-changes.html
@@ -2,61 +2,36 @@
 
   This template is used to render the set of changes in the changelog page.
 
-  If this version of the spec is unstable, it expects to find a
-  "changelogs/<api>/newsfragments" directory containing all unreleased changes,
-  and renders them all.
+  It expects to find a directory "changelogs" containing a subdirectory for
+  each of the 5 APIs in the specification. Inside each of these directories
+  it expects to find newsfragments describing changes to that API.
 
-  Otherwise it expects to find a "changelog/releases" directory, under which
-  is one or more directories whose name is a patch number, like "0", "1", and so on.
-
-  It renders each of these subdirectories as a separate patch, including
-  a table containing basic info about that patch and the set of changes in it.
+  If the `version.status` setting in config.toml is anything other than
+  "unstable", then it also expects to find a "release.yaml" file in /changelogs,
+  which contains:
+  - `tag`: Git tag for this release
+  - `date`: date of this release
+  It then renders this info a table, before the list of changes.
 
 */}}
 
 {{ $path := path.Join "changelogs" }}
-
 {{ $status := .Site.Params.version.status }}
 
-{{ if eq $status "unstable" }}
-<h2 id=api-changes>Changes since last release</h2>
-    {{ partial "render-api-changes" (dict "title" "Client-Server API" "id" "client-server-api" "path" (path.Join $path "client_server")) }}
-    {{ partial "render-api-changes" (dict "title" "Server-Server API" "id" "server-server-api" "path" (path.Join $path "server_server")) }}
-    {{ partial "render-api-changes" (dict "title" "Application Service API" "id" "application-service-api" "path" (path.Join $path "application_service")) }}
-    {{ partial "render-api-changes" (dict "title" "Identity Service API" "id" "identity-service-api" "path" (path.Join $path "identity_service")) }}
-    {{ partial "render-api-changes" (dict "title" "Push Gateway API" "id" "push-gateway-api" "path" (path.Join $path "push_gateway")) }}
-{{ else }}
-    {{ $releases_path := path.Join $path "releases" }}
-    {{ $major_version := .Site.Params.version.major_version }}
-    {{ $minor_version := .Site.Params.version.minor_version }}
-    {{ $releases := partial "reverse-slice" (readDir $releases_path) }}
-    {{ range $releases }}
-        {{ if .IsDir }}
-<h2 id="{{ .Name }}">Version {{ $major_version }}.{{ $minor_version }}.{{ .Name }}</h2>
-        {{ $release_path := path.Join $releases_path .Name}}
-        {{ $release_info := readFile (path.Join $release_path "release.yaml") | transform.Unmarshal }}
+{{ if ne $status "unstable" }}
+{{ $release_info := readFile (path.Join $path "release.yaml") | transform.Unmarshal }}
 <table class="release-info">
 <tr><th>Git commit</th><td><a href="https://github.com/matrix-org/matrix-doc/tree/{{ $release_info.tag }}">https://github.com/matrix-org/matrix-doc/tree/{{ $release_info.tag }}</a></td>
 <tr><th>Release date</th><td>{{ $release_info.date }}</td>
 </table>
-            {{ partial "render-api-changes" (dict "title" "Client-Server API" "id" "client-server-api" "path" (path.Join $release_path "client_server")) }}
-            {{ partial "render-api-changes" (dict "title" "Server-Server API" "id" "server-server-api" "path" (path.Join $release_path "server_server")) }}
-            {{ partial "render-api-changes" (dict "title" "Application Service API" "id" "application-service-api" "path" (path.Join $release_path "application_service")) }}
-            {{ partial "render-api-changes" (dict "title" "Identity Service API" "id" "identity-service-api" "path" (path.Join $release_path "identity_service")) }}
-            {{ partial "render-api-changes" (dict "title" "Push Gateway API" "id" "push-gateway-api" "path" (path.Join $release_path "push_gateway")) }}
-        {{ end }}
-    {{ end }}
 {{ end }}
 
-{{ define "partials/reverse-slice" }}
-{{ $sliceOriginal := . }}
-{{ $len := len $sliceOriginal }}
-{{ $sliceReversed := slice }}
-{{ range seq $len }}
-    {{ $sliceReversed = $sliceReversed | append (index $sliceOriginal (sub $len .)) }}
-{{ end }}
-{{ return $sliceReversed }}
-{{ end }}
+<h2 id=api-changes>Changes since last release</h2>
+{{ partial "render-api-changes" (dict "title" "Client-Server API" "id" "client-server-api" "path" (path.Join $path "client_server")) }}
+{{ partial "render-api-changes" (dict "title" "Server-Server API" "id" "server-server-api" "path" (path.Join $path "server_server")) }}
+{{ partial "render-api-changes" (dict "title" "Application Service API" "id" "application-service-api" "path" (path.Join $path "application_service")) }}
+{{ partial "render-api-changes" (dict "title" "Identity Service API" "id" "identity-service-api" "path" (path.Join $path "identity_service")) }}
+{{ partial "render-api-changes" (dict "title" "Push Gateway API" "id" "push-gateway-api" "path" (path.Join $path "push_gateway")) }}
 
 {{ define "partials/render-api-changes" }}
 <h3 id="{{.id}}">{{ .title }}</h3>

--- a/layouts/shortcodes/changelog/changelog-changes.html
+++ b/layouts/shortcodes/changelog/changelog-changes.html
@@ -1,0 +1,108 @@
+{{/*
+
+  This template is used to render the set of changes in the changelog page.
+
+  If this version of the spec is unstable, it expects to find a
+  "changelog/newsfragments" directory containing all unreleased changes,
+  and renders them all.
+
+  Otherwise it expects to find a "changelog/releases" directory, under which
+  is one or more directories whose name is a patch number, like "0", "1", and so on.
+
+  It renders each of these subdirectories as a separate patch, including
+  a table containing basic info about that patch and the set of changes in it.
+
+*/}}
+
+{{ $path := path.Join "changelogs" }}
+
+{{ $status := .Site.Params.version.status }}
+
+{{ if eq $status "unstable" }}
+<h2 id=api-changes>Changes since last release</h2>
+    {{ partial "render-api-changes" (dict "title" "Client-Server API" "id" "client-server-api" "path" (path.Join $path "client_server")) }}
+    {{ partial "render-api-changes" (dict "title" "Server-Server API" "id" "server-server-api" "path" (path.Join $path "server_server")) }}
+    {{ partial "render-api-changes" (dict "title" "Application Service API" "id" "application-service-api" "path" (path.Join $path "application_service")) }}
+    {{ partial "render-api-changes" (dict "title" "Identity Service API" "id" "identity-service-api" "path" (path.Join $path "identity_service")) }}
+    {{ partial "render-api-changes" (dict "title" "Push Gateway API" "id" "push-gateway-api" "path" (path.Join $path "push_gateway")) }}
+{{ else }}
+    {{ $releases_path := path.Join $path "releases" }}
+    {{ $major_version := .Site.Params.version.major_version }}
+    {{ $minor_version := .Site.Params.version.minor_version }}
+    {{ $releases := partial "reverse-slice" (readDir $releases_path) }}
+    {{ range $releases }}
+        {{ if .IsDir }}
+<h2 id="{{ .Name }}">Version {{ $major_version }}.{{ $minor_version }}.{{ .Name }}</h2>
+        {{ $release_path := path.Join $releases_path .Name}}
+        {{ $release_info := readFile (path.Join $release_path "release.yaml") | transform.Unmarshal }}
+<table class="release-info">
+<tr><th>Git commit</th><td><a href="https://github.com/matrix-org/matrix-doc/tree/{{ $release_info.tag }}">https://github.com/matrix-org/matrix-doc/tree/{{ $release_info.tag }}</a></td>
+<tr><th>Release date</th><td>{{ $release_info.date }}</td>
+</table>
+            {{ partial "render-api-changes" (dict "title" "Client-Server API" "id" "client-server-api" "path" (path.Join $release_path "client_server")) }}
+            {{ partial "render-api-changes" (dict "title" "Server-Server API" "id" "server-server-api" "path" (path.Join $release_path "server_server")) }}
+            {{ partial "render-api-changes" (dict "title" "Application Service API" "id" "application-service-api" "path" (path.Join $release_path "application_service")) }}
+            {{ partial "render-api-changes" (dict "title" "Identity Service API" "id" "identity-service-api" "path" (path.Join $release_path "identity_service")) }}
+            {{ partial "render-api-changes" (dict "title" "Push Gateway API" "id" "push-gateway-api" "path" (path.Join $release_path "push_gateway")) }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+
+{{ define "partials/reverse-slice" }}
+{{ $sliceOriginal := . }}
+{{ $len := len $sliceOriginal }}
+{{ $sliceReversed := slice }}
+{{ range seq $len }}
+    {{ $sliceReversed = $sliceReversed | append (index $sliceOriginal (sub $len .)) }}
+{{ end }}
+{{ return $sliceReversed }}
+{{ end }}
+
+{{ define "partials/render-api-changes" }}
+<h3 id="{{.id}}">{{ .title }}</h3>
+    {{ $api_path := .path }}
+    {{ $config_file := path.Join $api_path "pyproject.toml" }}
+    {{ $config := readFile $config_file | transform.Unmarshal }}
+    {{ $news_path := path.Join $api_path "newsfragments" }}
+    {{ partial "render-newsfragments"  (dict "config" $config "news_path" $news_path )}}
+{{ end }}
+
+{{ define "partials/render-newsfragments" }}
+{{ $config := .config }}
+{{ $news_path := .news_path }}
+
+{{ $types := dict }}
+{{ range $config.tool.towncrier.type }}
+    {{ $types = merge $types (dict .directory (slice)) }}
+{{ end }}
+
+{{ range (readDir $news_path) }}
+
+    {{ $pieces := split .Name "." }}
+
+    {{ $ticket := index $pieces 0 }}
+    {{ $description := readFile (path.Join $news_path .Name ) }}
+    {{ $change_info := (dict "ticket" $ticket "description" $description )}}
+
+    {{ $type := index $pieces 1 }}
+    {{ $instances := index $types $type }}
+    {{ $instances = $instances | append $change_info }}
+    {{ $types = merge $types (dict $type $instances) }}
+
+{{ end }}
+
+<ul>
+{{ range $config.tool.towncrier.type }}
+    {{ $changes_of_type := (index $types .directory) }}
+    {{ if $changes_of_type }}
+<li><strong>{{.name}}</strong>
+<p><ul>
+        {{ range $changes_of_type }}
+<li><a href="https://github.com/matrix-org/matrix-doc/issues/{{.ticket}}"><strong>{{ .ticket }}: </strong></a>{{ .description | markdownify }}</li>
+        {{ end }}
+</ul></p>
+</li>
+    {{ end }}
+{{ end }}
+</ul>
+{{ end }}

--- a/layouts/shortcodes/changelog/changelog-description.html
+++ b/layouts/shortcodes/changelog/changelog-description.html
@@ -11,14 +11,5 @@
 <p>This is the <strong>unstable</strong> version of the Matrix specification.</p>
 <p>This changelog lists changes made since the last release of the specification.</p>
 {{ else }}
-<p>This is version <strong>{{ .Site.Params.version.major_version}}.{{ .Site.Params.version.minor_version}}.{{ .Site.Params.version.patch_version}}</strong> of the Matrix specification.</p>
-
-
-<p>Versions for the Matrix specification follow a three-part format like `major.minor.patch`.</p>
-
-* `major` version increments are reserved for very significant changes.
-* `minor` version increments may signal additions, deprecations, or breaking changes.
-* `patch` version increments are for clarifications to the specification and don't affect implementations.
-
-<p>This changelog lists changes made in the initial <strong>{{ .Site.Params.version.major_version}}.{{ .Site.Params.version.minor_version}}</strong> release and any subsequent patch releases to that version.</p>
+<p>This is version <strong>{{ .Site.Params.version.number }}</strong> of the Matrix specification.</p>
 {{ end }}

--- a/layouts/shortcodes/changelog/changelog-description.html
+++ b/layouts/shortcodes/changelog/changelog-description.html
@@ -1,0 +1,24 @@
+{{/*
+
+  This template is used to provide different content for the unstable spec
+  version and for a versioned release.
+
+*/}}
+
+{{ $status := .Site.Params.version.status }}
+
+{{ if eq $status "unstable"}}
+<p>This is the <strong>unstable</strong> version of the Matrix specification.</p>
+<p>This changelog lists changes made since the last release of the specification.</p>
+{{ else }}
+<p>This is version <strong>{{ .Site.Params.version.major_version}}.{{ .Site.Params.version.minor_version}}.{{ .Site.Params.version.patch_version}}</strong> of the Matrix specification.</p>
+
+
+<p>Versions for the Matrix specification follow a three-part format like `major.minor.patch`.</p>
+
+* `major` version increments are reserved for very significant changes.
+* `minor` version increments may signal additions, deprecations, or breaking changes.
+* `patch` version increments are for clarifications to the specification and don't affect implementations.
+
+<p>This changelog lists changes made in the initial <strong>{{ .Site.Params.version.major_version}}.{{ .Site.Params.version.minor_version}}</strong> release and any subsequent patch releases to that version.</p>
+{{ end }}


### PR DESCRIPTION
This is the fourth of a series of PRs to ship the new spec platform, as part of https://github.com/matrix-org/matrix-doc/issues/2906.

It adds support for rendering changelogs.

This is all tied up with how we want to handle spec versioning, and what's implemented here is based on what was discussed in https://github.com/matrix-org/matrix-doc/issues/2877, but that thread is a bit hard to follow, so I'll summarise it again here.

*********

## Changelogs and versions

The `main` branch of the matrix-doc repository is always the current unstable version of the spec. Each major.minor release of the spec is a separate tagged branch. Each patch version of the spec is an incremental change in top of its existing major.minor branch. That is, we use separate branches for major.minor versions but not for patch versions.

There is metadata in the repo telling it which version of the spec it represents, and the site uses this for things like "unstable" warnings as well as to build the changelog. Specifically, we have the following properties in `config.toml`:

* `status`: this can have one of three values:
    * `"unstable"`: this is the unstable version of the spec
    * `"current"`: this is the most recent released version of the spec
    * `"historical"`: this is an older release of the spec
* `current_version_url`: the place we put the current version of the spec (e.g. `"https://spec.matrix.org/latest"`)
* `major_version`: the major version number for this version of the spec (omitted if `status` is `"unstable"`)
* `minor_version`: the minor version number for this version of the spec (omitted if `status` is `"unstable"`)
* `patch_version`: the patch version number for this version of the spec (omitted if `status` is `"unstable"`)

The repo also contains a directory `/changelogs`.

### /changelogs in the unstable branch

In the main (`"unstable"`) branch, `/changelogs` is exactly the way it was before: a directory for each API, and under each of these directories a `pyproject.toml` describing the towncrier format and a `newsfragments` directory containing changes in towncrier format:

```
/changelogs
    /application_service   (other API directories also have this internal structure)
        /newsfragments
        pyproject.toml
    /client_server
    /identity_service
    /push_gateway
    /server_server
```

### /changelogs in release branches

In a release branch, `/changelogs` is expected to contain a "releases" directory which is expected to contain one directory for the initial major.minor release for which we created this branch, and one for each patch release which has been added. Inside each of these directories is:
* a "release.yaml" file which includes the date of this release and its Git tag
* a directory for each API, containing changes included for that API in this release.

For example, if we've made two patches, it would look like:

```
/changelogs
    /releases
        /0                         <- initial major.minor release
            /application_service   (other API directories also have this internal structure)
                /newsfragments
                pyproject.toml
            /client_server
            /identity_service
            /push_gateway
            /server_server
            release.yaml
        /1                         <- first patch
            /application_service   (other API directories also have this internal structure)
                /newsfragments
                pyproject.toml
            /client_server
            /identity_service
            /push_gateway
            /server_server
            release.yaml
        /2                          <- second patch
            /application_service   (other API directories also have this internal structure)
                /newsfragments
                pyproject.toml
            /client_server
            /identity_service
            /push_gateway
            /server_server
            release.yaml
```

## This PR

This PR assumes we will have a setup like the above. So it includes:

* a new content file, `/content/changelog.md`
* two new templates to help render changelogs, under `/layouts/shortcodes/changelog`.
    * `changelog-changes.html`: this renders the changelog entries differently depending on whether we are in the unstable branch or a released branch.
    * `changelog-description.html`: this renders different boilerplate text depending on whether we are in the unstable branch or a released branch.

Because this PR is targeting the main branch, of course you'll see the "unstable" version of the changelog. I made another branch: https://github.com/wbamberg/matrix-doc/tree/demonstrate-release-branch to show what the thing would look like in a release branch. 

Finally, this PR changes the changelog entry descriptions from RST to Markdown, which is a fix for https://github.com/matrix-org/matrix-doc/issues/2919.

It's probably worth mentioning that we don't have to buy into the whole versioning process outlined above until we actually want to make a release. So we can merge this change and still redo the versioning process. But I've gone into it in detail here just to explain what this PR is trying to support.
 