### PR TITLE
Prevent sidebar scroll from overflowing

### DIFF
--- a/assets-hugo/scss/custom.scss
+++ b/assets-hugo/scss/custom.scss
@@ -43,6 +43,7 @@ Custom SCSS for the Matrix spec
 /* Styles for the sidebar nav */
 .td-sidebar-nav {
   scroll-behavior: smooth;
+  overscroll-behavior: contain;
 
   /* This overrides calc(100vh - 10rem);, which gives us a blank space at the bottom of the sidebar */
   max-height: calc(100vh - 6rem);


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/2978.

To reproduce the issue, visit https://adoring-einstein-5ea514.netlify.app/client-server-api/#fallback, and scroll the sidebar back up to the top, then try to scroll up again: the document and sidebar will both bounce back somewhere down the page.

With this fix, scrolling up when the sidebar is already at the top should have no effect.

See https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior for details of why this fixes the problem.