### PR TITLE
More consistent widths

### DIFF
--- a/assets-hugo/scss/custom.scss
+++ b/assets-hugo/scss/custom.scss
@@ -246,7 +246,6 @@ footer {
 /* Styles for sections that are rendered from data, such as HTTP APIs and event schemas */
 .rendered-data {
   margin: 1rem 0 3rem 0;
-  padding: 1rem;
 
   details {
 
@@ -296,7 +295,6 @@ footer {
   }
 
   p {
-    margin: .5rem;
     max-width: 80%;
   }
 
@@ -415,4 +413,10 @@ Make padding symmetrical (this selector is used in the default styles to apply p
   background-position: left 1rem center;
   background-repeat: no-repeat;
   padding-left: 100px;
+}
+
+/* Full-width tables */
+.td-content > table {
+  width: 100%;
+  display: table;
 }


### PR DESCRIPTION
This is a (at least partial) fix for https://github.com/matrix-org/matrix-doc/issues/2983:

> Block widths are all over the place. Text blocks have one standard width, code blocks are wider, tables are sometimes wider, sometimes narrower than text, and so on. See section 12.11.1.6 for an example, where the two parameter tables (EncryptedFile and JWK) have different widths even though they are adjacent to each other. This sticks out like a sore thumb when scrolling through the document.

It's intentional that text blocks are narrower, so as to have a more comfortable line length for readability. On the other hand tables often want as much width as they can get, and I agree it's not a good look when different tables get different widths. So I'm giving all tables 100% in this PR.

I've also adjusted padding for rendered HTTP APIs, so they should align better with the text in which they're embedded.

I'm not a designer, and there's probably room for improvement on top of this PR, but to me it does make the widths look more consistent.
