### PR TITLE
Override issue templates from org

### DIFF
--- a/.github/ISSUE_TEMPLATE/clarification.md
+++ b/.github/ISSUE_TEMPLATE/clarification.md
@@ -1,0 +1,13 @@
+---
+name: Clarity problem
+about: Report an area of the spec that is unclear.
+title: ''
+labels: 'clarification'
+assignees: ''
+
+---
+
+**Link to problem area**:
+
+**Issue**
+What is wrong? How can we improve?

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+ - name: Matrix Spec Discussion
+   url: "https://matrix.to/#/#matrix-spec:matrix.org"
+   about: Questions about the spec and proposal process can be asked here.
+ - name: Matrix Security Policy
+   url: https://www.matrix.org/security-disclosure-policy/
+   about: Learn more about our security disclosure policy.

--- a/.github/ISSUE_TEMPLATE/cosmetic-bug.md
+++ b/.github/ISSUE_TEMPLATE/cosmetic-bug.md
@@ -1,0 +1,13 @@
+---
+name: Cosmetic issue
+about: Report an issue with how the spec looks.
+title: ''
+labels: 'aesthetic'
+assignees: ''
+
+---
+
+**Link to problem area**:
+
+**Issue**
+What is wrong? What can we do to improve?

--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -1,0 +1,12 @@
+---
+name: Feature request
+about: Suggest a future MSC idea.
+title: ''
+labels: 'improvement'
+assignees: ''
+
+---
+
+**Suggestion**
+What would you like to see in Matrix? If your idea is vaguely complete enough, we
+recommend submitting [an MSC](https://matrix.org/docs/spec/proposals) instead.

--- a/.github/ISSUE_TEMPLATE/idea.md
+++ b/.github/ISSUE_TEMPLATE/idea.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: Spec idea
 about: Suggest a future MSC idea.
 title: ''
 labels: 'improvement'

--- a/.github/ISSUE_TEMPLATE/spec-bug.md
+++ b/.github/ISSUE_TEMPLATE/spec-bug.md
@@ -1,0 +1,16 @@
+---
+name: Documentation error
+about: Report an issue with the spec itself (incorrect text).
+title: ''
+labels: 'spec-bug'
+assignees: ''
+
+---
+
+**Link to problem area**:
+
+**Issue**
+What is wrong?
+
+**Expected behaviour**
+How can the issue be fixed? Links to implementations/documents which prove the spec is wrong are appreciated.


### PR DESCRIPTION
We don't need OS information for a bug report here.

Demo for as long as I don't poke the repo: https://github.com/turt2live/test/issues/new/choose