### PR TITLE
Don't generate matrix assets on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,6 @@ checkexamples: &checkexamples
     source /env/bin/activate
     scripts/check-event-schema-examples.py
 
-genmatrixassets: &genmatrixassets
-  name: Generate/Verify matrix.org assets
-  command: |
-    source /env/bin/activate
-    ./scripts/generate-matrix-org-assets
-
 validateapi: &validateapi
   name: Validate OpenAPI specifications
   command: |
@@ -69,7 +63,6 @@ jobs:
     steps:
       - checkout
       - run: *checkexamples
-      - run: *genmatrixassets # We don't actually use the assets, but we do want to make sure they build
   build-docs:
     docker:
       - image: uhoreg/matrix-doc-build

--- a/scripts/generate-matrix-org-assets
+++ b/scripts/generate-matrix-org-assets
@@ -8,11 +8,8 @@ cd `dirname $0`/..
 
 mkdir -p assets
 
-if [ "$CIRCLECI" != "true" ]
-then
-    # generate specification/proposals.rst
-    ./scripts/proposals.py
-fi
+# generate specification/proposals.rst
+./scripts/proposals.py
 
 # generate the spec docs
 ./scripts/gendoc.py -d assets/spec


### PR DESCRIPTION
We already do this in the buildkite pipeline, so doing so in CircleCI is just duplicate work:

https://github.com/matrix-org/matrix-doc/blob/7c7bc677fb485d3df0e2dcb52554eb1bf2bd7f28/.buildkite/pipeline.yaml#L4-L6

I also removed the CircleCI-specific condition in generate-matrix-org-assets, which is no longer necessary if CircleCI isn't running that script.

Split out from https://github.com/matrix-org/matrix-doc/pull/3017.