### PR TITLE
Update prod build's baseURL to /unstable

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -28,7 +28,7 @@ steps:
       # Pull current proposal information
       - npm run get-proposals
       # Build the spec, will build to './spec'
-      - hugo -d "spec"
+      - hugo --baseURL "/unstable" -d "spec"
       # Compress the result and make it available as an artifact
       - tar -czf spec.tar.gz spec
     artifact_paths:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -28,6 +28,7 @@ steps:
       # Pull current proposal information
       - npm run get-proposals
       # Build the spec, will build to './spec'
+      # Set the baseURL as we're deploying to https://spec.matrix.org/unstable
       - hugo --baseURL "/unstable" -d "spec"
       # Compress the result and make it available as an artifact
       - tar -czf spec.tar.gz spec


### PR DESCRIPTION
Since we're deploying to https://spec.matrix.org/unstable now. This only updates the `baseURL` for our buildkite build. The default is still `/` when doing a local build.