### PR TITLE
Fix absolute path links when spec is hosted under a different path other than /

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,10 @@
 baseURL = "/"
 title = "Matrix Specification"
 
+# Prepends absolute URLs with the baseURL. Useful when hosting on non-root
+# paths, such as /unstable.
+canonifyURLs = true
+
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.


### PR DESCRIPTION
This fixes absolute path links when we're hosting the site under a different path other than / (for example, https://spec.matrix.org/unstable).

Links in markdown to say, `/proposals` would go to https://spec.matrix.org/proposals instead of https://spec.matrix.org/unstable/proposals.

Setting `canonifyURLs` to `true` fixes that by prepending the site's baseurl to absolute links.

Documentation: https://gohugo.io/content-management/urls/#canonicalization