### PR TITLE
MSC3074: Proposal for URIs conforming to RFC 3986 syntax.

### DIFF
--- a/proposals/3074-RFC-3986-URIs.md
+++ b/proposals/3074-RFC-3986-URIs.md
@@ -1,0 +1,39 @@
+# MSC 3074: Change Matrix URIs to conform to standard RFC 3986 syntax
+
+I propose changing Matrix URLs to conform to standard URI syntax described in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3).
+
+## The Problem
+
+Currently, Matrix URI syntax places resource information before the authority (host), in violation of the syntax described by [RFC 3986 Section 3: Syntax](https://tools.ietf.org/html/rfc3986#section-3). Because of this, URI parsing modules for all major languages do not work for Matrix URIs. For example, parsing the host using nodejs `require('url').parse('matrix://r/roomAlias:matrix.org')` does not work.
+
+## The Solution
+
+Change the Matrix URI syntax to conform to [RFC 3986 Syntax](https://tools.ietf.org/html/rfc3986#section-3):
+
+RFC 3986 URI Syntax:
+
+`scheme:[//authority]path[?query][#fragment]` where `authority = [userinfo@]host[:port]`
+
+Example of Matrix URIs using RFC 3986 Syntax:
+
+User URLs: `@user:matrix.org` -> `user@matrix.org`  
+Room Alias URLs: `#roomAlias:matrix.org` -> `matrix.org/rooms/roomAlias`  
+Room ID URLs: `!roomId:matrix.org` -> `matrix.org/rooms?id=roomId`  
+Event URLs: `$eventId:matrix.org` -> `matrix.org/events/eventId`  
+Group URLs: `+groupId:matrix.org` -> `matrix.org/groups/groupId`  
+
+## Benefits
+
+- **Improved library support**: All major languages have URI parsers that conform to RFC 3986, so using standard URI syntax alleviates the need for custom Matrix URI parsing code. For example, parsing the host would no longer require code customized for Matrix URIs.
+- **Improved interoperability**: Developers and applications expect URIs to conform to the standard syntax. For example, many applications display only the host of a URL in certain contexts, which would work out-of-the-box for URIs conforming to the standard.
+- **Builds on Internet standards**: The RFC 3986 syntax is widely deployed, followed by HTTP, Git, XMPP, etc. As Matrix seeks to be an Internet standard, it should follow other Internet standards where possible.
+
+## Common Objections
+
+1. *Matrix URIs do conform to standard syntax, because everything after the scheme can be treated as a path.*
+   
+	 This is not correct. Matrix URIs include authority (host) information, which should come after the scheme in the standard. Currently, Matrix URIs put authority information after resource information.
+
+2. *This would be a big change, as Matrix URIs are widespread in Matrix code.*
+   
+	 Yes, but the sooner this is done the less work it will be. All change in federated standards takes a lot of time and work. I don't think changes should be evaluated solely on this criteria.


### PR DESCRIPTION
# MSC 3074: Change Matrix URIs to conform to standard RFC 3986 syntax

I propose changing Matrix URLs to conform to standard URI syntax described in [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3).

## The Problem

Currently, Matrix URI syntax places resource information before the authority (host), in violation of the syntax described by [RFC 3986 Section 3: Syntax](https://tools.ietf.org/html/rfc3986#section-3). Because of this, URI parsing modules for all major languages do not work for Matrix URIs. For example, parsing the host using nodejs `require('url').parse('matrix://r/roomAlias:matrix.org')` does not work.

## The Solution

Change the Matrix URI syntax to conform to [RFC 3986 Syntax](https://tools.ietf.org/html/rfc3986#section-3):

RFC 3986 URI Syntax:

`scheme:[//authority]path[?query][#fragment]` where `authority = [userinfo@]host[:port]`

Example of Matrix URIs using RFC 3986 Syntax:

User URLs: `@user:matrix.org` -> `user@matrix.org`  
Room Alias URLs: `#roomAlias:matrix.org` -> `matrix.org/rooms/roomAlias`  
Room ID URLs: `!roomId:matrix.org` -> `matrix.org/rooms?id=roomId`  
Event URLs: `$eventId:matrix.org` -> `matrix.org/events/eventId`  
Group URLs: `+groupId:matrix.org` -> `matrix.org/groups/groupId`  

## Benefits

- **Improved library support**: All major languages have URI parsers that conform to RFC 3986, so using standard URI syntax alleviates the need for custom Matrix URI parsing code. For example, parsing the host would no longer require code customized for Matrix URIs.
- **Improved interoperability**: Developers and applications expect URIs to conform to the standard syntax. For example, many applications display only the host of a URL in certain contexts, which would work out-of-the-box for URIs conforming to the standard.
- **Builds on Internet standards**: The RFC 3986 syntax is widely deployed, followed by HTTP, Git, XMPP, etc. As Matrix seeks to be an Internet standard, it should follow other Internet standards where possible.

## Common Objections

1. *Matrix URIs do conform to standard syntax, because there is no authority.*
   
	  Matrix URIs include authority (host) information for users and room aliases, which should come after the scheme in the standard. Currently, Matrix URIs put authority information after resource information.

2. *This would be a big change, as Matrix URIs are widespread in Matrix code.*
   
	 Yes, but the sooner this is done the less work it will be. All change in federated standards takes a lot of time and work. I don't think changes should be evaluated solely on this criteria.

## Related MSCs

#2312 should be considered alongside this proposal