### PR TITLE
Use the same domain for room ID and avatar URL.

### DIFF
--- a/changelogs/client_server/newsfragments/3116.clarification
+++ b/changelogs/client_server/newsfragments/3116.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/changelogs/server_server/newsfragments/3116.clarification
+++ b/changelogs/server_server/newsfragments/3116.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/definitions/public_rooms_response.yaml
+++ b/data/api/client-server/definitions/public_rooms_response.yaml
@@ -90,7 +90,7 @@ example: {
   "chunk": [
     {
       "aliases": ["#murrays:cheese.bar"],
-      "avatar_url": "mxc://bleeker.street/CHEDDARandBRIE",
+      "avatar_url": "mxc://bleecker.street/CHEDDARandBRIE",
       "guest_can_join": false,
       "name": "CHEESE",
       "num_joined_members": 37,

--- a/data/api/server-server/public_rooms.yaml
+++ b/data/api/server-server/public_rooms.yaml
@@ -215,7 +215,7 @@ paths:
               "chunk": [
                 {
                   "aliases": ["#murrays:cheese.bar"],
-                  "avatar_url": "mxc://bleeker.street/CHEDDARandBRIE",
+                  "avatar_url": "mxc://bleecker.street/CHEDDARandBRIE",
                   "guest_can_join": false,
                   "name": "CHEESE",
                   "num_joined_members": 37,

--- a/proposals/2403-knock.md
+++ b/proposals/2403-knock.md
@@ -199,7 +199,7 @@ contain this information:
   "aliases": [
     "#murrays:cheese.bar"
   ],
-  "avatar_url": "mxc://bleeker.street/CHEDDARandBRIE",
+  "avatar_url": "mxc://bleecker.street/CHEDDARandBRIE",
   "guest_can_join": false,
   "name": "CHEESE",
   "num_joined_members": 37,


### PR DESCRIPTION
I noticed that same of the examples had an avatar URL pointing to `bleeker.street`, but an ID pointing to `bleecker.street`, seems these should be the same?