### PR TITLE
Fix user ID examples in direct_to_device schema

### DIFF
--- a/changelogs/server_server/newsfragments/3128.clarification
+++ b/changelogs/server_server/newsfragments/3128.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/server-server/definitions/event-schemas/m.direct_to_device.yaml
+++ b/data/api/server-server/definitions/event-schemas/m.direct_to_device.yaml
@@ -35,7 +35,7 @@ allOf:
           sender:
             type: string
             description: User ID of the sender.
-            example: "john@example.com"
+            example: "@john:example.com"
           type:
             type: string
             description: Event type for the message.
@@ -59,7 +59,7 @@ allOf:
                 title: Device Message Contents
                 properties: {}
             example: {
-              "alice@example.org": {
+              "@alice:example.org": {
                 "IWHQUZUIAH": {
                   "algorithm": "m.megolm.v1.aes-sha2",
                   "room_id": "!Cuyf34gef24t:localhost",


### PR DESCRIPTION
Just noticed this while copy/pasting examples as tests in Ruma.