### PR TITLE
MSC3173: Expose stripped state events to any potential joiner

### DIFF
--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -24,7 +24,9 @@ This will allow for improved future use cases, such as:
 
 * Improved user experience for more complicated access controls (e.g.
   [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083)).
-* More information available to platforms like matrix.to.
+* Showing a room preview on platforms when peeking fails (using for clients as
+  well as matrix.to).
+* Joining by alias (e.g. as in Element) could show a room preview.
 
 ## Background
 

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -80,7 +80,7 @@ include the following as stripped state events:
 * Canonical alias (`m.room.canonical_alias`)
 * Room avatar (`m.room.avatar`)
 * Room name (`m.room.name`)
-* Encrypted status (`m.room.encryption`)<sup id="a2">[3](#f2)</sup>
+* Encryption information (`m.room.encryption`)<sup id="a2">[3](#f2)</sup>
 
 This also implies that the above information is available to any potential joiner
 in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946).

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -1,15 +1,17 @@
 # MSC3173: Expose stripped state events to any potential joiner
 
-It is currently possible to inspect the state of rooms in some circumstances:
+The current design of Matrix somtimes allows for inspecting part of the room state
+without being joined to the room:
 
 * If the room has `history_visibility: world_readable`, then anyone can inspect
   it (by calling `/state` on it).
-* Rooms in the room directory expose some of their state publicly.
+* Rooms in the [room directory](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-publicrooms)
+  expose some of their state publicly.
 * [Invited users](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid)
-  (and [knocking users](https://github.com/matrix-org/matrix-doc/pull/2403))
-  receive stripped state events.
+  and [knocking users](https://github.com/matrix-org/matrix-doc/pull/2403)
+  receive stripped state events to display metadata to users.
 
-This MSC proposes exposing the stripped state events that are currently available
+This MSC proposes allowing the stripped state events that are currently available
 to invited and knocking users to any user who could potentially join a room. It
 also consolidates the recommendation on which states events are available to
 potential joiners.
@@ -62,10 +64,13 @@ recommends including the `m.room.create` event as one of the stripped state even
 
 ## Proposal
 
-Any user who is able to join a room can access the stripped state events of that room.
+Any user who is able to join a room shall be allowed to have access the stripped
+state events of that room. No changes are proposed to the mechanics of how the
+users may get those state events, e.g. the `invite_state` of an invite or the
+roomd irectory.
 
-Potential ways that a user might be able to join include, but are not limited to,
-the following mechanisms:
+Potential ways that a user might be able to join a room include, but are not
+limited to, the following mechanisms:
 
 * A room that has `join_rules` set to `public` or `knock`.
 * A room that the user is in possession of an invite to (regardless of the `join_rules`).
@@ -77,8 +82,10 @@ should consider this MSC, for example:
   proposes allowing users to join a room based on their membership in a space (as defined in
   [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772)).
 
-Additionally, it is recommended, but not required, that homeserver implementations
-include the following as stripped state events:
+It is also proposed to create a single definition for what stripped state events
+should be provided to be potential joiners. Thus, it is recommended (although not
+required<sup id="a0">[0](#f0)</sup>) that homeserver implementations include the
+following as stripped state events:
 
 * Create event (`m.room.create`)<sup id="a1">[1](#f1)</sup>
 * Join rules (`m.room.join_rules`)
@@ -87,11 +94,6 @@ include the following as stripped state events:
 * Room name (`m.room.name`)
 * Encryption information (`m.room.encryption`)<sup id="a2">[2](#f2)</sup>
 * Room topic (`m.room.topic`)<sup id="a3">[3](#f3)</sup>
-
-This also implies that the above information is available to any potential joiner
-in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946).
-E.g. rooms which could be joined due to [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083)
-can expose the information available in stripped state events.
 
 ## Potential issues
 
@@ -112,15 +114,34 @@ seem to be a major weakening of the security.
 
 ## Future extensions
 
+### Dedicated APIs
+
 Dedicated client-server and server-server APIs could be added to request the
 stripped state events, but that is considered out-of-scope for the current
 proposal.
+
+### Revisions to the room directory
+
+A future MSC could include additional information from the stripped state events
+in the [room directory](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-publicrooms).
+This seems to mostly be the encryption information, but there may also be other
+pieces of information to include.
+
+### Additional ways to join a room
+
+[MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083) leverages this to
+expose the information available in stripped state events via the spaces summary
+for potential joiners due to membership in a space.
 
 ## Unstable prefix
 
 N/A
 
 ## Footnotes
+
+<a id="f0"/>[0]: Privacy conscious deployments may wish to limit the metadata
+available to users who are not in a room as the trade-off against user experience.
+There seems to be no reason to not allow this. [↩](#a0)
 
 <a id="f1"/>[1]: As updated in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772). [↩](#a1)
 

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -1,4 +1,4 @@
-# MSCXXXX: Exposing stripped state events to any potential joiner
+# MSC3173: Expose stripped state events to any potential joiner
 
 It is currently possible to inspect the state of rooms in some circumstances:
 

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -151,5 +151,5 @@ from Synapse and generally seems useful for  a user to know before joining a roo
 
 <a id="f3"/>[3]: The room topic (`m.room.topic`) is included as part of the
 [room directory](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-publicrooms)
-response for public rooms. It is additional to be included as part of [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946)
+response for public rooms. It is also planned to be included as part of [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946)
 in the spaces summary response. [↩](#a3)

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -80,12 +80,13 @@ should consider this MSC, for example:
 Additionally, it is recommended, but not required, that homeserver implementations
 include the following as stripped state events:
 
-* Create event (`m.room.create`)<sup id="a1">[2](#f1)</sup>
+* Create event (`m.room.create`)<sup id="a1">[1](#f1)</sup>
 * Join rules (`m.room.join_rules`)
 * Canonical alias (`m.room.canonical_alias`)
 * Room avatar (`m.room.avatar`)
 * Room name (`m.room.name`)
-* Encryption information (`m.room.encryption`)<sup id="a2">[3](#f2)</sup>
+* Encryption information (`m.room.encryption`)<sup id="a2">[2](#f2)</sup>
+* Room topic (`m.room.topic`)<sup id="a3">[3](#f3)</sup>
 
 This also implies that the above information is available to any potential joiner
 in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946).
@@ -121,7 +122,13 @@ N/A
 
 ## Footnotes
 
-<a id="f1"/>[1]: As updated in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).[↩](#a1)
+<a id="f1"/>[1]: As updated in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772). [↩](#a1)
 
-<a id="f2"/>[2]: This is already sent from Synapse and generally seems useful for
-a user to know before joining a room.[↩](#a2)
+<a id="f2"/>[2]: The encryption information (`m.room.encryption`) is already sent
+from Synapse and generally seems useful for  a user to know before joining a room.
+[↩](#a2)
+
+<a id="f3"/>[3]: The room topic (`m.room.topic`) is included as part of the
+[room directory](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-publicrooms)
+response for public rooms. It is additional to be included as part of [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946)
+in the spaces summary response. [↩](#a3)

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -43,7 +43,7 @@ for knocking users:
 It is also provides an extended rationale of why this is useful:
 
 > These stripped state events contain information about the room, most notably the
-> room's name and avatar. A client will need this information to show a nice 
+> room's name and avatar. A client will need this information to show a nice
 > representation of pending knocked rooms. The recommended events to include are the
 > join rules, canonical alias, avatar, name and encryption state of the room, rather
 > than all room state. This behaviour matches the information sent to remote
@@ -52,9 +52,9 @@ It is also provides an extended rationale of why this is useful:
 [MSC1772: Spaces](https://github.com/matrix-org/matrix-doc/pull/1772) additionally
 recommends including the `m.room.create` event as one of the stripped state events:
 
-> Join rules, invites and 3PID invites work as for a normal room, with the exception 
+> Join rules, invites and 3PID invites work as for a normal room, with the exception
 > that `invite_state` sent along with invites should be amended to include the
-> `m.room.create` event, to allow clients to discern whether an invite is to a 
+> `m.room.create` event, to allow clients to discern whether an invite is to a
 > space-room or not.
 
 ## Proposal
@@ -67,7 +67,7 @@ the following mechanisms:
 * A room that has `join_rules` set to `public` or `knock`.<sup id="a1">[1](#f1)</sup>
 * A room that the user is in possession of an invite to (regardless of the `join_rules`).
 
-Future MSCs might include additional mechanism for a user to join a room and 
+Future MSCs might include additional mechanism for a user to join a room and
 should consider this MSC, for example:
 
 * [MSC3083: Restricting room membership based on space membership](https://github.com/matrix-org/matrix-doc/pull/3083) proposes allowing users to join a room based on their membership in a space (as defined in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772)).
@@ -82,8 +82,8 @@ include the following as stripped state events:
 * Room name (`m.room.name`)
 * Encrypted status (`m.room.encryption`)<sup id="a3">[3](#f3)</sup>
 
-This also implies that the above information is available to any potential joiner 
-in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946). 
+This also implies that the above information is available to any potential joiner
+in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946).
 I.e. rooms which could be joined due to [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083)
 can expose the information available in stripped state events.
 
@@ -106,20 +106,20 @@ calling server to properly filter this information.
 
 Consider that Alice and Bob share a server; Alice is a member of a space, but Bob
 is not. The remote server will not know whether the request is on behalf of Alice
-or Bob (and hence whether it should share details of private rooms within that 
+or Bob (and hence whether it should share details of private rooms within that
 space).
 
 Trust is placed in the calling server: if there are any users on the calling
 server in the correct space, that calling server has a right to know about the
-rooms in that space and should return the relevant summaries, along with enough 
+rooms in that space and should return the relevant summaries, along with enough
 information that the calling server can then do some filtering.
 
-(The alternative, where the calling server sends the requesting `user_id`, and 
+(The alternative, where the calling server sends the requesting `user_id`, and
 the target server does the filtering, is unattractive because it rules out a
 future world where the calling server can cache the result.)
 
-This does not decrease security since a server could lie and make a request on 
-behalf of a user in the proper space to see the given information. I.e. the 
+This does not decrease security since a server could lie and make a request on
+behalf of a user in the proper space to see the given information. I.e. the
 calling server must be trusted anyway.
 
 ## Future extensions

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -67,7 +67,7 @@ recommends including the `m.room.create` event as one of the stripped state even
 Any user who is able to join a room shall be allowed to have access the stripped
 state events of that room. No changes are proposed to the mechanics of how the
 users may get those state events, e.g. the `invite_state` of an invite or the
-roomd irectory.
+room directory.
 
 Potential ways that a user might be able to join a room include, but are not
 limited to, the following mechanisms:

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -84,7 +84,7 @@ include the following as stripped state events:
 
 This also implies that the above information is available to any potential joiner
 in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946).
-I.e. rooms which could be joined due to [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083)
+E.g. rooms which could be joined due to [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083)
 can expose the information available in stripped state events.
 
 ## Potential issues
@@ -98,29 +98,6 @@ a user is allowed to see stripped state events, as we do currently for invites a
 knocking.
 
 ## Security considerations
-
-The server-server API discussed in [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946)
-does not know the user who is requesting a summary of the space, but should divulge
-the above information if any member of a server could see it. It is up to the
-calling server to properly filter this information.
-
-Consider that Alice and Bob share a server; Alice is a member of a space, but Bob
-is not. The remote server will not know whether the request is on behalf of Alice
-or Bob (and hence whether it should share details of private rooms within that
-space).
-
-Trust is placed in the calling server: if there are any users on the calling
-server in the correct space, that calling server has a right to know about the
-rooms in that space and should return the relevant summaries, along with enough
-information that the calling server can then do some filtering.
-
-(The alternative, where the calling server sends the requesting `user_id`, and
-the target server does the filtering, is unattractive because it rules out a
-future world where the calling server can cache the result.)
-
-This does not decrease security since a server could lie and make a request on
-behalf of a user in the proper space to see the given information. I.e. the
-calling server must be trusted anyway.
 
 ## Future extensions
 

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -64,7 +64,7 @@ Any user who is able to join a room can access the stripped state events of that
 Potential ways that a user might be able to join include, but are not limited to,
 the following mechanisms:
 
-* A room that has `join_rules` set to `public` or `knock`.<sup id="a1">[1](#f1)</sup>
+* A room that has `join_rules` set to `public` or `knock`.
 * A room that the user is in possession of an invite to (regardless of the `join_rules`).
 
 Future MSCs might include additional mechanism for a user to join a room and
@@ -75,12 +75,12 @@ should consider this MSC, for example:
 Additionally, it is recommended, but not required, that homeserver implementations
 include the following as stripped state events:
 
-* Create event (`m.room.create`)<sup id="a2">[2](#f2)</sup>
+* Create event (`m.room.create`)<sup id="a1">[2](#f1)</sup>
 * Join rules (`m.room.join_rules`)
 * Canonical alias (`m.room.canonical_alias`)
 * Room avatar (`m.room.avatar`)
 * Room name (`m.room.name`)
-* Encrypted status (`m.room.encryption`)<sup id="a3">[3](#f3)</sup>
+* Encrypted status (`m.room.encryption`)<sup id="a2">[3](#f2)</sup>
 
 This also implies that the above information is available to any potential joiner
 in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946).
@@ -99,6 +99,11 @@ knocking.
 
 ## Security considerations
 
+This would allow for invisibly accessing the stripped state of a room with `knock`
+join rules. This is already trivially accessible by knocking on the room, but
+currently users in the room would know that the knock occurred. This does not
+seem to be a major weakening of the security.
+
 ## Future extensions
 
 Dedicated client-server and server-server APIs could be added to request the
@@ -111,10 +116,7 @@ N/A
 
 ## Footnotes
 
-<a id="f1"/>[1]: The rationale for including `knock` is that the user can
-trivially get this state already by knocking on the room.[↩](#a1)
+<a id="f1"/>[1]: As updated in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).[↩](#a1)
 
-<a id="f2"/>[2]: As updated in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).[↩](#a2)
-
-<a id="f3"/>[3]: This is already sent from Synapse and generally seems useful for
-a user to know before joining a room.[↩](#a3)
+<a id="f2"/>[2]: This is already sent from Synapse and generally seems useful for
+a user to know before joining a room.[↩](#a2)

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -6,46 +6,74 @@ It is currently possible to inspect the state of rooms in some circumstances:
 * Rooms in the room directory expose some of their state publicly.
 * [Invited users](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid) (and [knocking users](https://github.com/matrix-org/matrix-doc/pull/2403)) receive stripped state events.
 
-This MSC proposes exposing the stripped state events that are currently available to invited and knocking users to any user who could potentially join a room. It also consolidates the recommendation on which states events are available to potential joiners.
+This MSC proposes exposing the stripped state events that are currently available
+to invited and knocking users to any user who could potentially join a room. It
+also consolidates the recommendation on which states events are available to
+potential joiners.
 
 ## Background
 
-When creating an invite it is [currently recommended](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid) to include stripped state events which are useful for displaying the invite to a user:
+When creating an invite it is [currently recommended](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid)
+to include stripped state events which are useful for displaying the invite to a user:
 
-> An optional list of simplified events to help the receiver of the invite identify the room. The recommended events to include are the join rules, canonical alias, avatar, and name of the room.
+> An optional list of simplified events to help the receiver of the invite identify
+> the room. The recommended events to include are the join rules, canonical alias,
+> avatar, and name of the room.
 
-The invited user receives these [stripped state events](https://spec.matrix.org/unstable/client-server-api/#get_matrixclientr0sync) as part of the `/sync` response:
+The invited user receives these [stripped state events](https://spec.matrix.org/unstable/client-server-api/#get_matrixclientr0sync)
+as part of the `/sync` response:
 
-> The state of a room that the user has been invited to. These state events may only have the `sender`, `type`, `state_key` and `content` keys present. These events do not replace any state that the client already has for the room, for example if the client has archived the room.
+> The state of a room that the user has been invited to. These state events may
+> only have the `sender`, `type`, `state_key` and `content` keys present. These
+> events do not replace any state that the client already has for the room, for
+> example if the client has archived the room.
 
-These are sent as part of the [`unsigned` content of the `m.room.member` event](https://spec.matrix.org/unstable/client-server-api/#mroommember) containing the invite.
+These are sent as part of the [`unsigned` content of the `m.room.member` event](https://spec.matrix.org/unstable/client-server-api/#mroommember)
+containing the invite.
 
-[MSC2403: Add "knock" feature](https://github.com/matrix-org/matrix-doc/pull/2403) extends this concept to also include the stripped state events in the `/sync` response for knocking users:
+[MSC2403: Add "knock" feature](https://github.com/matrix-org/matrix-doc/pull/2403)
+extends this concept to also include the stripped state events in the `/sync` response
+for knocking users:
 
-> It is proposed to add a fourth possible key to rooms, called `knock`. Its value is a mapping from room ID to room information. The room information is a mapping from a key `knock_state` to another mapping with key events being a list of `StrippedStateEvent`.
+> It is proposed to add a fourth possible key to rooms, called `knock`. Its value
+> is a mapping from room ID to room information. The room information is a mapping
+> from a key `knock_state` to another mapping with key events being a list of
+> `StrippedStateEvent`.
 
 It is also provides an extended rationale of why this is useful:
 
-> These stripped state events contain information about the room, most notably the room's name and avatar. A client will need this information to show a nice representation of pending knocked rooms. The recommended events to include are the join rules, canonical alias, avatar, name and encryption state of the room, rather than all room state. This behaviour matches the information sent to remote homeservers when remote users are invited to a room.
+> These stripped state events contain information about the room, most notably the
+> room's name and avatar. A client will need this information to show a nice 
+> representation of pending knocked rooms. The recommended events to include are the
+> join rules, canonical alias, avatar, name and encryption state of the room, rather
+> than all room state. This behaviour matches the information sent to remote
+> homeservers when remote users are invited to a room.
 
-[MSC1772: Spaces](https://github.com/matrix-org/matrix-doc/pull/1772) additionally recommends including the `m.room.create` event as one of the stripped state events:
+[MSC1772: Spaces](https://github.com/matrix-org/matrix-doc/pull/1772) additionally
+recommends including the `m.room.create` event as one of the stripped state events:
 
-> Join rules, invites and 3PID invites work as for a normal room, with the exception that `invite_state` sent along with invites should be amended to include the `m.room.create` event, to allow clients to discern whether an invite is to a space-room or not.
+> Join rules, invites and 3PID invites work as for a normal room, with the exception 
+> that `invite_state` sent along with invites should be amended to include the
+> `m.room.create` event, to allow clients to discern whether an invite is to a 
+> space-room or not.
 
 ## Proposal
 
 Any user who is able to join a room can access the stripped state events of that room.
 
-Potential ways that a user might be able to join include, but are not limited to, the following mechanisms:
+Potential ways that a user might be able to join include, but are not limited to,
+the following mechanisms:
 
 * A room that has `join_rules` set to `public` or `knock`.<sup id="a1">[1](#f1)</sup>
 * A room that the user is in possession of an invite to (regardless of the `join_rules`).
 
-Future MSCs might include additional mechanism for a user to join a room and should consider this MSC, for example:
+Future MSCs might include additional mechanism for a user to join a room and 
+should consider this MSC, for example:
 
 * [MSC3083: Restricting room membership based on space membership](https://github.com/matrix-org/matrix-doc/pull/3083) proposes allowing users to join a room based on their membership in a space (as defined in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772)).
 
-Additionally, it is recommended, but not required, that homeserver implementations include the following as stripped state events:
+Additionally, it is recommended, but not required, that homeserver implementations
+include the following as stripped state events:
 
 * Create event (`m.room.create`)<sup id="a2">[2](#f2)</sup>
 * Join rules (`m.room.join_rules`)
@@ -54,7 +82,10 @@ Additionally, it is recommended, but not required, that homeserver implementatio
 * Room name (`m.room.name`)
 * Encrypted status (`m.room.encryption`)<sup id="a3">[3](#f3)</sup>
 
-This also implies that the above information is available to any potential joiner in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946). I.e. rooms which could be joined due to [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083) can expose the information available in stripped state events.
+This also implies that the above information is available to any potential joiner 
+in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946). 
+I.e. rooms which could be joined due to [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083)
+can expose the information available in stripped state events.
 
 ## Potential issues
 
@@ -62,23 +93,40 @@ This is a generalization of current behavior and shouldn't introduce any new iss
 
 ## Alternatives
 
-A different approach to this would be to separately specify each situation in which a user is allowed to see stripped state events, as we do currently for invites and knocking.
+A different approach to this would be to separately specify each situation in which
+a user is allowed to see stripped state events, as we do currently for invites and
+knocking.
 
 ## Security considerations
 
-The server-server API discussed in [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946) does not know the user who is requesting a summary of the space, but should divulge the above information if any member of a server could see it. It is up to the calling server to properly filter this information.
+The server-server API discussed in [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946)
+does not know the user who is requesting a summary of the space, but should divulge
+the above information if any member of a server could see it. It is up to the
+calling server to properly filter this information.
 
-Consider that Alice and Bob share a server; Alice is a member of a space, but Bob is not. The remote server will not know whether the request is on behalf of Alice or Bob (and hence whether it should share details of private rooms within that space).
+Consider that Alice and Bob share a server; Alice is a member of a space, but Bob
+is not. The remote server will not know whether the request is on behalf of Alice
+or Bob (and hence whether it should share details of private rooms within that 
+space).
 
-Trust is placed in the calling server: if there are any users on the calling server in the correct space, that calling server has a right to know about the rooms in that space and should return the relevant summaries, along with enough information that the calling server can then do some filtering.
+Trust is placed in the calling server: if there are any users on the calling
+server in the correct space, that calling server has a right to know about the
+rooms in that space and should return the relevant summaries, along with enough 
+information that the calling server can then do some filtering.
 
-(The alternative, where the calling server sends the requesting `user_id`, and the target server does the filtering, is unattractive because it rules out a future world where the calling server can cache the result.)
+(The alternative, where the calling server sends the requesting `user_id`, and 
+the target server does the filtering, is unattractive because it rules out a
+future world where the calling server can cache the result.)
 
-This does not decrease security since a server could lie and make a request on behalf of a user in the proper space to see the given information. I.e. the calling server must be trusted anyway.
+This does not decrease security since a server could lie and make a request on 
+behalf of a user in the proper space to see the given information. I.e. the 
+calling server must be trusted anyway.
 
 ## Future extensions
 
-Dedicated client-server and server-server APIs could be added to request the stripped state events, but that is considered out-of-scope for the current proposal.
+Dedicated client-server and server-server APIs could be added to request the
+stripped state events, but that is considered out-of-scope for the current
+proposal.
 
 ## Unstable prefix
 
@@ -86,8 +134,10 @@ N/A
 
 ## Footnotes
 
-<a id="f1"/>[1]: The rationale for including `knock` is that the user can trivially get this state already by knocking on the room.[↩](#a1)
+<a id="f1"/>[1]: The rationale for including `knock` is that the user can
+trivially get this state already by knocking on the room.[↩](#a1)
 
 <a id="f2"/>[2]: As updated in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).[↩](#a2)
 
-<a id="f3"/>[3]: This is already sent from Synapse and generally seems useful for a user to know before joining a room.[↩](#a3)
+<a id="f3"/>[3]: This is already sent from Synapse and generally seems useful for
+a user to know before joining a room.[↩](#a3)

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -2,9 +2,12 @@
 
 It is currently possible to inspect the state of rooms in some circumstances:
 
-* If the room has `history_visibility: world_readable`, then anyone can inspect it (by calling `/state` on it).
+* If the room has `history_visibility: world_readable`, then anyone can inspect
+  it (by calling `/state` on it).
 * Rooms in the room directory expose some of their state publicly.
-* [Invited users](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid) (and [knocking users](https://github.com/matrix-org/matrix-doc/pull/2403)) receive stripped state events.
+* [Invited users](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid)
+  (and [knocking users](https://github.com/matrix-org/matrix-doc/pull/2403))
+  receive stripped state events.
 
 This MSC proposes exposing the stripped state events that are currently available
 to invited and knocking users to any user who could potentially join a room. It
@@ -70,7 +73,9 @@ the following mechanisms:
 Future MSCs might include additional mechanism for a user to join a room and
 should consider this MSC, for example:
 
-* [MSC3083: Restricting room membership based on space membership](https://github.com/matrix-org/matrix-doc/pull/3083) proposes allowing users to join a room based on their membership in a space (as defined in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772)).
+* [MSC3083: Restricting room membership based on space membership](https://github.com/matrix-org/matrix-doc/pull/3083)
+  proposes allowing users to join a room based on their membership in a space (as defined in
+  [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772)).
 
 Additionally, it is recommended, but not required, that homeserver implementations
 include the following as stripped state events:

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -13,8 +13,8 @@ without being joined to the room:
 
 This MSC proposes allowing the stripped state events that are currently available
 to invited and knocking users to any user who could potentially join a room. It
-also consolidates the recommendation on which states events are available to
-potential joiners.
+also consolidates the recommendation on which events to include as stripped state
+for potential joiners.
 
 ## Background
 
@@ -64,10 +64,16 @@ recommends including the `m.room.create` event as one of the stripped state even
 
 ## Proposal
 
+This proposal includes two aspects which are dealt with separately:
+
+1. Generalizing when a user is allowed to view the stripped state of a room.
+2. A consistent recommendation for which events to include in the stripped state.
+
+### Accessing the stripped state of a room
+
 Any user who is able to join a room shall be allowed to have access the stripped
 state events of that room. No changes are proposed to the mechanics of how the
-users may get those state events, e.g. the `invite_state` of an invite or the
-room directory.
+users may get those state events.
 
 Potential ways that a user might be able to join a room include, but are not
 limited to, the following mechanisms:
@@ -81,6 +87,8 @@ should consider this MSC, for example:
 * [MSC3083: Restricting room membership based on space membership](https://github.com/matrix-org/matrix-doc/pull/3083)
   proposes allowing users to join a room based on their membership in a space (as defined in
   [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772)).
+
+### Events to include in the stripped state
 
 It is also proposed to create a single definition for what stripped state events
 should be provided to be potential joiners. Thus, it is recommended (although not

--- a/proposals/3173-expose-stripped-state-events.md
+++ b/proposals/3173-expose-stripped-state-events.md
@@ -169,10 +169,7 @@ for it.
 
 ## Unstable prefix
 
-| Stable Endpoint | Unstable Endpoint |
-|---|---|
-| `/_matrix/client/r0/rooms/{roomIdOrAlias}/stripped_state` | `/_matrix/client/unstable/org.matrix.msc3173/rooms/{roomIdOrAlias}/stripped_state` |
-| `/_matrix/federation/v1/stripped_state/{roomId}` | `/_matrix/federation/unstable/org.matrix.msc3173/stripped_state/{roomId}` |
+N/A
 
 ## Footnotes
 

--- a/proposals/xxxx-stripped-state-events.md
+++ b/proposals/xxxx-stripped-state-events.md
@@ -88,6 +88,6 @@ N/A
 
 <a id="f1"/>[1]: The rationale for including `knock` is that the user can trivially get this state already by knocking on the room.[↩](#a1)
 
-<a id="f2"/>[2]: As suggested in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).[↩](#a2)
+<a id="f2"/>[2]: As updated in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).[↩](#a2)
 
 <a id="f3"/>[3]: This is already sent from Synapse and generally seems useful for a user to know before joining a room.[↩](#a3)

--- a/proposals/xxxx-stripped-state-events.md
+++ b/proposals/xxxx-stripped-state-events.md
@@ -1,0 +1,93 @@
+# MSCXXXX: Exposing stripped state events to any potential joiner
+
+It is currently possible to inspect the state of rooms in some circumstances:
+
+* If the room has `history_visibility: world_readable`, then anyone can inspect it (by calling `/state` on it).
+* Rooms in the room directory expose some of their state publicly.
+* [Invited users](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid) (and [knocking users](https://github.com/matrix-org/matrix-doc/pull/2403)) receive stripped state events.
+
+This MSC proposes exposing the stripped state events that are currently available to invited and knocking users to any user who could potentially join a room. It also consolidates the recommendation on which states events are available to potential joiners.
+
+## Background
+
+When creating an invite it is [currently recommended](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v2-invite-roomid-eventid) to include stripped state events which are useful for displaying the invite to a user:
+
+> An optional list of simplified events to help the receiver of the invite identify the room. The recommended events to include are the join rules, canonical alias, avatar, and name of the room.
+
+The invited user receives these [stripped state events](https://spec.matrix.org/unstable/client-server-api/#get_matrixclientr0sync) as part of the `/sync` response:
+
+> The state of a room that the user has been invited to. These state events may only have the `sender`, `type`, `state_key` and `content` keys present. These events do not replace any state that the client already has for the room, for example if the client has archived the room.
+
+These are sent as part of the [`unsigned` content of the `m.room.member` event](https://spec.matrix.org/unstable/client-server-api/#mroommember) containing the invite.
+
+[MSC2403: Add "knock" feature](https://github.com/matrix-org/matrix-doc/pull/2403) extends this concept to also include the stripped state events in the `/sync` response for knocking users:
+
+> It is proposed to add a fourth possible key to rooms, called `knock`. Its value is a mapping from room ID to room information. The room information is a mapping from a key `knock_state` to another mapping with key events being a list of `StrippedStateEvent`.
+
+It is also provides an extended rationale of why this is useful:
+
+> These stripped state events contain information about the room, most notably the room's name and avatar. A client will need this information to show a nice representation of pending knocked rooms. The recommended events to include are the join rules, canonical alias, avatar, name and encryption state of the room, rather than all room state. This behaviour matches the information sent to remote homeservers when remote users are invited to a room.
+
+[MSC1772: Spaces](https://github.com/matrix-org/matrix-doc/pull/1772) additionally recommends including the `m.room.create` event as one of the stripped state events:
+
+> Join rules, invites and 3PID invites work as for a normal room, with the exception that `invite_state` sent along with invites should be amended to include the `m.room.create` event, to allow clients to discern whether an invite is to a space-room or not.
+
+## Proposal
+
+Any user who is able to join a room can access the stripped state events of that room.
+
+Potential ways that a user might be able to join include, but are not limited to, the following mechanisms:
+
+* A room that has `join_rules` set to `public` or `knock`.<sup id="a1">[1](#f1)</sup>
+* A room that the user is in possession of an invite to (regardless of the `join_rules`).
+
+Future MSCs might include additional mechanism for a user to join a room and should consider this MSC, for example:
+
+* [MSC3083: Restricting room membership based on space membership](https://github.com/matrix-org/matrix-doc/pull/3083) proposes allowing users to join a room based on their membership in a space (as defined in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772)).
+
+Additionally, it is recommended, but not required, that homeserver implementations include the following as stripped state events:
+
+* Create event (`m.room.create`)<sup id="a2">[2](#f2)</sup>
+* Join rules (`m.room.join_rules`)
+* Canonical alias (`m.room.canonical_alias`)
+* Room avatar (`m.room.avatar`)
+* Room name (`m.room.name`)
+* Encrypted status (`m.room.encryption`)<sup id="a3">[3](#f3)</sup>
+
+This also implies that the above information is available to any potential joiner in the API proposed in [MSC2946: Spaces summary](https://github.com/matrix-org/matrix-doc/pull/2946). I.e. rooms which could be joined due to [MSC3083](https://github.com/matrix-org/matrix-doc/pull/3083) can expose the information available in stripped state events.
+
+## Potential issues
+
+This is a generalization of current behavior and shouldn't introduce any new issues.
+
+## Alternatives
+
+A different approach to this would be to separately specify each situation in which a user is allowed to see stripped state events, as we do currently for invites and knocking.
+
+## Security considerations
+
+The server-server API discussed in [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946) does not know the user who is requesting a summary of the space, but should divulge the above information if any member of a server could see it. It is up to the calling server to properly filter this information.
+
+Consider that Alice and Bob share a server; Alice is a member of a space, but Bob is not. The remote server will not know whether the request is on behalf of Alice or Bob (and hence whether it should share details of private rooms within that space).
+
+Trust is placed in the calling server: if there are any users on the calling server in the correct space, that calling server has a right to know about the rooms in that space and should return the relevant summaries, along with enough information that the calling server can then do some filtering.
+
+(The alternative, where the calling server sends the requesting `user_id`, and the target server does the filtering, is unattractive because it rules out a future world where the calling server can cache the result.)
+
+This does not decrease security since a server could lie and make a request on behalf of a user in the proper space to see the given information. I.e. the calling server must be trusted anyway.
+
+## Future extensions
+
+Dedicated client-server and server-server APIs could be added to request the stripped state events, but that is considered out-of-scope for the current proposal.
+
+## Unstable prefix
+
+N/A
+
+## Footnotes
+
+<a id="f1"/>[1]: The rationale for including `knock` is that the user can trivially get this state already by knocking on the room.[↩](#a1)
+
+<a id="f2"/>[2]: As suggested in [MSC1772](https://github.com/matrix-org/matrix-doc/pull/1772).[↩](#a2)
+
+<a id="f3"/>[3]: This is already sent from Synapse and generally seems useful for a user to know before joining a room.[↩](#a3)


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-doc/blob/clokep/stripped-state/proposals/3173-expose-stripped-state-events.md)

[FCP vote](https://github.com/matrix-org/matrix-doc/pull/3173#issuecomment-853103499)