### PR TITLE
OpenAPI: fix tags of add3PID

### DIFF
--- a/data/api/client-server/administrative_contact.yaml
+++ b/data/api/client-server/administrative_contact.yaml
@@ -233,6 +233,8 @@ paths:
           description: This request was rate-limited.
           schema:
             "$ref": "definitions/errors/rate_limited.yaml"
+      tags:
+        - User data
   "/account/3pid/bind":
     post:
       summary: Binds a 3PID to the user's account through an Identity Service.


### PR DESCRIPTION
The tag needs to be set to include add3PID in scripts/swagger/api-docs.json.