### PR TITLE
Mention expected client behaviour of unknown types on MSC1772

### DIFF
--- a/proposals/1772-groups-as-rooms.md
+++ b/proposals/1772-groups-as-rooms.md
@@ -45,7 +45,11 @@ depending on the purpose of the room. Currently, no server-side behaviour is
 expected to depend on this property.  A `type` property on the `m.room.create`
 event is used to ensure that a room cannot change between being a space-room
 and a non-space room. For more information, see the "Rejected Alternatives"
-section below.
+section below. Additionally, no client behaviour is recommended for handling
+unknown room types given the potential for legacy data: clients are free to
+make their own decisions about hiding unknown room types from users, though
+should note that a future conversation-like type (for example) might be
+introduced and could be considered "unknown" by older versions of their client.
 
 As with regular rooms, public spaces are expected to have an alias, for example
 `#foo:matrix.org`, which can be used to refer to the space.


### PR DESCRIPTION
This was discussed in various places, but never quite made it to the MSC.

*Process note: there is no significant alteration to this MSC's functionality, so it doesn't need an MSC to edit the MSC. This is correcting a documentation error and only needs approving review from a spec core team member for validation of the process path.*