### PR TITLE
OpenAPI: displayname required in setDisplayName

### DIFF
--- a/data/api/client-server/profile.yaml
+++ b/data/api/client-server/profile.yaml
@@ -56,6 +56,8 @@ paths:
               displayname:
                 type: string
                 description: The new display name for this user.
+            required:
+              - displayname
       responses:
         200:
           description: The display name was set.


### PR DESCRIPTION
The displayname should be required in an operation called setDisplayName.