### PR TITLE
Deprecate verifications that don't begin with a request.

### DIFF
--- a/changelogs/client_server/newsfragments/3199.deprecaation
+++ b/changelogs/client_server/newsfragments/3199.deprecaation
@@ -1,0 +1,1 @@
+Deprecate starting verifications that don't start with `m.key.verification.request` as per [MSC3122](https://github.com/matrix-org/matrix-doc/pull/3122).

--- a/content/client-server-api/modules/end_to_end_encryption.md
+++ b/content/client-server-api/modules/end_to_end_encryption.md
@@ -528,7 +528,9 @@ method, then the verification should be cancelled with a `code` of
 `m.unexpected_message`.
 
 An `m.key.verification.start` message can also be sent independently of any
-request, specifying the verification method to use.
+request, specifying the verification method to use. This behaviour is
+deprecated, and new clients should not begin verifications in this way.
+However, clients should handle such verifications started by other clients.
 
 Individual verification methods may add additional steps, events, and
 properties to the verification messages. Event types for methods defined


### PR DESCRIPTION
spec PR for #3122 