### PR TITLE
Drop Origin & Accept from Access-Control-Allow-Headers value

### DIFF
--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -226,7 +226,7 @@ headers to be returned by servers on all requests are:
 
     Access-Control-Allow-Origin: *
     Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
-    Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization
+    Access-Control-Allow-Headers: X-Requested-With, Content-Type, Authorization
 
 ## Server Discovery
 


### PR DESCRIPTION
This change drops the `Origin` and `Accept` header names from the recommended value for the CORS `Access-Control-Allow-Headers` header. Per the CORS protocol, it’s not necessary or useful to include them.

Details:

Per-spec at https://fetch.spec.whatwg.org/#forbidden-header-name, `Origin` is a “forbidden header name” set by the browser and that frontend JavaScript code is never allowed to set.

So the value of `Access-Control-Allow-Headers` isn’t relevant to `Origin` or in general to other headers set by the browser itself — the browser never ever consults the `Access-Control-Allow-Headers` value to confirm that it’s OK for the request to include an `Origin` header.

And per-spec at https://fetch.spec.whatwg.org/#cors-safelisted-request-header, `Accept` is a “CORS-safelisted request-header”, which means that browsers allow requests to contain the `Accept` header regardless of whether the `Access-Control-Allow-Headers` value contains "Accept".＊

So it’s unnecessary for the `Access-Control-Allow-Headers` to explicitly include `Accept`. Browsers will not perform a CORS preflight for requests containing an `Accept` request header.

Related: https://github.com/matrix-org/synapse/pull/10114

Signed-off-by: Michael[tm] Smith `<mike@w3.org>`

---

＊ There is actually one edge case in which browsers won’t allow an `Accept` header in a request: If the value contains a “CORS-unsafe request-header byte” https://fetch.spec.whatwg.org/#cors-unsafe-request-header-byte. But in that case, the `Accept` header is anyway malformed and is therefore not going to have its intended effect. So that edge case doesn’t merit including `Accept` in the `Access-Control-Allow-Headers` value.