### PR TITLE
[WIP] MSC3234: Send currently open room in client to bots

### DIFF
--- a/proposals/0000-client-bot-current-active-room.md
+++ b/proposals/0000-client-bot-current-active-room.md
@@ -1,0 +1,27 @@
+**This is a first time informal draft, please edit and reformat freely**
+
+## Summary
+
+Whenever a client is actively checking a room, i.e. the client window is active and a room is being monitored, send an ephemiral event to compatible bots in the room so they are aware the user is still actively surveing the room. The client would periodically check if the user is still monitoring the room and if so send appropriate events to the bots.
+
+## Usecase
+
+Consider a bridge implementation that needs to actively check a browser for read-receipts. It would make sense to only do so for the rooms that are currently open and when the user is actually waiting to check for such receipts. Without it the bridge would need its own timer to check for the receipts, and could potentially mark incoming messages as read.
+
+## Potential implementation
+
+- A bot would check if the server has this functionality and send its desired configuration for this protocol to the currently active clients.
+- The server would redirect the request to any compatible clients as soon as available
+- The client would configure itself according to the request:
+  - **delay time**: A desired time to check and periodically send this event to the bots
+  - **bot pause**: If and how the bot can pause this check. E.g. only check if last message is not the user's
+- The client would then set its timer for sending these events while active in the given room. If the user is not active on the client ignore/pause the timers
+- Receiving bot would then proceed with their own logic utilizing  this event, e.g. checking for bridge read-receipts
+
+## Why make a specific MSC
+
+There are some MSCs that would relate to this implementation like MSC3006 and MSC2477. This could be a specific implementation of those, but still necessary to be standardized as there are no general systems to install logics to custom ephemiral events proposed in MSC2477.
+
+## Notes
+
+This is a first time making an MSC draft, and I'm not familiar with all the MSC relating to this issue, so please add them accordingly and instruct me on the process. Feel free to edit the fork directly.

--- a/proposals/3234-client-bot-current-active-room.md
+++ b/proposals/3234-client-bot-current-active-room.md
@@ -37,3 +37,7 @@ This could be a specific implementation of those, but still necessary to be stan
 there are no general systems to install logics to custom ephemiral events proposed in MSC2477.
 
 ## Security considerations
+
+This might be abused to monitor unwilling users, so there should be a stage requiring user
+verification at least during the bot's registration stage to the clients. For tranperancy sake
+the client could also display to which bot the events were sent and when, e.g. `poked bot_A at ...`

--- a/proposals/3234-client-bot-current-active-room.md
+++ b/proposals/3234-client-bot-current-active-room.md
@@ -1,14 +1,15 @@
+# MSC3234: Send currently active room event to bots
+
 **This is a first time informal draft, please edit and reformat freely**
 
-## Summary
 
 Whenever a client is actively checking a room, i.e. the client window is active and a room is being monitored, send an ephemiral event to compatible bots in the room so they are aware the user is still actively surveing the room. The client would periodically check if the user is still monitoring the room and if so send appropriate events to the bots.
 
-## Usecase
+## Proposal
 
 Consider a bridge implementation that needs to actively check a browser for read-receipts. It would make sense to only do so for the rooms that are currently open and when the user is actually waiting to check for such receipts. Without it the bridge would need its own timer to check for the receipts, and could potentially mark incoming messages as read.
 
-## Potential implementation
+### Potential implementation (Please replace with specifics)
 
 - A bot would check if the server has this functionality and send its desired configuration for this protocol to the currently active clients.
 - The server would redirect the request to any compatible clients as soon as available
@@ -18,10 +19,10 @@ Consider a bridge implementation that needs to actively check a browser for read
 - The client would then set its timer for sending these events while active in the given room. If the user is not active on the client ignore/pause the timers
 - Receiving bot would then proceed with their own logic utilizing  this event, e.g. checking for bridge read-receipts
 
-## Why make a specific MSC
+## Potential issues
+
+## Alternatives
 
 There are some MSCs that would relate to this implementation like MSC3006 and MSC2477. This could be a specific implementation of those, but still necessary to be standardized as there are no general systems to install logics to custom ephemiral events proposed in MSC2477.
 
-## Notes
-
-This is a first time making an MSC draft, and I'm not familiar with all the MSC relating to this issue, so please add them accordingly and instruct me on the process. Feel free to edit the fork directly.
+## Security considerations

--- a/proposals/3234-client-bot-current-active-room.md
+++ b/proposals/3234-client-bot-current-active-room.md
@@ -3,26 +3,37 @@
 **This is a first time informal draft, please edit and reformat freely**
 
 
-Whenever a client is actively checking a room, i.e. the client window is active and a room is being monitored, send an ephemiral event to compatible bots in the room so they are aware the user is still actively surveing the room. The client would periodically check if the user is still monitoring the room and if so send appropriate events to the bots.
+Whenever a client is actively checking a room, i.e. the client window is active and a room is
+being monitored, send an ephemeral event to compatible bots in the room so they are aware
+the user is still actively looking at the room. The client would periodically check if the user
+is still monitoring the room and if so, send appropriate events to the other clients.
 
 ## Proposal
 
-Consider a bridge implementation that needs to actively check a browser for read-receipts. It would make sense to only do so for the rooms that are currently open and when the user is actually waiting to check for such receipts. Without it the bridge would need its own timer to check for the receipts, and could potentially mark incoming messages as read.
+Consider a bridge implementation that needs to actively check a browser for read-receipts.
+It would make sense to only do so for the rooms that are currently open and when the user
+is actually waiting to check for such receipts. Without it the bridge would need its own timer
+to check for the receipts, and could potentially mark incoming messages as read.
 
 ### Potential implementation (Please replace with specifics)
 
-- A bot would check if the server has this functionality and send its desired configuration for this protocol to the currently active clients.
+- A user would check if the server has this functionality and send its desired configuration
+for this protocol to the currently active clients.
 - The server would redirect the request to any compatible clients as soon as available
 - The client would configure itself according to the request:
-  - **delay time**: A desired time to check and periodically send this event to the bots
-  - **bot pause**: If and how the bot can pause this check. E.g. only check if last message is not the user's
-- The client would then set its timer for sending these events while active in the given room. If the user is not active on the client ignore/pause the timers
-- Receiving bot would then proceed with their own logic utilizing  this event, e.g. checking for bridge read-receipts
+  - **delay time**: A desired time to check and periodically send this event to the listed users
+  - **timeout**: If and how the user can pause this check e.g. only check if last message is not the user's
+- The client would then set its timer for sending these events while active in the given room.
+If the user is not active on the client ignore/pause the timers
+- Receiving user would then proceed with their own logic utilizing this event, 
+e.g. checking for bridge read-receipts
 
 ## Potential issues
 
 ## Alternatives
 
-There are some MSCs that would relate to this implementation like MSC3006 and MSC2477. This could be a specific implementation of those, but still necessary to be standardized as there are no general systems to install logics to custom ephemiral events proposed in MSC2477.
+There are some MSCs that would relate to this implementation like MSC3006 and MSC2477.
+This could be a specific implementation of those, but still necessary to be standardized as
+there are no general systems to install logics to custom ephemiral events proposed in MSC2477.
 
 ## Security considerations


### PR DESCRIPTION
[Rendered](https://github.com/LecrisUT/matrix-doc/blob/client_bot-active-room/proposals/3234-client-bot-current-active-room.md)

This MSC is closed in light of two aspects:
- Main issue: The original application for bridges falls apart when there are clients/users who do not subscribe to such tracking. If there are other applications this could be resolved. The discussion is in @penn5's [review](https://github.com/matrix-org/matrix-doc/pull/3234#discussion_r650172647).
- Risk of abuse and tracking users via leaked metadata. The discussion is in @kevincox's [review](https://github.com/matrix-org/matrix-doc/pull/3234#discussion_r649537731).

Please continue discussion there and re-open if there is new developments.

Signed-off-by: Cristian Le git@lecris.me