### PR TITLE
Fix sidebar overlap for small width devices

### DIFF
--- a/assets-hugo/scss/custom.scss
+++ b/assets-hugo/scss/custom.scss
@@ -45,9 +45,6 @@ Custom SCSS for the Matrix spec
   scroll-behavior: smooth;
   overscroll-behavior: contain;
 
-  /* This overrides calc(100vh - 10rem);, which gives us a blank space at the bottom of the sidebar */
-  max-height: calc(100vh - 6rem);
-
   &>.td-sidebar-nav__section {
     margin-top: 1rem;
   }
@@ -88,6 +85,15 @@ Custom SCSS for the Matrix spec
     &.active, &active:hover {
       background-color: $secondary-background;
       font-weight: $font-weight-normal;
+    }
+  }
+}
+
+@media (min-width: 768px) {
+  @supports (position: sticky) {
+    .td-sidebar-nav {
+      /* This overrides calc(100vh - 10rem);, which gives us a blank space at the bottom of the sidebar */
+      max-height: calc(100vh - 6rem);
     }
   }
 }


### PR DESCRIPTION
This resolves a jarring text overlap issue with the sidebar by only adjusting the `max-height` at larger widths, which matches the original rule being overridden.

Before:

![Screen Shot 2021-06-17 at 00 24 52](https://user-images.githubusercontent.com/279572/122307578-839e3580-cf02-11eb-9657-7689b68517e3.png)

After:

![Screen Shot 2021-06-17 at 00 26 52](https://user-images.githubusercontent.com/279572/122307691-bfd19600-cf02-11eb-8c6b-286254c30d37.png)

Fixes https://github.com/matrix-org/matrix-doc/issues/3049