### PR TITLE
MSC3254: Add "knock" membership to /members filters

### DIFF
--- a/data/api/client-server/rooms.yaml
+++ b/data/api/client-server/rooms.yaml
@@ -206,6 +206,7 @@ paths:
           enum:
             - join
             - invite
+            - knock
             - leave
             - ban
           description: |-
@@ -220,6 +221,7 @@ paths:
           enum:
             - join
             - invite
+            - knock
             - leave
             - ban
           description: |-


### PR DESCRIPTION
I assume it's an oversight that the filters of [`GET /_matrix/client/r0/rooms/{roomId}/members`](https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-members) doesn't include `"knock"` as a possible membership state.

The response format lists knock as a possible value because it's referencing MemberEvent. 