### PR TITLE
Use `changelogs/release.yaml` for the version number source everywhere

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,7 +43,13 @@ privacy_policy = "https://matrix.org/legal/privacy-notice"
 # must be one of "unstable", "current", "historical"
 # this is used to decide whether to show a banner pointing to the current release
 status = "unstable"
+# A URL pointing to the latest, stable release of the spec. To be shown in the unstable version warning banner.
 current_version_url = "https://matrix.org/docs/spec/"
+# The following is used when status = "stable", and is displayed in various UI elements on a released version
+# of the spec. CI will set these values here automatically when a release git tag (i.e `v1.5`) is created.
+#major = "1"
+#minor = "0"
+#release_date = "April 01, 2021"
 
 # User interface configuration
 [params.ui]

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -46,10 +46,9 @@
 
     {{ if ne $status "unstable"}}
         {{ $path := path.Join "changelogs" }}
-        {{ $release_info := readFile (path.Join $path "release.yaml") | transform.Unmarshal }}
 
-        {{ $ret = $release_info.tag }}
-        {{ $ret = delimit (slice "version" $ret) " " }}
+		{{/* produces a string similar to "version v1.5" */}}
+		{{ $ret = delimit (slice "version" " v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
     {{ end }}
 
     {{ return $ret }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -47,8 +47,8 @@
     {{ if ne $status "unstable"}}
         {{ $path := path.Join "changelogs" }}
 
-		{{/* produces a string similar to "version v1.5" */}}
-		{{ $ret = delimit (slice "version v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
+        {{/* produces a string similar to "version v1.5" */}}
+        {{ $ret = delimit (slice "version v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
     {{ end }}
 
     {{ return $ret }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -48,7 +48,7 @@
         {{ $path := path.Join "changelogs" }}
 
 		{{/* produces a string similar to "version v1.5" */}}
-		{{ $ret = delimit (slice "version" " v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
+		{{ $ret = delimit (slice "version v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
     {{ end }}
 
     {{ return $ret }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -45,7 +45,10 @@
     {{ $status := .Site.Params.version.status }}
 
     {{ if ne $status "unstable"}}
-        {{ $ret = .Site.Params.version.number }}
+        {{ $path := path.Join "changelogs" }}
+        {{ $release_info := readFile (path.Join $path "release.yaml") | transform.Unmarshal }}
+
+        {{ $ret = $release_info.tag }}
         {{ $ret = delimit (slice "version" $ret) " " }}
     {{ end }}
 

--- a/layouts/shortcodes/changelog/changelog-changes.html
+++ b/layouts/shortcodes/changelog/changelog-changes.html
@@ -7,22 +7,26 @@
   it expects to find newsfragments describing changes to that API.
 
   If the `version.status` setting in config.toml is anything other than
-  "unstable", then it also expects to find a "release.yaml" file in /changelogs,
-  which contains:
-  - `tag`: Git tag for this release
-  - `date`: date of this release
-  It then renders this info a table, before the list of changes.
+  "unstable", then it also expects to find additional settings under
+  `version` in config.toml:
+  - `major`: the major version number of the release
+  - `minor`: the minor version number of the release
+  - `release_date`: the date of the release
+
+  The release tag is calculated as `v<major>.<minor>`; for example `v1.5`.
+
+  It then renders this into a table displayed before the list of changes.
 
 */}}
 
 {{ $path := path.Join "changelogs" }}
 {{ $status := .Site.Params.version.status }}
+{{ $release_tag := delimit (slice "v" .Site.Params.version.major "." .Site.Params.version.minor) "" }}
 
 {{ if ne $status "unstable" }}
-{{ $release_info := readFile (path.Join $path "release.yaml") | transform.Unmarshal }}
 <table class="release-info">
-<tr><th>Git commit</th><td><a href="https://github.com/matrix-org/matrix-doc/tree/{{ $release_info.tag }}">https://github.com/matrix-org/matrix-doc/tree/{{ $release_info.tag }}</a></td>
-<tr><th>Release date</th><td>{{ $release_info.date }}</td>
+<tr><th>Git commit</th><td><a href="https://github.com/matrix-org/matrix-doc/tree/{{ $release_tag }}">https://github.com/matrix-org/matrix-doc/tree/{{ $release_tag }}</a></td>
+<tr><th>Release date</th><td>{{ .Site.Params.version.release_date }}</td>
 </table>
 {{ end }}
 

--- a/layouts/shortcodes/changelog/changelog-description.html
+++ b/layouts/shortcodes/changelog/changelog-description.html
@@ -8,8 +8,14 @@
 {{ $status := .Site.Params.version.status }}
 
 {{ if eq $status "unstable"}}
+
 <p>This is the <strong>unstable</strong> version of the Matrix specification.</p>
 <p>This changelog lists changes made since the last release of the specification.</p>
+
 {{ else }}
-<p>This is version <strong>{{ .Site.Params.version.number }}</strong> of the Matrix specification.</p>
+
+{{ $path := path.Join "changelogs" }}
+{{ $release_info := readFile (path.Join $path "release.yaml") | transform.Unmarshal }}
+<p>This is version <strong>{{ $release_info.tag }}</strong> of the Matrix specification.</p>
+
 {{ end }}

--- a/layouts/shortcodes/changelog/changelog-description.html
+++ b/layouts/shortcodes/changelog/changelog-description.html
@@ -14,8 +14,6 @@
 
 {{ else }}
 
-{{ $path := path.Join "changelogs" }}
-{{ $release_info := readFile (path.Join $path "release.yaml") | transform.Unmarshal }}
-<p>This is version <strong>{{ $release_info.tag }}</strong> of the Matrix specification.</p>
+<p>This is version <strong>v{{ .Site.Params.version.major }}.{{ .Site.Params.version.minor }}</strong> of the Matrix specification.</p>
 
 {{ end }}


### PR DESCRIPTION
Currently both the top banner of the site and the top paragraph on the Changelogs page pull the current version number of the spec from `config.toml`, i.e:

https://github.com/matrix-org/matrix-doc/blob/6c6aa0b3d6eb6edc65c68ad78072a6733998969b/layouts/shortcodes/changelog/changelog-description.html#L8-L15

Note the `{{ .Site.Params.version.number }}` bit.

However, we already have a method of specifying the version number of a release build of the spec: `changelogs/release.yaml`:

https://github.com/matrix-org/matrix-doc/blob/6c6aa0b3d6eb6edc65c68ad78072a6733998969b/layouts/shortcodes/changelog/changelog-changes.html#L1-L16

This commit changes the site banner and Changelogs page to use `tag` in `changelogs/release.yaml` for the version number of the spec, instead of having two different ways to do things. Note that if we're building an unstable version of the spec, then `changelogs/release.yaml` is never read from.