### PR TITLE
`/_matrix/federation/v1/user/devices/{userId}`: Rename `self_signing_keys` to `self_signing_key`

### DIFF
--- a/changelogs/server_server/newsfragments/3312.clarification
+++ b/changelogs/server_server/newsfragments/3312.clarification
@@ -1,0 +1,1 @@
+Corrects the `/_matrix/federation/v1/user/devices/{userId}` response which actually returns `"self_signing_key"` instead of `"self_signing_keys"`.

--- a/changelogs/server_server/newsfragments/3312.clarification
+++ b/changelogs/server_server/newsfragments/3312.clarification
@@ -1,1 +1,1 @@
-Corrects the `/_matrix/federation/v1/user/devices/{userId}` response which actually returns `"self_signing_key"` instead of `"self_signing_keys"`.
+Correct the `/_matrix/federation/v1/user/devices/{userId}` response which actually returns `"self_signing_key"` instead of `"self_signing_keys"`.

--- a/data/api/server-server/user_devices.yaml
+++ b/data/api/server-server/user_devices.yaml
@@ -96,7 +96,7 @@ paths:
                         "ed25519:base64+master+public+key": "base64+master+public+key",
                       }
                     }
-              self_signing_keys:
+              self_signing_key:
                 type: object
                 description: |-
                   The user\'s self-signing key.


### PR DESCRIPTION
Apparently, in response to a `/_matrix/federation/v1/user/devices/{userId}` request, Synapse actually returns a key called `"self_signing_key"` instead of `"self_signing_keys"`.