### PR TITLE
dump-swagger.py: include untagged operations

### DIFF
--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -98,10 +98,9 @@ for filename in os.listdir(cs_api_dir):
             path = (basePath + path).replace('%CLIENT_MAJOR_VERSION%',
                                              major_version)
             for method, spec in methods.items():
-                if "tags" in spec.keys():
-                    if path not in output["paths"]:
-                        output["paths"][path] = {}
-                    output["paths"][path][method] = spec
+                if path not in output["paths"]:
+                    output["paths"][path] = {}
+                output["paths"][path][method] = spec
 
 print("Generating %s" % output_file)
 


### PR DESCRIPTION
These operations are untagged and therefore currently not included in scripts/swagger/api-docs.json:
- requestTokenTo3PIDEmail
- requestTokenTo3PIDMSISDN
- requestTokenToResetPasswordEmail
- requestTokenToResetPasswordMSISDN
- getRoomVisibilityOnDirectory
- setRoomVisibilityOnDirectory
- peekEvents
- uploadCrossSigningKeys
- uploadCrossSigningSignatures
- redirectToSSO
- redirectToIdP
- requestTokenToRegisterEmail
- requestTokenToRegisterMSISDN
- deleteRoomKeysKeyRoomId
- getRoomKeysKeyRoomId
- deleteRoomKeysKeyRoomId
- getRoomKeysKeyRoomId
- deleteRoomKeysKeyRoomIdSessionId
- getRoomKeysKeyRoomIdSessionId
- queryLocationByAlias
- queryLocationByProtocol
- getProtocolMetadata
- getProtocols
- queryUserByID
- queryUserByProtocol

Is this intentional? If not, please merge this PR.