### PR TITLE
OpenAPI: add auth property in uploadCrossSigningKeys

### DIFF
--- a/changelogs/client_server/newsfragments/3331.clarification
+++ b/changelogs/client_server/newsfragments/3331.clarification
@@ -1,0 +1,1 @@
+Add auth property to UIA endpoint uploadCrossSigningKeys.

--- a/data/api/client-server/cross_signing.yaml
+++ b/data/api/client-server/cross_signing.yaml
@@ -66,6 +66,12 @@ paths:
                   request.
                 allOf:
                   - $ref: definitions/cross_signing_key.yaml
+              auth:
+                description: |-
+                  Additional authentication information for the
+                  user-interactive authentication API.
+                allOf:
+                - $ref: "definitions/auth_data.yaml"
             example: {
               "master_key": {
                 "user_id": "@alice:example.com",


### PR DESCRIPTION
The description mentions this API endpoint uses the [User-Interactive Authentication API](/client-server-api/#user-interactive-authentication-api) and this is used in practice, but the auth property is missing.