### PR TITLE
OpenAPI: require all bodies in cross_signing

### DIFF
--- a/changelogs/client_server/newsfragments/3332.clarification
+++ b/changelogs/client_server/newsfragments/3332.clarification
@@ -1,0 +1,1 @@
+Clarify that all request bodies are required.

--- a/data/api/client-server/cross_signing.yaml
+++ b/data/api/client-server/cross_signing.yaml
@@ -42,6 +42,7 @@ paths:
           name: keys
           description: |-
             The keys to be published.
+          required: true
           schema:
             type: object
             properties:
@@ -143,6 +144,7 @@ paths:
           name: signatures
           description: |-
             The signatures to be published.
+          required: true
           schema:
             type: object
             title: Signatures


### PR DESCRIPTION
Like #3238, but I haven't seen these bodies because they were hidden (#3329).