### PR TITLE
Tweak PDU diagram demonstrating `prev_events`.

### DIFF
--- a/changelogs/server_server/newsfragments/3340.clarification
+++ b/changelogs/server_server/newsfragments/3340.clarification
@@ -1,0 +1,1 @@
+Tweak the example PDU diagram to better demonstrate situations with multiple `prev_events`.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -333,15 +333,16 @@ after all other known events.
 
 For example, consider a room whose events form the DAG shown below. A
 server creating a new event in this room should populate the new event's
-`prev_events` field with `E4` and `E5`, since neither event yet has a
-child:
+`prev_events` field with both `E4` and `E6`, since neither event yet has
+a child:
 
     E1
     ^
     |
-    +-> E2 <-+
-    |        |
-    E3       E5
+    E2 <--- E5
+    ^       ^
+    |       |
+    E3      E6
     ^
     |
     E4


### PR DESCRIPTION
This tweaks the example DAG at https://spec.matrix.org/unstable/server-server-api/#pdus to be simpler, with two linear event chains E4 -> E3 -> E2 -> E1 and E6 -> E5 -> E2 -> E1. The extremities of the DAG are now the first and only point in the DAG where multiple event parents occur.

Since the point of the diagram is to demonstrate this very situation, it's better didactically if there is only one such situation in the diagram.

Prompted by [this discussion](https://matrix.to/#/!KzgjYxOASBbBMrtCXC:matrix.org/$kmjz3oscsg98-lM-FK4zKIP-1uksTIg0Y2JXmauDR_Q?via=matrix.org&via=vector.modular.im&via=half-shot.uk).