### PR TITLE
Add type null for nullable properties

### DIFF
--- a/data/api/client-server/content-repo.yaml
+++ b/data/api/client-server/content-repo.yaml
@@ -435,7 +435,7 @@ paths:
             type: object
             properties:
               m.upload.size:
-                type: integer
+                type: [integer, "null"]
                 format: int64
                 description: |-
                   The maximum size an upload can be in bytes.

--- a/data/api/client-server/pusher.yaml
+++ b/data/api/client-server/pusher.yaml
@@ -177,7 +177,7 @@ paths:
                   If the `kind` is `"email"`, this is the email address to
                   send notifications to.
               kind:
-                type: string
+                type: [string, "null"]
                 description: |-
                   The kind of pusher to configure. `"http"` makes a pusher that
                   sends HTTP pokes. `"email"` makes a pusher that emails the


### PR DESCRIPTION
Use a `type` array including `"null"` like in https://github.com/matrix-org/matrix-doc/blob/master/data/api/client-server/presence.yaml#L116.

There are required properties in postPusher which are unnecessary for deletion: app_display_name, device_display_name, lang, and data are required, but [ignored by synapse](https://github.com/matrix-org/synapse/blob/develop/synapse/rest/client/pusher.py#L66) for deletion. Maybe a better solution would be to use `oneOf` and define separate schemes for creation and deletion. `oneOf` is not allowed in OpenAPI 2, but `type` arrays aren't too. Or define a separate deletePusher operation with trailing space? Both alternative solutions have the advantage that creation and getPushers could `$ref` a unified pusher schema.