### PR TITLE
Port CI to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     name: "👷 Rebuild matrix.org"
     needs: build-openapi
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/head/main' }}
+    if: ${{ false && github.event_name == 'push' && github.ref == 'refs/head/main' }}
     steps:
       - name: "🪄 Triggering rebuild of matrix.org"
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,16 @@ jobs:
   build-spec:
     name: "📖 Build the spec"
     runs-on: ubuntu-latest
-    container:
-      image: "alpine"
-      options: --user root
     steps:
-      - name: "➕ Install missing packages"
-        run: apk add nodejs npm git hugo
+      - name: "➕ Setup Node"
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: "➕ Setup Hugo"
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.85.0'
+          extended: true
       - name: "📥 Source checkout"
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+name: "Spec"
+on: [push, pull_request]
+jobs:
+  build-openapi:
+    name: "🐍 Build OpenAPI definitions for matrix.org"
+    runs-on: ubuntu-latest
+    container: "python:3.9"
+    steps:
+      - name: "📥 Source checkout"
+        uses: actions/checkout@v2
+      - name: "📦 Asset creation"
+        run: |
+          python3 -m venv env && . env/bin/activate
+          pip install -r scripts/requirements.txt
+          scripts/generate-matrix-org-assets
+      - name: "📤 Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: openapi-artifact
+          path: assets.tar.gz
+  build-spec:
+    name: "📖 Build the spec"
+    runs-on: ubuntu-latest
+    container:
+      image: "alpine"
+      options: --user root
+    steps:
+      - name: "➕ Install missing packages"
+        run: apk add nodejs npm git hugo
+      - name: "📥 Source checkout"
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: "⚙️ npm"
+        run: |
+          npm i
+          npm run get-proposals
+      - name: "⚙️ hugo"
+        run: hugo --baseURL "/unstable" -d "spec"
+      - name: "📦 Tarball creation"
+        run: tar -czf spec.tar.gz spec
+      - name: "📤 Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: spec-artifact
+          path: spec.tar.gz
+  rebuild-matrixdotorg:
+    name: "👷 Rebuild matrix.org"
+    needs: build-openapi
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Triggering rebuild of matrix.org"
+        run: echo "TODO"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,5 +49,6 @@ jobs:
     needs: build-openapi
     runs-on: ubuntu-latest
     steps:
-      - name: "Triggering rebuild of matrix.org"
-        run: echo "TODO"
+      - name: "🪄 Triggering rebuild of matrix.org"
+        run: |
+          curl -XPOST -u "${{secrets.TRIGGER_MATRIXORG_REBUILD_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${{ github.repository_owner }}/matrix.org/actions/workflows/build-matrix.org.yml/dispatches --data '{"ref": "${{ github.ref }}" }'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build-openapi:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,8 @@
 name: "Spec"
 on:
   push:
-    branches: master
+    branches:
+      - main
   pull_request:
 jobs:
   build-openapi:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
     name: "👷 Rebuild matrix.org"
     needs: build-openapi
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/head/main' }}
     steps:
       - name: "🪄 Triggering rebuild of matrix.org"
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: "Spec"
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
 jobs:
   build-openapi:
     name: "🐍 Build OpenAPI definitions for matrix.org"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version: '14'
       - name: "➕ Setup Hugo"
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@c03b5dbed22245418539b65eb9a3b1d5fdd9a0a6
         with:
           hugo-version: '0.85.0'
           extended: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
   build-openapi:
     name: "🐍 Build OpenAPI definitions for matrix.org"
@@ -22,6 +23,7 @@ jobs:
         with:
           name: openapi-artifact
           path: assets.tar.gz
+
   build-spec:
     name: "📖 Build the spec"
     runs-on: ubuntu-latest
@@ -48,6 +50,7 @@ jobs:
         with:
           name: spec-artifact
           path: spec.tar.gz
+
   rebuild-matrixdotorg:
     name: "👷 Rebuild matrix.org"
     needs: build-openapi


### PR DESCRIPTION
This is intended to replace the existing Buildkite one, but the latter can be removed at a latter point when all the bits are in place. The workflow can be seen working for the gh-actions branch at [the Actions tab](https://github.com/matrix-org/matrix-doc/actions).