### PR TITLE
🐛 Fix OpenAPI definition generation

### DIFF
--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -71,7 +71,7 @@ output = {
     # The servers value will be picked up by RapiDoc to provide a way
     # to switch API servers. Useful when one wants to test compliance
     # of their server with the API.
-    "servers": {
+    "servers": [{
         "url": "https://{homeserver_address}/",
         "variables": {
             "homeserver_address": {
@@ -79,7 +79,7 @@ output = {
                 "description": "The base URL for your homeserver",
             }
         }
-    },
+    }],
     "schemes": ["https"],
     "info": {
         "title": "Matrix Client-Server API",


### PR DESCRIPTION
This is supposed to implement the same change as https://github.com/matrix-org/matrix.org/commit/d14b93a0bd80da4c112ba75c7bc1693aaec6fe61

Can I please have a sanity check?

Signed-off-by: Alexandre Franke <alexandre.franke@matrix.org>