### PR TITLE
Fix "invite_state" to "knock_state"

### DIFF
--- a/data/api/client-server/sync.yaml
+++ b/data/api/client-server/sync.yaml
@@ -461,7 +461,7 @@ paths:
                   },
                   "knock": {
                     "!223asd456:example.com": {
-                      "invite_state": {
+                      "knock_state": {
                         "events": [
                           {
                             "sender": "@alice:example.com",


### PR DESCRIPTION
This PR fixes the `invite_state` to `knock_state` to match the purpose according to the API spec found here: https://spec.matrix.org/unstable/client-server-api/#get_matrixclientr0sync

Signed-off-by: Andrew Fargo <drew.fargo@gmail.com>

Closes #3424 