### PR TITLE
Fix `dump-swagger.py` for PyYAML 6.0.

### DIFF
--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -93,7 +93,7 @@ output = {
 cs_api_dir = os.path.join(api_dir, 'client-server')
 with open(os.path.join(cs_api_dir, 'definitions',
                        'security.yaml')) as f:
-    output['securityDefinitions'] = yaml.load(f)
+    output['securityDefinitions'] = yaml.safe_load(f)
 
 for filename in os.listdir(cs_api_dir):
     if not filename.endswith(".yaml"):
@@ -102,7 +102,7 @@ for filename in os.listdir(cs_api_dir):
 
     print("Reading swagger API: %s" % filepath)
     with open(filepath, "r") as f:
-        api = yaml.load(f.read())
+        api = yaml.safe_load(f.read())
         api = units.resolve_references(filepath, api)
 
         basePath = api['basePath']


### PR DESCRIPTION
PyYAML 6.0 was released yesterday, and it finally drops support for `yaml.load` without a `loader` argument, which has been deprecated since 2017.

This [wiki page](
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) suggests several alternatives, including `safe_load` and `unsafe_load`. We don't use any fancy yaml objects, so `safe_load` should be fine for us.