### PR TITLE
Rename threepidCreds to threepid_creds and get rid of array

### DIFF
--- a/changelogs/client_server/newsfragments/3471.clarification
+++ b/changelogs/client_server/newsfragments/3471.clarification
@@ -1,1 +1,1 @@
-Make the auth stages for email and msisdn actually match the implementations.
+Fix documentation errors around `threepid_creds`.

--- a/changelogs/client_server/newsfragments/3471.clarification
+++ b/changelogs/client_server/newsfragments/3471.clarification
@@ -1,0 +1,1 @@
+Make the auth stages for email and msisdn actually match the implementations.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -719,14 +719,12 @@ follows:
 ```json
 {
   "type": "m.login.email.identity",
-  "threepidCreds": [
-    {
-      "sid": "<identity server session id>",
-      "client_secret": "<identity server client secret>",
-      "id_server": "<url of identity server authed with, e.g. 'matrix.org:8090'>",
-      "id_access_token": "<access token previously registered with the identity server>"
-    }
-  ],
+  "threepid_creds": {
+    "sid": "<identity server session id>",
+    "client_secret": "<identity server client secret>",
+    "id_server": "<url of identity server authed with, e.g. 'matrix.org:8090'>",
+    "id_access_token": "<access token previously registered with the identity server>"
+  },
   "session": "<session ID>"
 }
 ```
@@ -750,14 +748,12 @@ follows:
 ```json
 {
   "type": "m.login.msisdn",
-  "threepidCreds": [
-    {
-      "sid": "<identity server session id>",
-      "client_secret": "<identity server client secret>",
-      "id_server": "<url of identity server authed with, e.g. 'matrix.org:8090'>",
-      "id_access_token": "<access token previously registered with the identity server>"
-    }
-  ],
+  "threepid_creds": {
+    "sid": "<identity server session id>",
+    "client_secret": "<identity server client secret>",
+    "id_server": "<url of identity server authed with, e.g. 'matrix.org:8090'>",
+    "id_access_token": "<access token previously registered with the identity server>"
+  },
   "session": "<session ID>"
 }
 ```


### PR DESCRIPTION
This fixes the behaviour to match what synapse implements in practice.
If you use threepidCreds, you will just get an error about a missing
threepid_creds field. Synapse also treats this as an object. All clients
also seem to send threepid_creds, if they work on Synapse. Since
matrix.org requires an email currently for registration, most clients
that implement registration, will hit this issue.

https://github.com/matrix-org/synapse/blob/a0f48ee89d88fd7b6da8023dbba607a69073152e/synapse/handlers/ui_auth/checkers.py#L145

fixes #3156
fixes #2189

Signed-off-by: Nicolas Werner <nicolas.werner@hotmail.de>

Note that there is a lot of debate about this in the different issues. I really don't care about how this is resolved, but after 4 years, can please someone either fix this in synapse or matrix-doc? I just wasted half a day on this, the 3pid stuff in UIA is complicated enough. Alternatively I can add a note in the spec, that this is still up for debate and clients should send multiple versions of the auth dict, until one of them works or something, that at least suggests, that the spec does not match reality.

Current reality is that clients use an object called `threepid_creds`, Synapse uses it. It is probably easier to change the spec at this point. But I haven't checked what other servers do, I am still doing that.

| Implementation | threepid_creds object | threepidCreds object | threepidCreds array | threepid_creds array |
|----------------------|------------------------------|------------------------------|----------------------------|-----------------------------|
| Spec | ❌ | ❌ | ✅ | ❌ |
| Element/Web | ✅ | ✅ | ❌ | ❌ |
| Element/Android | ✅ | ❌ | ❌ | ❌ |
| Element/iOS | ✅ | ❌ | ❌ | ❌ |
| Synapse | ✅ | ❌ | ❌| ❌ |
| Conduit | ❌ | ❌ | ❌ | ❌ |
| Ruma | ❌ | ❌ | ✅ | ✅ |
| Dendrite | ❌ | ❌ | ❌ | ❌ |
| FluffyChat | ❌ | ❌ | ✅ | ✅ |
| Nheko | ✅ | ❌ | ❌ | ❌ |

(fluffy actually seems to send both spelling variations as an array... Ruma added that variant now...)
(Nheko doesn't care, I'll implement whatever we decide on, but I just fixed it to work on Synapse today.)
(Couldn't find anything in libQuotient)







<!-- Replace -->
Preview: https://pr3471--matrix-org-previews.netlify.app
<!-- Replace -->
