### PR TITLE
Hide room version fragments from table of contents

### DIFF
--- a/content/rooms/fragments/v1-auth-rules.md
+++ b/content/rooms/fragments/v1-auth-rules.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 The types of state events that affect authorization are:
 
 -   `m.room.create`

--- a/content/rooms/fragments/v1-canonical-json.md
+++ b/content/rooms/fragments/v1-canonical-json.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 Servers MUST NOT strictly enforce the JSON format specified in the
 [appendices](/appendices#canonical-json) for the reasons
 described there.

--- a/content/rooms/fragments/v1-redactions.md
+++ b/content/rooms/fragments/v1-redactions.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 Upon receipt of a redaction event, the server must strip off any keys
 not in the following list:
 

--- a/content/rooms/fragments/v2-state-res.md
+++ b/content/rooms/fragments/v2-state-res.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 The room state *S*′(*E*) after an event *E* is defined in terms of the
 room state *S*(*E*) before *E*, and depends on whether *E* is a state
 event or a message event:

--- a/content/rooms/fragments/v3-auth-rules.md
+++ b/content/rooms/fragments/v3-auth-rules.md
@@ -1,6 +1,5 @@
 ---
-# unused frontmatter - just fixing a hugo issue where it doesn't parse
-# shortcodes at the start of a file.
+toc_hide: true
 ---
 
 {{% added-in this=true %}} In room versions 1 and 2, events need a

--- a/content/rooms/fragments/v3-handling-redactions.md
+++ b/content/rooms/fragments/v3-handling-redactions.md
@@ -1,6 +1,5 @@
 ---
-# unused frontmatter - just fixing a hugo issue where it doesn't parse
-# shortcodes at the start of a file.
+toc_hide: true
 ---
 
 {{% added-in this=true %}} In room versions 1 and 2, redactions were

--- a/content/rooms/fragments/v4-event-explainer.md
+++ b/content/rooms/fragments/v4-event-explainer.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 The event ID is the [reference
 hash](/server-server-api#calculating-the-reference-hash-for-an-event) of
 the event encoded using a variation of [Unpadded

--- a/content/rooms/fragments/v5-signing-requirements.md
+++ b/content/rooms/fragments/v5-signing-requirements.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 When validating event signatures, servers MUST enforce the
 `valid_until_ts` property from a key request is at least as large as the
 `origin_server_ts` for the event being validated. Servers missing a copy

--- a/content/rooms/fragments/v6-canonical-json.md
+++ b/content/rooms/fragments/v6-canonical-json.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 Servers MUST strictly enforce the JSON format specified in the
 [appendices](/appendices#canonical-json). This translates to a
 400 `M_BAD_JSON` error on most endpoints, or discarding of events over

--- a/content/rooms/fragments/v6-redactions.md
+++ b/content/rooms/fragments/v6-redactions.md
@@ -1,3 +1,7 @@
+---
+toc_hide: true
+---
+
 Upon receipt of a redaction event, the server must strip off any keys
 not in the following list:
 


### PR DESCRIPTION
The entries were text-less and not really helping anyone. They are included as pages because we need them for templating, but we don't need people to be able to land on them directly.

Before:
![image](https://user-images.githubusercontent.com/1190097/140870664-ccf3c54f-5325-40d0-bc1d-94c413c9bfea.png)

After:
![image](https://user-images.githubusercontent.com/1190097/140870671-23411307-08e9-488d-8a9f-9c2cdffd2d2b.png)


<!-- Replace -->
Preview: https://pr3479--matrix-org-previews.netlify.app
<!-- Replace -->
