### PR TITLE
Key name is supposed to be optional, as per MSC2874

### DIFF
--- a/changelogs/client_server/newsfragments/3481.clarification
+++ b/changelogs/client_server/newsfragments/3481.clarification
@@ -1,0 +1,2 @@
+Make `AesHmacSha2KeyDescription` consistent with `KeyDescription` in marking
+`name` as optional.

--- a/changelogs/client_server/newsfragments/3481.clarification
+++ b/changelogs/client_server/newsfragments/3481.clarification
@@ -1,2 +1,1 @@
-Make `AesHmacSha2KeyDescription` consistent with `KeyDescription` in marking
-`name` as optional.
+Make `AesHmacSha2KeyDescription` consistent with `KeyDescription` in marking `name` as optional.

--- a/content/client-server-api/modules/secrets.md
+++ b/content/client-server-api/modules/secrets.md
@@ -184,7 +184,7 @@ correctly entered the key, clients should:
 
 | Parameter   | Type   | Description                                                                                                                       |
 |-------------|--------|-----------------------------------------------------------------------------------------------------------------------------------|
-| name        | string | **Required.** The name of the key.                                                                                                |
+| name        | string | Optional. The name of the key.                                                                                                    |
 | algorithm   | string | **Required.** The encryption algorithm to be used for this key. Currently, only `m.secret_storage.v1.aes-hmac-sha2` is supported. |
 | passphrase  | object | See [deriving keys from passphrases](#deriving-keys-from-passphrases) section for a description of this property.                 |
 | iv          | string | The 16-byte initialization vector, encoded as base64.                                                                             |


### PR DESCRIPTION
https://github.com/matrix-org/matrix-doc/pull/3151 changed the `name` to be optional in one spot, but missed another spot




<!-- Replace -->
Preview: https://pr3481--matrix-org-previews.netlify.app
<!-- Replace -->
