### PR TITLE
remove extra `type` property

### DIFF
--- a/changelogs/client_server/newsfragments/3482.clarification
+++ b/changelogs/client_server/newsfragments/3482.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/event-schemas/schema/m.key.verification.m.relates_to.yaml
+++ b/data/event-schemas/schema/m.key.verification.m.relates_to.yaml
@@ -16,6 +16,5 @@ properties:
     description: |-
       The event ID of the `m.key.verification.request` that this message is
       related to.
-    type: object
 type: object
 title: VerificationRelatesTo


### PR DESCRIPTION
`event_id` somehow ended up with two `type` properties, one saying `string` and one saying `object`




<!-- Replace -->
Preview: https://pr3482--matrix-org-previews.netlify.app
<!-- Replace -->
