### PR TITLE
Explicitly link to geo URI spec

### DIFF
--- a/changelogs/client_server/newsfragments/3492.clarification
+++ b/changelogs/client_server/newsfragments/3492.clarification
@@ -1,0 +1,1 @@
+Explicity mention RFC5870 in the definition of `m.location` events

--- a/data/event-schemas/schema/m.room.message$m.location.yaml
+++ b/data/event-schemas/schema/m.room.message$m.location.yaml
@@ -9,7 +9,7 @@ properties:
         description: "A description of the location e.g. 'Big Ben, London, UK', or some kind of content description for accessibility e.g. 'location attachment'."
         type: string
       geo_uri:
-        description: A geo URI representing this location.
+        description: A [geo URI](https://datatracker.ietf.org/doc/html/rfc5870) (RFC5870) representing this location.
         type: string
       msgtype:
         enum:

--- a/data/event-schemas/schema/m.room.message$m.location.yaml
+++ b/data/event-schemas/schema/m.room.message$m.location.yaml
@@ -9,7 +9,7 @@ properties:
         description: "A description of the location e.g. 'Big Ben, London, UK', or some kind of content description for accessibility e.g. 'location attachment'."
         type: string
       geo_uri:
-        description: A [geo URI](https://datatracker.ietf.org/doc/html/rfc5870) (RFC5870) representing this location.
+        description: A [geo URI (RFC5870)](https://datatracker.ietf.org/doc/html/rfc5870) representing this location.
         type: string
       msgtype:
         enum:


### PR DESCRIPTION
We mention geo uri in the spec, but unhelpfully do not link to any documentation on what those are. This PR explicitly names the RFC and links to it. I am unsure if this needs a MSC, since I believe it doesn't change the spec in a meaningful way and just clarifies which RFC we're talking about.

If this needs a proposal, happy to open one first.







<!-- Replace -->
Preview: https://pr3492--matrix-org-previews.netlify.app
<!-- Replace -->
