### PR TITLE
Fix example response in MSC2946.

### DIFF
--- a/proposals/2946-spaces-summary.md
+++ b/proposals/2946-spaces-summary.md
@@ -132,7 +132,6 @@ GET /_matrix/client/v1/rooms/%21ol19s%3Ableecker.street/hierarchy?
                         "via": ["example.com"],
                         "suggested": true
                     },
-                    "room_id": "!ol19s:bleecker.street",
                     "sender": "@alice:bleecker.street",
                     "origin_server_ts": 1432735824653
                 },


### PR DESCRIPTION
This was pointed out by @t3chguy, we updated [MSC2946](https://github.com/matrix-org/matrix-doc/pull/2946) (see [`482597e` (#2946)](https://github.com/matrix-org/matrix-doc/pull/2946/commits/482597e9b7a1cbd92d9c64955aadd6b2b1fe3db0) in particular) to remove the `room_id` field of `children_state` since it is duplicative with the containing `room` data.

This updates the example to match to limit confusion until this is in the spec.

<!-- Replace -->
Preview: https://pr3493--matrix-org-previews.netlify.app
<!-- Replace -->
