### PR TITLE
typos: Corrected typos in message_pagination.yaml

### DIFF
--- a/changelogs/client_server/newsfragments/3495.clarification
+++ b/changelogs/client_server/newsfragments/3495.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/message_pagination.yaml
+++ b/data/api/client-server/message_pagination.yaml
@@ -74,7 +74,7 @@ paths:
           description: |-
             The direction to return events from. If this is set to `f`, events
             will be returned in chronological order starting at `from`. If it
-            is set to `b`, events will be returned in *reverse* chronolgical
+            is set to `b`, events will be returned in *reverse* chronological
             order, again starting at `from`.
           required: true
           x-example: "b"


### PR DESCRIPTION
Corrected typos in `matrix-doc/data/api/client-server/message_pagination.yaml`.

Fixes: #3487 

<!-- Replace -->
Preview: https://pr3495--matrix-org-previews.netlify.app
<!-- Replace -->
