### PR TITLE
Open API: Changed `RoomKeys` to `RoomKey`

### DIFF
--- a/data/api/client-server/key_backup.yaml
+++ b/data/api/client-server/key_backup.yaml
@@ -377,7 +377,7 @@ paths:
       summary: Store a key in the backup.
       description: |-
         Store a key in the backup.
-      operationId: putRoomKeysBySessionId
+      operationId: putRoomKeyBySessionId
       security:
         - accessToken: []
       parameters:
@@ -449,7 +449,7 @@ paths:
       summary: Retrieve a key from the backup.
       description: |-
         Retrieve a key from the backup.
-      operationId: getRoomKeysBySessionId
+      operationId: getRoomKeyBySessionId
       security:
         - accessToken: []
       parameters:
@@ -496,7 +496,7 @@ paths:
       summary: Delete a key from the backup.
       description: |-
         Delete a key from the backup.
-      operationId: deleteRoomKeysBySessionId
+      operationId: deleteRoomKeyBySessionId
       security:
         - accessToken: []
       parameters:

--- a/data/api/client-server/message_pagination.yaml
+++ b/data/api/client-server/message_pagination.yaml
@@ -74,7 +74,7 @@ paths:
           description: |-
             The direction to return events from. If this is set to `f`, events
             will be returned in chronological order starting at `from`. If it
-            is set to `b`, events will be returned in *reverse* chronolgical
+            is set to `b`, events will be returned in *reverse* chronological
             order, again starting at `from`.
           required: true
           x-example: "b"


### PR DESCRIPTION
Changed:
- `putRoomKeysBySessionId` to `putRoomKeyBySessionId`
- `getRoomKeysBySessionId` to `getRoomKeyBySessionId`
- `deleteRoomKeysBySessionId` to `deleteRoomKeysBySessionId`

in `matrix-doc/data/api/client-server/key_backup.yaml`.

Fixes: #3486 

Signed-off-by: ankur12-1610 <anknerd.12@gmail.com>
