### PR TITLE
Open API: Change RoomKeys to RoomKey

### DIFF
--- a/data/api/client-server/key_backup.yaml
+++ b/data/api/client-server/key_backup.yaml
@@ -377,7 +377,7 @@ paths:
       summary: Store a key in the backup.
       description: |-
         Store a key in the backup.
-      operationId: putRoomKeysBySessionId
+      operationId: putRoomKeyBySessionId
       security:
         - accessToken: []
       parameters:
@@ -449,7 +449,7 @@ paths:
       summary: Retrieve a key from the backup.
       description: |-
         Retrieve a key from the backup.
-      operationId: getRoomKeysBySessionId
+      operationId: getRoomKeyBySessionId
       security:
         - accessToken: []
       parameters:
@@ -496,7 +496,7 @@ paths:
       summary: Delete a key from the backup.
       description: |-
         Delete a key from the backup.
-      operationId: deleteRoomKeysBySessionId
+      operationId: deleteRoomKeyBySessionId
       security:
         - accessToken: []
       parameters:


### PR DESCRIPTION
Changed:
- `putRoomKeysBySessionId` to `putRoomKeyBySessionId`
- `getRoomKeysBySessionId` to `getRoomKeyBySessionId`
- `deleteRoomKeysBySessionId` to `deleteRoomKeysBySessionId`

in `matrix-doc/data/api/client-server/key_backup.yaml`.

Fixes: #3486 

Signed-off-by: ankur12-1610 <anknerd.12@gmail.com>

<!-- Replace -->
Preview: https://pr3500--matrix-org-previews.netlify.app
<!-- Replace -->
