### PR TITLE
Remove gilesbot config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,0 @@
-[ tool.gilesbot ]
-
-  [ tool.gilesbot.circleci_artifacts.docs ]
-    url = "public/index.html"
-    message = "Click details to preview the HTML documentation."
-
-  [ tool.gilesbot.circleci_artifacts.swagger ]
-    url = "client-server/index.html"
-    message = "Click to preview the swagger build."


### PR DESCRIPTION
gilesbot is a tool written and run by @Cadair that would insert little "click here to preview the spec content" entries in the CI checks on a PR. Nowadays, however, we're started using Github Actions and netlify, with the netlify preview link being added to the PR description by a Github Action.

As such, gilesbot isn't necessary for our purposes anymore. But it was really useful while it lasted!

This PR removes the config for it, and as that was the only thing in `pyproject.toml`, the whole file as well.

<!-- Replace -->
Preview: https://pr3503--matrix-org-previews.netlify.app
<!-- Replace -->
