### PR TITLE
OpenAPI: Add missing `required` flag in `getRoomKeys`

### DIFF
--- a/changelogs/client_server/newsfragments/3509.clarification
+++ b/changelogs/client_server/newsfragments/3509.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/data/api/client-server/key_backup.yaml
+++ b/data/api/client-server/key_backup.yaml
@@ -878,6 +878,8 @@ paths:
                     }
                   }
                 }
+            required:
+              - rooms
         404:
           description: The backup was not found.
           examples:


### PR DESCRIPTION
Added missing required flag in `getRoomKeys` in `matrix-doc/data/api/client-server/key_backup.yaml`.

Fixes: #3485

Signed-off-by: ankur12-1610 <anknerd.12@gmail.com>







<!-- Replace -->
Preview: https://pr3509--matrix-org-previews.netlify.app
<!-- Replace -->
