### PR TITLE
Remove C-S `unsigned` data from PDU definitions

### DIFF
--- a/changelogs/room_versions/newsfragments/3522.clarification
+++ b/changelogs/room_versions/newsfragments/3522.clarification
@@ -1,0 +1,1 @@
+Remove a number of fields which were incorrectly shown to form part of the `unsigned` data of a Federation PDU.

--- a/data/api/server-server/definitions/unsigned_pdu_base.yaml
+++ b/data/api/server-server/definitions/unsigned_pdu_base.yaml
@@ -117,33 +117,13 @@ properties:
     type: object
     title: UnsignedData
     description: |-
-      Additional data added by the origin server but not covered by the `signatures`. More
-      keys than those defined here may be used.
+      Additional data added by the origin server but not covered by the `signatures`.
     example: {"key": "value"}
     properties:
       age:
         type: integer
         description: The number of milliseconds that have passed since this message was sent.
         example: 4612
-      replaces_state:
-        type: string
-        description: The event ID of the state event this event replaces.
-        example: "$state_event:example.org"
-      prev_sender:
-        type: string
-        description: The sender of the replaced state event.
-        example: "@someone:example.org"
-      prev_content:
-        type: object
-        description: The content of the replaced state event.
-        example: {
-          "membership": "join",
-          "displayname": "Bob"
-        }
-      redacted_because:
-        type: string
-        description: A reason for why the event was redacted.
-        example: "Inappropriate content"
 required:
   - event_id
   - room_id


### PR DESCRIPTION
Remove a bunch of fields from the `unsigned` property of PDUs. These things shouldn't be passed over the Federation API, and they *really* shouldn't be trusted if they are sent by another server. (See also https://github.com/matrix-org/synapse/issues/11080)

 * `replaces_state` *is* returned by Synapse, but probably shouldn't   be.
 * `redacted_because`, `prev_sender` and `prev_content` are not sent by Synapse.

<!-- Replace -->
Preview: https://pr3522--matrix-org-previews.netlify.app
<!-- Replace -->
