### PR TITLE
Separate PDU terms from their definitions

### DIFF
--- a/changelogs/server_server/newsfragments/3527.clarification
+++ b/changelogs/server_server/newsfragments/3527.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -375,19 +375,19 @@ them.
 
 #### Definitions
 
-Required Power Level
+**Required Power Level** \
 A given event type has an associated *required power level*. This is
 given by the current `m.room.power_levels` event. The event type is
 either listed explicitly in the `events` section or given by either
 `state_default` or `events_default` depending on if the event is a state
 event or not.
 
-Invite Level, Kick Level, Ban Level, Redact Level
+**Invite Level, Kick Level, Ban Level, Redact Level** \
 The levels given by the `invite`, `kick`, `ban`, and `redact` properties
 in the current `m.room.power_levels` state. Each defaults to 50 if
 unspecified.
 
-Target User
+**Target User** \
 For an `m.room.member` state event, the user given by the `state_key` of
 the event.
 


### PR DESCRIPTION
Signed-off-by: Devon Hudson <devonhudson@librem.one>

Currently on the new spec site the definitions section on S-S PDUs has no clear distinction between the terms and their definitions.
This PR adds a distinction between them.




<!-- Replace -->
Preview: https://pr3527--matrix-org-previews.netlify.app
<!-- Replace -->
