### PR TITLE
Fix broken link in server-server signing events section

### DIFF
--- a/changelogs/server_server/3528.clarification
+++ b/changelogs/server_server/3528.clarification
@@ -1,0 +1,1 @@
+Fix various typos throughout the specification.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -1069,8 +1069,8 @@ JSON](/appendices#signing-json), using the server's signing key
 
 The signature is then copied back to the original event object.
 
-See [Persistent Data Unit schema](#Persistent Data Unit schema) for an
-example of a signed event.
+For an example of a signed event, see the [room version
+specification](/rooms).
 
 ### Validating hashes and signatures on received events
 


### PR DESCRIPTION
Signed-off-by: Devon Hudson <devonhudson@librem.one>

The signing events section of the server-server-api has a reference that has since been moved.
This PR fixes the reference.




<!-- Replace -->
Preview: https://pr3528--matrix-org-previews.netlify.app
<!-- Replace -->
