### PR TITLE
MSC3550: Allow HTTP 403 as a response to profile lookups

### DIFF
--- a/proposals/3550-allow-403-response-profile-lookup.md
+++ b/proposals/3550-allow-403-response-profile-lookup.md
@@ -17,7 +17,8 @@ clients such as [vector-im/element-web#17269](https://github.com/vector-im/eleme
 # Proposal
 The proposal is to allow HTTP 403 as an option for responding to [GET /_matrix/client/v3/profile/{userId}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid)
 requests. Allowing HTTP 403 gives clients more specific information as to why a request has 
-failed, thus enabling more precise error handling.
+failed, thus enabling more precise error handling. For example, Synapse currently 
+returns the `M_FORBIDDEN` error code along with the HTTP 403 response.  
 
 # Potential Issues
 The change to the spec may conflict with other existing server implementations.

--- a/proposals/3550-allow-403-response-profile-lookup.md
+++ b/proposals/3550-allow-403-response-profile-lookup.md
@@ -1,7 +1,8 @@
-#MSC 3550: Add HTTP 403 to possible profile lookup responses
+#MSC3550: Add HTTP 403 to possible profile lookup responses
 
 #Background
-In the current spec, the only response codes listed for  GET /_matrix/client/v3/profile/{userId}
+In the current spec, the only response codes listed for  [GET /_matrix/client/v3/profile/{userId}]
+(https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid)
 are `200` and `404`. However, some servers may not allow profile lookup over federation, and thus
 respond to GET /_matrix/client/v3/profile/{userId} with an HTTP 403.
 

--- a/proposals/3550-allow-403-response-profile-lookup.md
+++ b/proposals/3550-allow-403-response-profile-lookup.md
@@ -1,15 +1,9 @@
 #MSC3550: Add HTTP 403 to possible profile lookup responses
 
-#Background
-In the current spec, the only response codes listed for  [GET /_matrix/client/v3/profile/{userId}]
-(https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid)
-
-# MSC 3550: Add HTTP 403 to possible profile lookup responses
-
 # Background
-In the current spec, the only response codes listed for  GET /_matrix/client/v3/profile/{userId}
+In the current spec, the only response codes listed for [GET /_matrix/client/v3/profile/{userId}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid)
 are `200` and `404`. However, some servers may not allow profile lookup over federation, and thus
-respond to GET /_matrix/client/v3/profile/{userId} with an HTTP 403.
+respond to [GET /_matrix/client/v3/profile/{userId}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid) with an HTTP 403.
 
 For example, Synapse can be configured to behave in this way by setting:
 
@@ -21,7 +15,7 @@ Thus, this behavior already exists in Synapse, and may cause issues for
 clients such as [vector-im/element-web#17269](https://github.com/vector-im/element-web/issues/17269).
 
 # Proposal
-The proposal is to allow HTTP 403 as an option for responding to  GET /_matrix/client/v3/profile/{userId}
+The proposal is to allow HTTP 403 as an option for responding to [GET /_matrix/client/v3/profile/{userId}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid)
 requests. Allowing HTTP 403 gives clients more specific information as to why a request has 
 failed, thus enabling more precise error handling.
 

--- a/proposals/3550-allow-403-response-profile-lookup.md
+++ b/proposals/3550-allow-403-response-profile-lookup.md
@@ -1,4 +1,4 @@
-#MSC3550: Add HTTP 403 to possible profile lookup responses
+# MSC3550: Add HTTP 403 to possible profile lookup responses
 
 # Background
 In the current spec, the only response codes listed for [GET /_matrix/client/v3/profile/{userId}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid)

--- a/proposals/3550-allow-403-response-profile-lookup.md
+++ b/proposals/3550-allow-403-response-profile-lookup.md
@@ -17,8 +17,8 @@ clients such as [vector-im/element-web#17269](https://github.com/vector-im/eleme
 # Proposal
 The proposal is to allow HTTP 403 as an option for responding to [GET /_matrix/client/v3/profile/{userId}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3profileuserid)
 requests. Allowing HTTP 403 gives clients more specific information as to why a request has 
-failed, thus enabling more precise error handling. For example, Synapse currently 
-returns the `M_FORBIDDEN` error code along with the HTTP 403 response.  
+failed, thus enabling more precise error handling. The 403 would be accompanied by an
+`M_FORBIDDEN` error code. 
 
 # Potential Issues
 The change to the spec may conflict with other existing server implementations.

--- a/proposals/3550-allow-403-response-profile-lookup.md
+++ b/proposals/3550-allow-403-response-profile-lookup.md
@@ -1,4 +1,4 @@
-#MSC: Add HTTP 403 to possible profile lookup responses
+#MSC 3550: Add HTTP 403 to possible profile lookup responses
 
 #Background
 In the current spec, the only response codes listed for  GET /_matrix/client/v3/profile/{userId}

--- a/proposals/add_403.md
+++ b/proposals/add_403.md
@@ -1,0 +1,30 @@
+#MSC: Add HTTP 403 to possible profile lookup responses
+
+#Background
+In the current spec, the only response codes listed for  GET /_matrix/client/v3/profile/{userId}
+are `200` and `404`. However, some servers may not allow profile lookup over federation, and thus
+respond to GET /_matrix/client/v3/profile/{userId} with an HTTP 403.
+
+For example, Synapse can be configured to behave in this way by setting:
+
+```
+allow_profile_lookup_over_federation=false
+```
+
+Thus, this behavior already exists in Synapse, and may cause issues for
+clients such as [vector-im/element-web#17269](https://github.com/vector-im/element-web/issues/17269).
+
+#Proposal
+The proposal is to allow HTTP 403 as an option for responding to  GET /_matrix/client/v3/profile/{userId}
+requests. Allowing HTTP 403 gives clients more specific information as to why a request has 
+failed, thus enabling more precise error handling.
+
+#Potential Issues
+The change to the spec may conflict with other existing server implementations.
+
+#Alternatives
+The spec could remain as-is and Synapse could alter its current behavior and return an HTTP 
+404 rather than 403 in this case. 
+
+#Security Considerations
+None at this time. 


### PR DESCRIPTION
This is a MSC proposal generated in response to the feedback on https://github.com/matrix-org/matrix-doc/pull/3530.

Essentially, servers (such as Synapse) may not allow profile lookup over federation. For example, Synapse will return an HTTP 403 in response to `GET /_matrix/client/v3/profile/{userId}` if `allow_profile_lookup_over_federation` is set to `False`. This behavior is not currently documented in the spec. This proposal aims to add HTTP 403 to the list of responses to `GET /_matrix/client/v3/profile/{userId}`. 

Signed off by: H.Shay hillerys@element.io

Rendered: https://github.com/matrix-org/matrix-doc/blob/msc_403/proposals/3550-allow-403-response-profile-lookup.md

PR where this behavior was implemented:  https://github.com/matrix-org/synapse/pull/9203













<!-- Replace -->
Preview: https://pr3550--matrix-org-previews.netlify.app
<!-- Replace -->
