### PR TITLE
Bump `validator` dependency to 13.7.0

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -268,9 +268,9 @@
       }
     },
     "validator": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "z-schema": {
       "version": "5.0.1",


### PR DESCRIPTION
`validator` 13.6 has a security advisory: https://github.com/advisories/GHSA-qgmg-gppg-76g5

I don't think it really affects us but it's making annoying noise in the repo.

<!-- Replace -->
Preview: https://pr3566--matrix-org-previews.netlify.app
<!-- Replace -->
