### PR TITLE
MSC3582: Remove m.room.message.feedback

### DIFF
--- a/proposals/3582-remove-room-feedback.md
+++ b/proposals/3582-remove-room-feedback.md
@@ -1,4 +1,4 @@
-# MSCxxxx: Remove m.room.message.feedback
+# MSC3582: Remove m.room.message.feedback
 
 The spec defines an
 [`m.room.message.feedback`](https://spec.matrix.org/unstable/client-server-api/#mroommessagefeedback)

--- a/proposals/xxxx-remove-room-feedback.md
+++ b/proposals/xxxx-remove-room-feedback.md
@@ -1,0 +1,15 @@
+# MSCxxxx: Remove m.room.message.feedback
+
+The spec defines an
+[`m.room.message.feedback`](https://spec.matrix.org/unstable/client-server-api/#mroommessagefeedback)
+event that
+
+- is obsoleted by read receipts,
+- is not used by anyone anywhere, and
+- is discouraged by the spec.
+
+See also: https://github.com/matrix-org/matrix-doc/issues/3318
+
+## Proposal
+
+The `m.room.message.feedback` event should be removed from the spec.


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-doc/blob/uhoreg/remove_room_message_feedback/proposals/3582-remove-room-feedback.md)

I don't think anything implements this event, so I guess lack of implementation of the event is proof of implementation?

Fixes https://github.com/matrix-org/matrix-doc/issues/3318

<!-- Replace -->
Preview: https://pr3582--matrix-org-previews.netlify.app
<!-- Replace -->
