### PR TITLE
Clarification for `/event_auth`

### DIFF
--- a/changelogs/server_server/newsfragments/3583.clarification
+++ b/changelogs/server_server/newsfragments/3583.clarification
@@ -1,0 +1,1 @@
+Clarify that `GET /_matrix/federation/v1/event_auth/{roomId}/{eventId}` does *not* return the auth chain for the full state of the room.

--- a/data/api/server-server/event_auth.yaml
+++ b/data/api/server-server/event_auth.yaml
@@ -57,17 +57,13 @@ paths:
               auth_chain:
                 type: array
                 description: |-
-                  The full set of authorization events that make up the state of
-                  the room, and their authorization events, recursively. Note that
-                  events have a different format depending on the room version -
-                  check the [room version specification](/rooms) for precise event formats.
+                  The [PDUs](/server-server-api/#pdus) forming the auth chain
+                  of the given event. The event format varies depending on the
+                  room version - check the [room version specification](/rooms)
+                  for precise event formats.
                 items:
                   type: object
                   title: PDU
-                  description: |-
-                    The [PDUs](/server-server-api/#pdus) contained in the auth chain. The event format
-                    varies depending on the room version - check the [room version specification](/rooms)
-                    for precise event formats.
                   properties: []
                   example:
                     $ref: "examples/minimal_pdu.json"


### PR DESCRIPTION
The current text on this reads:

> The full set of authorization events that make up the state of the room, and their authorization events, recursively. Note that events have a different format depending on the room version - check the room version specification for precise event formats.

This is misleading at best, as it implies it should return the auth chains for the full state of the room. Rather, it returns the auth chain for the event specified in the request: this is a much smaller set of data. (Consider a large room with many members: as worded, we should return the auth chain for every single `m.room.member` event in the state; in practice, Synapse only returns the auth chain for the requested event.)

For reference, the Synapse implementation of this method can be seen at https://github.com/matrix-org/synapse/blob/v1.49.2/synapse/handlers/federation.py#L420-L425 (which calls [`get_auth_chain`](https://github.com/matrix-org/synapse/blob/v1.49.2/synapse/storage/databases/main/event_federation.py#L80-L137)). The code has been optimised over the years, but in principle it has changed little since Synapse 0.6.0 (https://github.com/matrix-org/synapse/blob/v0.6.0/synapse/handlers/federation.py#L291-L304, https://github.com/matrix-org/synapse/blob/v0.6.0/synapse/storage/event_federation.py#L35-L71).

This text was introduced into the spec in [matrix-doc#1475](https://github.com/matrix-org/matrix-doc/pull/1475), so correction does not require an MSC - it's simply a bug in the spec.

<!-- Replace -->
Preview: https://pr3583--matrix-org-previews.netlify.app
<!-- Replace -->
