### PR TITLE
Fix rendering of response examples

### DIFF
--- a/layouts/partials/json-schema/resolve-example.html
+++ b/layouts/partials/json-schema/resolve-example.html
@@ -11,11 +11,10 @@
 
 {{ $this_object := partial "json-schema/resolve-allof" . }}
 
-{{ $example := false }}
+{{ $example := $this_object.example }}
 
 {{ if eq $this_object.type "object" }}
-    {{ $example = $this_object.example }}
-    {{ if not $this_object.example }}
+    {{ if not $example }}
         {{ $example = dict }}
     {{ end }}
 
@@ -28,19 +27,21 @@
 
 {{ else if eq $this_object.type "array" }}
 
-    {{/* the "items" within an array can either be an object (where we have a
-         list of items which match the schema), or a list (for tuple
-         validation, where each item has a different schema).
+    {{ if not $example }}
+        {{/* the "items" within an array can either be an object (where we have a
+             list of items which match the schema), or a list (for tuple
+             validation, where each item has a different schema).
 
-         TODO: support tuple validation here.
-    */}}
-
-    {{ if reflect.IsMap $this_object.items }}
-        {{ $items_example := partial "json-schema/resolve-example" $this_object.items }}
-        {{ $example = slice $items_example }}
-    {{ else }}
-        {{ $example = slice }}
+             TODO: support tuple validation here.
+        */}}
+        {{ if reflect.IsMap $this_object.items }}
+            {{ $items_example := partial "json-schema/resolve-example" $this_object.items }}
+            {{ $example = slice $items_example }}
+        {{ else }}
+            {{ $example = slice }}
+        {{ end }}
     {{ end }}
+
 {{ end }}
 
 {{ return $example }}

--- a/layouts/partials/json-schema/resolve-example.html
+++ b/layouts/partials/json-schema/resolve-example.html
@@ -11,19 +11,36 @@
 
 {{ $this_object := partial "json-schema/resolve-allof" . }}
 
-{{ if eq $this_object.type "object" }}
+{{ $example := false }}
 
+{{ if eq $this_object.type "object" }}
+    {{ $example = $this_object.example }}
     {{ if not $this_object.example }}
-        {{ $this_object := merge (dict "example" dict ) $this_object }}
+        {{ $example = dict }}
     {{ end }}
 
     {{ range $key, $property := $this_object.properties}}
         {{ $this_property_example := partial "json-schema/resolve-example" $property }}
         {{ if $this_property_example }}
-            {{ $this_object = merge (dict "example" (dict $key $this_property_example)) $this_object }}
+            {{ $example = merge (dict $key $this_property_example) $example }}
         {{ end }}
     {{ end }}
 
+{{ else if eq $this_object.type "array" }}
+
+    {{/* the "items" within an array can either be an object (where we have a
+         list of items which match the schema), or a list (for tuple
+         validation, where each item has a different schema).
+
+         TODO: support tuple validation here.
+    */}}
+
+    {{ if reflect.IsMap $this_object.items }}
+        {{ $items_example := partial "json-schema/resolve-example" $this_object.items }}
+        {{ $example = slice $items_example }}
+    {{ else }}
+        {{ $example = slice }}
+    {{ end }}
 {{ end }}
 
-{{ return $this_object.example }}
+{{ return $example }}

--- a/layouts/partials/openapi/render-request.html
+++ b/layouts/partials/openapi/render-request.html
@@ -47,19 +47,13 @@
 <h3>Request body example</h3>
 
         {{ $example := partial "json-schema/resolve-example" $schema }}
-        {{ if $example }}
-            {{ $example_json := jsonify (dict "indent" "  ") $example }}
-            {{ $example_json = replace $example_json "\\u003c" "<" }}
-            {{ $example_json = replace $example_json "\\u003e" ">" | safeHTML }}
+        {{ $example_json := jsonify (dict "indent" "  ") $example }}
+        {{ $example_json = replace $example_json "\\u003c" "<" }}
+        {{ $example_json = replace $example_json "\\u003e" ">" | safeHTML }}
 
 ```json
 {{ $example_json }}
 ```
-
-        {{ else }}
-            {{ partial "alert" (dict "type" "warning" "omit_title" "true" "color" "warning" "content" "Specification error: Example invalid or not present") }}
-        {{ end }}
-
     {{ end }}
 
 {{ else }}

--- a/layouts/partials/openapi/render-responses.html
+++ b/layouts/partials/openapi/render-responses.html
@@ -79,19 +79,13 @@
                 {{ $example = index $example "application/json" }}
             {{ end }}
 
-            {{ if $example }}
-                {{ $example_json := jsonify (dict "indent" "  ") $example }}
-                {{ $example_json = replace $example_json "\\u003c" "<" }}
-                {{ $example_json = replace $example_json "\\u003e" ">" | safeHTML }}
+            {{ $example_json := jsonify (dict "indent" "  ") $example }}
+            {{ $example_json = replace $example_json "\\u003c" "<" }}
+            {{ $example_json = replace $example_json "\\u003e" ">" | safeHTML }}
 
 ```json
 {{ $example_json }}
 ```
-
-            {{ else }}
-                {{ partial "alert" (dict "type" "warning" "omit_title" "true" "color" "warning" "content" "Specification error: Example invalid or not present") }}
-            {{ end }}
-
         {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
Fixes the autogeneration of JSON examples for array objects. This fixes a
number of "Specification error: Example invalid or not present" errors in the
rendered spec.




<!-- Replace -->
Preview: https://pr3584--matrix-org-previews.netlify.app
<!-- Replace -->
