### PR TITLE
🐛 Fix base URL for OpenAPI definition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           python3 -m venv env && . env/bin/activate
           pip install -r scripts/requirements.txt
           scripts/dump-swagger.py \
-            --base-url "${{ needs.calculate-baseurl.outputs.baseURL }}" \
+            --base-url "https://spec.matrix.org/${{ needs.calculate-baseurl.outputs.baseURL }}" \
             -o assets/spec/client_server/api.json
           tar -czf assets.tar.gz assets
       - name: "📤 Artifact upload"


### PR DESCRIPTION
Followup to #3598 so that the links in the JSON have a **full** URL.

<!-- Replace -->
Preview: https://pr3602--matrix-org-previews.netlify.app
<!-- Replace -->
