### PR TITLE
Update to MSC 2664; shared_rooms -> mutual_rooms, plus typo fixes

### DIFF
--- a/proposals/2666-get-rooms-in-common.md
+++ b/proposals/2666-get-rooms-in-common.md
@@ -2,11 +2,11 @@
 
 It is useful to be able to fetch rooms you have in common with another user. Popular messaging services
 such as Telegram offer users the ability to show "groups in common", which allows users to determine
-what they have in common before participating in converstion.
+what they have in common before participating in conversation.
 
 There are a variety of applications for this information. Some users may want to block invites from
 users they do not share a room with at the client level, and need a way to poll the homeserver for
-this information. Another use case would be trying to determine how a user came across your mxid, as
+this information. Another use case would be trying to determine how a user came across your MXID, as
 invites on their own do not present much context. With this endpoint, a client could tell you what
 rooms you have in common before you accept an invite.
 
@@ -19,7 +19,7 @@ This proposal aims to implement a simple mechanism to fetch rooms you have in co
 
 ## Proposal
 
-Homeservers should implement a new endpoint `/user/shared_rooms/{user_id}` which will take
+Homeservers should implement a new endpoint `/user/mutual_rooms/{user_id}` which will take
 the MxID of the user who is being searched for.
 
 The response format will be an array containing all rooms where both the authenticated user and `user_id` have
@@ -27,7 +27,7 @@ a membership of type `join`. If the `user_id` does not exist, or does not share 
 an empty array should be returned.
 
 ```
-GET /_matrix/client/r0/user/shared_rooms/%40bob%3Aexample.com
+GET /_matrix/client/r0/user/mutual_rooms/%40bob%3Aexample.com
 ```
 
 ```json
@@ -58,7 +58,7 @@ A client which holds full and current state can already see all membership for a
 determine which of those rooms contains a "join" membership for the given user_id. Clients which "lazy-load"
 however do not have this information, as they will have only synced a subset of the full membership for
 all rooms. While a client *could* pull all membership for all rooms at the point of needing this information,
-it's computationally expensive for both the homeserver and the client, as well as a bandwidth waste for contrained
+it's computationally expensive for both the homeserver and the client, as well as a bandwidth waste for constrained
 clients.
 
 
@@ -71,8 +71,8 @@ to request all state ahead of time.
 
 ## Unstable prefix
 
-The implementation MUST use `/_matrix/client/unstable/uk.half-shot.msc2666/user/shared_rooms/{user_id}`.  
+The implementation MUST use `/_matrix/client/unstable/uk.half-shot.msc2666/user/mutual_rooms/{user_id}`.
 The /versions endpoint MUST include a new key in `unstable_features` with the name `uk.half-shot.msc2666`.
 If the value is false or the key is not present, clients MUST assume the feature is not available.
-Once the MSC has been merged, clients should use `/_matrix/client/r0/user/shared_rooms/{user_id}`
+Once the MSC has been merged, clients should use `/_matrix/client/r0/user/mutual_rooms/{user_id}`
 and will no longer need to check for the `unstable_features` flag.


### PR DESCRIPTION
I'm currently partially adopting #2666, so this is in accordance with @Half-Shot

This PR changes the naming from `shared_rooms` to `mutual_rooms`, as per https://github.com/matrix-org/matrix-doc/pull/2666#discussion_r772331947, and fixes some minor typos

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`