### PR TITLE
add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _rendered.rst
 /spec/
 changelogs/rendered.*
 .hugo_build.lock
+node_modules


### PR DESCRIPTION
Encountered this while logging back into a codespace, maybe it's useful to add this to gitignore?

<!-- Replace -->
Preview: https://pr3632--matrix-org-previews.netlify.app
<!-- Replace -->
