### PR TITLE
Revert "add node_modules to .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ _rendered.rst
 /spec/
 changelogs/rendered.*
 .hugo_build.lock
-node_modules


### PR DESCRIPTION
Reverts matrix-org/matrix-doc#3632

this was a duplicate of an existing entry
