### PR TITLE
Re-add knock's `otherwise, reject` per MSC2403

### DIFF
--- a/changelogs/room_versions/newsfragments/3432.clarification
+++ b/changelogs/room_versions/newsfragments/3432.clarification
@@ -1,0 +1,1 @@
+Fully specify room versions to indicate what exactly is carried over from parent versions.

--- a/changelogs/room_versions/newsfragments/3661.clarification
+++ b/changelogs/room_versions/newsfragments/3661.clarification
@@ -1,0 +1,1 @@
+Fully specify room versions to indicate what exactly is carried over from parent versions.

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -113,6 +113,7 @@ The rules are as follows:
         2.  If `sender` does not match `state_key`, reject.
         3.  If the `sender`'s current membership is not `ban`, `invite`,
             or `join`, allow.
+        4.  Otherwise, reject.
     8.  Otherwise, the membership is unknown. Reject.
 5.  If the `sender`'s current membership state is not `join`, reject.
 6.  If type is `m.room.third_party_invite`:

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -136,6 +136,7 @@ The rules are as follows:
         2.  If `sender` does not match `state_key`, reject.
         3.  If the `sender`'s current membership is not `ban`, `invite`,
             or `join`, allow.
+        4.  Otherwise, reject.
     7.  Otherwise, the membership is unknown. Reject.
 5.  If the `sender`'s current membership state is not `join`, reject.
 6.  If type is `m.room.third_party_invite`:


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/3648

Includes an added changelog for #3432 as the room version changelog didn't exist at the time.




<!-- Replace -->
Preview: https://pr3661--matrix-org-previews.netlify.app
<!-- Replace -->
