### PR TITLE
Fix rendering of responses with empty bodies

### DIFF
--- a/layouts/partials/openapi/render-responses.html
+++ b/layouts/partials/openapi/render-responses.html
@@ -35,44 +35,52 @@
 
 </table>
 
-{{ range  $code, $response := $responses }}
-
+{{ range $code, $response := $responses }}
     {{ if $response.schema }}
+
+<h3>{{$code}} response</h3>
 
         {{ $schema := partial "json-schema/resolve-refs" (dict "schema" $response.schema "path" $path) }}
         {{ $schema := partial "json-schema/resolve-allof" $schema }}
 
-        {{ if or $schema.properties (eq $schema.type "array") }}
-<h3>{{ $code}} response</h3>
-
-            {{/*
-              All this is to work out how to express the content of the response
-              in the case where it is an array.
-            */}}
-            {{ if eq $schema.type "array" }}
-                {{ $type_of := "" }}
-                {{ if reflect.IsSlice $schema.items }}
-                    {{ $types := slice }}
-                    {{ range $schema.items }}
-                        {{ if .title }}
-                            {{ $types = $types | append .title}}
-                        {{ else }}
-                            {{ $types = $types | append .type }}
-                        {{ end }}
+        {{/*
+          All this is to work out how to express the content of the response
+          in the case where it is an array.
+        */}}
+        {{ if eq $schema.type "array" }}
+            {{ $type_of := "" }}
+            {{ if reflect.IsSlice $schema.items }}
+                {{ $types := slice }}
+                {{ range $schema.items }}
+                    {{ if .title }}
+                        {{ $types = $types | append .title}}
+                    {{ else }}
+                        {{ $types = $types | append .type }}
                     {{ end }}
-                    {{ $type_of = delimit $types ", "}}
-                {{ else }}
-                    {{ $type_of = $schema.items.title }}
                 {{ end }}
+                {{ $type_of = delimit $types ", "}}
+            {{ else }}
+                {{ $type_of = $schema.items.title }}
+            {{ end }}
 <p>Array of <code>{{ $type_of }}</code>.</p>
-            {{ end }}
+        {{ end }}
 
-            {{ $additional_types := partial "json-schema/resolve-additional-types" $schema }}
-            {{ $additional_types = uniq $additional_types }}
-            {{ range $additional_types }}
-                {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
-            {{ end }}
 
+        {{/*
+          render object tables for any objects referenced in the
+          response. (This will be a no-op for response types which aren't
+          objects or arrays.)
+        */}}
+        {{ $additional_types := partial "json-schema/resolve-additional-types" $schema }}
+        {{ $additional_types = uniq $additional_types }}
+        {{ range $additional_types }}
+            {{ partial "openapi/render-object-table" (dict "caption" .title "properties" .properties "required" .required) }}
+        {{ end }}
+
+        {{/*
+           render an example. currently this is only supported for arrays and objects.
+        */}}
+        {{ if or (eq $schema.type "object") (eq $schema.type "array") }}
             {{ $example := partial "json-schema/resolve-example" $schema }}
             {{ if $response.examples }}
                 {{ $example = partial "json-schema/resolve-refs" (dict "schema" $response.examples "path" $path) }}


### PR DESCRIPTION
This PR fixes the rendering of API responses, so that responses which are objects with no `properties` are still rendered.

<!-- Replace -->
Preview: https://pr3674--matrix-org-previews.netlify.app
<!-- Replace -->

See, for example, [`PUT /_matrix/client/v3/pushrules/{scope}/{kind}/{ruleId}/enabled`](https://pr3674--matrix-org-previews.netlify.app/client-server-api/#put_matrixclientv3pushrulesscopekindruleidenabled).

They are shown only as an example, which isn't super-clear, but is better than nothing:

![image](https://user-images.githubusercontent.com/1389908/151030042-ce9eb4d0-8064-4a02-93fd-cbb02a9ffd9b.png)


For reference, the following endpoints now show an example response with an empty body:

```
PUT /_matrix/client/v3/room_keys/version/{version}
DELETE /_matrix/client/v3/room_keys/version/{version}
POST /_matrix/client/v3/pushers/set
PUT /_matrix/client/v3/pushrules/{scope}/{kind}/{ruleId}
DELETE /_matrix/client/v3/pushrules/{scope}/{kind}/{ruleId}
PUT /_matrix/client/v3/pushrules/{scope}/{kind}/{ruleId}/actions
PUT /_matrix/client/v3/pushrules/{scope}/{kind}/{ruleId}/enabled
POST /_matrix/client/v3/rooms/{roomId}/invite   (with a threepid)
PUT /_matrix/client/v3/user/{userId}/rooms/{roomId}/tags/{tag}
DELETE /_matrix/client/v3/user/{userId}/rooms/{roomId}/tags/{tag}
POST /_matrix/client/v3/rooms/{roomId}/report/{eventId}

PUT /_matrix/federation/v2/send_leave/{roomId}/{eventId}
PUT /_matrix/federation/v1/3pid/onbind
PUT /_matrix/federation/v1/exchange_third_party_invite/{roomId}

PUT /_matrix/app/v1/transactions/{txnId}
GET /_matrix/app/v1/users/{userId}
GET /_matrix/app/v1/rooms/{roomAlias}
PUT /_matrix/client/v3/directory/list/appservice/{networkId}/{roomId}

POST /_matrix/identity/v2/account/logout
POST /_matrix/identity/v2/terms
GET /_matrix/identity/v2
POST /_matrix/identity/v2/3pid/unbind
```

These endpoints are now shown with a non-empty example response:

```
GET /_matrix/client/v3/rooms/{roomId}/state/{eventType}/{stateKey}
GET /_matrix/client/v3/user/{userId}/account_data/{type}
GET /_matrix/client/v3/user/{userId}/rooms/{roomId}/account_data/{type}
```

Finally, [`GET /_matrix/client/v3/thirdparty/protocols`](https://pr3674--matrix-org-previews.netlify.app/client-server-api/#get_matrixclientv3thirdpartyprotocols) now has an entire hierarchy of objects. It's special, because its response is an object using only `additionalProperties` (ie, it is a map from arbitrary strings to objects). The rendering isn't super-clear, but it's not much different from the same [before the site redesign](https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-thirdparty-protocols).

