### PR TITLE
Fix the response for `GET /_matrix/app/v1/thirdparty/protocol/{protocol}`

### DIFF
--- a/changelogs/application_service/newsfragments/3675.clarification
+++ b/changelogs/application_service/newsfragments/3675.clarification
@@ -1,0 +1,1 @@
+Correct the documentation for the response value for `GET /_matrix/app/v1/thirdparty/protocol/{protocol}`.

--- a/data/api/application-service/protocols.yaml
+++ b/data/api/application-service/protocols.yaml
@@ -48,7 +48,7 @@ paths:
         200:
           description: The protocol was found and metadata returned.
           schema:
-            $ref: definitions/protocol_metadata.yaml
+            $ref: definitions/protocol.yaml
         401:
           description: |-
             The homeserver has not supplied credentials to the application service.


### PR DESCRIPTION
This should return a single protocol, not all of them.

Fixes #2286.

<!-- Replace -->
Preview: https://pr3675--matrix-org-previews.netlify.app
<!-- Replace -->
