### PR TITLE
Remove 'room_id' field from `m.typing`, `m.receipt` and `m.fully_read` examples and schema

### DIFF
--- a/changelogs/client_server/newsfragments/3679.clarification
+++ b/changelogs/client_server/newsfragments/3679.clarification
@@ -1,0 +1,1 @@
+Remove erroneous `room_id` field from examples of `m.read`, `m.typing` in `/sync` and `m.fully_read` in room account data.

--- a/data/event-schemas/examples/core/room_edu.json
+++ b/data/event-schemas/examples/core/room_edu.json
@@ -1,4 +1,3 @@
 {
-    "$ref": "event.json",
-    "room_id": "!jEsUZKDJdhlrceRyVU:example.org"
+    "$ref": "event.json"
 }

--- a/data/event-schemas/examples/m.fully_read.yaml
+++ b/data/event-schemas/examples/m.fully_read.yaml
@@ -1,7 +1,6 @@
 {
   "$ref": "core/event.json",
   "type": "m.fully_read",
-  "room_id": "!somewhere:example.org",
   "content": {
     "event_id": "$someplace:example.org"
   }

--- a/data/event-schemas/schema/m.fully_read.yaml
+++ b/data/event-schemas/schema/m.fully_read.yaml
@@ -19,11 +19,7 @@
         "type": {
             "type": "string",
             "enum": ["m.fully_read"]
-        },
-        "room_id": {
-            "type": "string",
-            "description": "The room ID the read marker applies to."
         }
     },
-    "required": ["type", "room_id", "content"]
+    "required": ["type", "content"]
 }

--- a/data/event-schemas/schema/m.receipt.yaml
+++ b/data/event-schemas/schema/m.receipt.yaml
@@ -42,10 +42,7 @@
         "type": {
             "type": "string",
             "enum": ["m.receipt"]
-        },
-        "room_id": {
-            "type": "string"
         }
     },
-    "required": ["room_id", "type", "content"]
+    "required": ["type", "content"]
 }

--- a/data/event-schemas/schema/m.typing.yaml
+++ b/data/event-schemas/schema/m.typing.yaml
@@ -23,9 +23,6 @@
             "type": "string",
             "enum": ["m.typing"]
         },
-        "room_id": {
-            "type": "string"
-        }
     },
     "required": ["type", "room_id", "content"]
 }

--- a/data/event-schemas/schema/m.typing.yaml
+++ b/data/event-schemas/schema/m.typing.yaml
@@ -22,7 +22,7 @@
         "type": {
             "type": "string",
             "enum": ["m.typing"]
-        },
+        }
     },
-    "required": ["type", "room_id", "content"]
+    "required": ["type", "content"]
 }


### PR DESCRIPTION
It was discovered [here](https://github.com/matrix-org/matrix-doc/pull/2477/files/2f4dd474f3cd314f8637e925b357d7d51ed3e634#r750565554) that the spec had an erroneous `room_id` field in a `m.typing` EDU entry of `/sync`. After some further research, `room_id` fields also appear in `m.read` receipts in `/sync`, and `m.fully_read` room account data objects in the spec. None of these are necessary nor used in practice.

Checking part of the ecosystem for whether clients look for, or homeservers include, these `room_id` fields, I found that:

* Element does not require them, nor does Synapse include them.
* Ruma does not include them.
* Dendrite does not include them.
* nheko/mtxclient does not look for them.

This change removes `room_id` from the example and OpenAPI schema in each case mentioned above. It only affects the Client-Server spec - the Server-Server spec text remains unchanged.

The field was initially introduced in https://github.com/matrix-org/matrix-doc/commit/0f28f8327021c43632678d4d54f5753c7cd021ec#diff-8d917764f05b0823bc6aee1f9a74895d38df32fb1eeb10c18a55d9120cf23cb2R3.




<!-- Replace -->
Preview: https://pr3679--matrix-org-previews.netlify.app
<!-- Replace -->
