### PR TITLE
Fix missed rst->md numbered list syntax for `m.room.server_acl`

### DIFF
--- a/changelogs/client_server/3681.clarification
+++ b/changelogs/client_server/3681.clarification
@@ -1,0 +1,1 @@
+Fix broken syntax in Server Access Control Lists definition.

--- a/data/event-schemas/schema/m.room.server_acl.yaml
+++ b/data/event-schemas/schema/m.room.server_acl.yaml
@@ -16,11 +16,11 @@ description: |-
   the following order:
 
   1. If there is no `m.room.server_acl` event in the room state, allow.
-  1. If the server name is an IP address (v4 or v6) literal, and `allow_ip_literals`
+  2. If the server name is an IP address (v4 or v6) literal, and `allow_ip_literals`
      is present and `false`, deny.
-  1. If the server name matches an entry in the `deny` list, deny.
-  1. If the server name matches an entry in the `allow` list, allow.
-  1. Otherwise, deny.
+  3. If the server name matches an entry in the `deny` list, deny.
+  4. If the server name matches an entry in the `allow` list, allow.
+  5. Otherwise, deny.
 
   **Note:**
   Server ACLs do not restrict the events relative to the room DAG via authorisation

--- a/data/event-schemas/schema/m.room.server_acl.yaml
+++ b/data/event-schemas/schema/m.room.server_acl.yaml
@@ -16,11 +16,11 @@ description: |-
   the following order:
 
   1. If there is no `m.room.server_acl` event in the room state, allow.
-  #. If the server name is an IP address (v4 or v6) literal, and `allow_ip_literals`
+  1. If the server name is an IP address (v4 or v6) literal, and `allow_ip_literals`
      is present and `false`, deny.
-  #. If the server name matches an entry in the `deny` list, deny.
-  #. If the server name matches an entry in the `allow` list, allow.
-  #. Otherwise, deny.
+  1. If the server name matches an entry in the `deny` list, deny.
+  1. If the server name matches an entry in the `allow` list, allow.
+  1. Otherwise, deny.
 
   **Note:**
   Server ACLs do not restrict the events relative to the room DAG via authorisation


### PR DESCRIPTION
There was some left-over RST syntax which was causing a numbered list to have broken formatting:

![image](https://user-images.githubusercontent.com/1342360/151385183-4e8f1726-97fa-47f8-b4d5-7b71f89dc7a5.png)

This PR applies the equivalent markdown syntax.







<!-- Replace -->
Preview: https://pr3681--matrix-org-previews.netlify.app
<!-- Replace -->
