### PR TITLE
Dump additional apis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,6 @@ jobs:
           node validator.js -s "../data/api/application-service"
           node validator.js -s "../data/api/client-server"
           node validator.js -s "../data/api/push-gateway"
-          node validator.js -s "../data/api/server-server"
 
   check-examples:
     name: "🔎 Check Event schema examples"
@@ -89,10 +88,6 @@ jobs:
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
             --api push-gateway \
             -o spec/push-gateway-api/api.json
-          scripts/dump-swagger.py \
-            --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
-            --api server-server \
-            -o spec/server-server-api/api.json
           tar -czf openapi.tar.gz spec
       - name: "📤 Artifact upload"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           node validator.js -s "../data/api/application-service"
           node validator.js -s "../data/api/client-server"
+          node validator.js -s "../data/api/push-gateway"
 
   check-examples:
     name: "🔎 Check Event schema examples"
@@ -83,6 +84,10 @@ jobs:
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
             --api client-server \
             -o spec/client-server-api/api.json
+          scripts/dump-swagger.py \
+            --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
+            --api push-gateway \
+            -o spec/push-gateway-api/api.json
           tar -czf openapi.tar.gz spec
       - name: "📤 Artifact upload"
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
           # The output path matches the final deployment path at spec.matrix.org
           scripts/dump-swagger.py \
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
+            --api client-server \
             -o spec/client-server-api/api.json
           tar -czf openapi.tar.gz spec
       - name: "📤 Artifact upload"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
       - name: "🔎 Run validator"
         working-directory: "./scripts"
         run: |
+          node validator.js -s "../data/api/application-service"
           node validator.js -s "../data/api/client-server"
 
   check-examples:
@@ -74,6 +75,10 @@ jobs:
           python3 -m venv env && . env/bin/activate
           pip install -r scripts/requirements.txt
           # The output path matches the final deployment path at spec.matrix.org
+          scripts/dump-swagger.py \
+            --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
+            --api application-service \
+            -o spec/application-service-api/api.json
           scripts/dump-swagger.py \
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
             --api client-server \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           node validator.js -s "../data/api/application-service"
           node validator.js -s "../data/api/client-server"
           node validator.js -s "../data/api/push-gateway"
+          node validator.js -s "../data/api/server-server"
 
   check-examples:
     name: "🔎 Check Event schema examples"
@@ -88,6 +89,10 @@ jobs:
             --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
             --api push-gateway \
             -o spec/push-gateway-api/api.json
+          scripts/dump-swagger.py \
+            --base-url "https://spec.matrix.org${{ needs.calculate-baseurl.outputs.baseURL }}" \
+            --api server-server \
+            -o spec/server-server-api/api.json
           tar -czf openapi.tar.gz spec
       - name: "📤 Artifact upload"
         uses: actions/upload-artifact@v2

--- a/data/api/server-server/definitions/send_join_response.yaml
+++ b/data/api/server-server/definitions/send_join_response.yaml
@@ -34,7 +34,7 @@ properties:
         on the room version - check the [room version specification](/rooms) for precise event formats.
       schema:
         type: object
-        properties: []
+        properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
   state:
@@ -52,7 +52,7 @@ properties:
         on the room version - check the [room version specification](/rooms) for precise event formats.
       schema:
         type: object
-        properties: []
+        properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
   event:

--- a/data/api/server-server/definitions/single_pdu_transaction.yaml
+++ b/data/api/server-server/definitions/single_pdu_transaction.yaml
@@ -26,7 +26,7 @@ properties:
       description: |-
         The [PDUs](/server-server-api/#pdus) contained in the transaction. The event format varies depending
         on the room version - check the [room version specification](/rooms) for precise event formats.
-      properties: []
+      properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
 required: ['origin', 'origin_server_ts', 'pdus']

--- a/data/api/server-server/definitions/transaction.yaml
+++ b/data/api/server-server/definitions/transaction.yaml
@@ -41,7 +41,7 @@ properties:
       description: |-
         The [PDUs](/server-server-api/#pdus) contained in the transaction. The event format varies depending
         on the room version - check the [room version specification](/rooms) for precise event formats.
-      properties: []
+      properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
 required: ['origin', 'origin_server_ts', 'pdus']

--- a/data/api/server-server/definitions/unlimited_pdu_transaction.yaml
+++ b/data/api/server-server/definitions/unlimited_pdu_transaction.yaml
@@ -27,7 +27,7 @@ properties:
       description: |-
         The [PDUs](/server-server-api/#pdus) contained in the transaction. The event format varies depending
         on the room version - check the [room version specification](/rooms) for precise event formats.
-      properties: []
+      properties: {}
       example:
         $ref: "../examples/minimal_pdu.json"
 required: ['origin', 'origin_server_ts', 'pdus']

--- a/data/api/server-server/event_auth.yaml
+++ b/data/api/server-server/event_auth.yaml
@@ -64,7 +64,7 @@ paths:
                 items:
                   type: object
                   title: PDU
-                  properties: []
+                  properties: {}
                   example:
                     $ref: "examples/minimal_pdu.json"
             required: ['auth_chain']

--- a/data/api/server-server/events.yaml
+++ b/data/api/server-server/events.yaml
@@ -69,7 +69,7 @@ paths:
                     The [PDUs](/server-server-api/#pdus) contained in the auth chain. The event format
                     varies depending on the room version - check the [room version specification](/rooms)
                     for precise event formats.
-                  properties: []
+                  properties: {}
                   example:
                     $ref: "examples/minimal_pdu.json"
               pdus:
@@ -85,7 +85,7 @@ paths:
                     The [PDUs](/server-server-api/#pdus) for the fully resolved state of the room. The event format
                     varies depending on the room version - check the [room version specification](/rooms)
                     for precise event formats.
-                  properties: []
+                  properties: {}
                   example:
                     $ref: "examples/minimal_pdu.json"
             required: ['auth_chain', 'pdus']

--- a/data/api/server-server/transactions.yaml
+++ b/data/api/server-server/transactions.yaml
@@ -69,7 +69,7 @@ paths:
                       $ref: "definitions/edu.yaml"
           example: {
             "$ref": "examples/transaction.json",
-            "edus": [{"$ref": "edu.json"}] # Relative to the examples directory
+            "edus": [{"$ref": "examples/edu.json"}] # Relative to the examples directory
           }
       responses:
         200:

--- a/data/api/server-server/transactions.yaml
+++ b/data/api/server-server/transactions.yaml
@@ -69,7 +69,7 @@ paths:
                       $ref: "definitions/edu.yaml"
           example: {
             "$ref": "examples/transaction.json",
-            "edus": [{"$ref": "examples/edu.json"}] # Relative to the examples directory
+            "edus": [{"$ref": "examples/edu.json"}]
           }
       responses:
         200:

--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -153,9 +153,12 @@ output = {
 }
 
 selected_api_dir = os.path.join(api_dir, selected_api)
-with open(os.path.join(selected_api_dir, 'definitions',
-                       'security.yaml')) as f:
-    output['securityDefinitions'] = yaml.safe_load(f)
+try:
+    with open(os.path.join(selected_api_dir, 'definitions',
+                           'security.yaml')) as f:
+        output['securityDefinitions'] = yaml.safe_load(f)
+except FileNotFoundError:
+    print("No security definitions available for this API")
 
 for filename in os.listdir(selected_api_dir):
     if not filename.endswith(".yaml"):

--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -93,12 +93,12 @@ parser.add_argument(
     %(default)s""",
 )
 available_apis = {
-        "client-server": "Matrix Client-Server API",
-        "server-server": "Matrix Server-Server API",
-        "application-service": "Matrix Application Service API",
-        "identity": "Matrix Identity Service API",
-        "push-gateway": "Matrix Push Gateway API",
-        }
+    "client-server": "Matrix Client-Server API",
+    "server-server": "Matrix Server-Server API",
+    "application-service": "Matrix Application Service API",
+    "identity": "Matrix Identity Service API",
+    "push-gateway": "Matrix Push Gateway API",
+}
 parser.add_argument(
     "--api",
     default="client-server",
@@ -133,15 +133,17 @@ output = {
     # The servers value will be picked up by RapiDoc to provide a way
     # to switch API servers. Useful when one wants to test compliance
     # of their server with the API.
-    "servers": [{
-        "url": "https://{homeserver_address}/",
-        "variables": {
-            "homeserver_address": {
-                "default": "matrix-client.matrix.org",
-                "description": "The base URL for your homeserver",
-            }
+    "servers": [
+        {
+            "url": "https://{homeserver_address}/",
+            "variables": {
+                "homeserver_address": {
+                    "default": "matrix-client.matrix.org",
+                    "description": "The base URL for your homeserver",
+                }
+            },
         }
-    }],
+    ],
     "schemes": ["https"],
     "info": {
         "title": available_apis[selected_api],
@@ -154,8 +156,7 @@ output = {
 
 selected_api_dir = os.path.join(api_dir, selected_api)
 try:
-    with open(os.path.join(selected_api_dir, 'definitions',
-                           'security.yaml')) as f:
+    with open(os.path.join(selected_api_dir, 'definitions', 'security.yaml')) as f:
         output['securityDefinitions'] = yaml.safe_load(f)
 except FileNotFoundError:
     print("No security definitions available for this API")

--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -87,10 +87,23 @@ parser.add_argument(
     %(default)s""",
 )
 parser.add_argument(
-    "--client_release", "-c", metavar="LABEL",
+    "--spec-release", "-r", metavar="LABEL",
     default="unstable",
-    help="""The client-server release version to generate for. Default:
+    help="""The spec release version to generate for. Default:
     %(default)s""",
+)
+available_apis = {
+        "client-server": "Matrix Client-Server API",
+        "server-server": "Matrix Server-Server API",
+        "application-service": "Matrix Application Service API",
+        "identity": "Matrix Identity Service API",
+        "push-gateway": "Matrix Push Gateway API",
+        }
+parser.add_argument(
+    "--api",
+    default="client-server",
+    choices=available_apis,
+    help="""The API to generate for. Default: %(default)s""",
 )
 parser.add_argument(
     "-o", "--output",
@@ -100,7 +113,8 @@ parser.add_argument(
 args = parser.parse_args()
 
 output_file = os.path.abspath(args.output)
-release_label = args.client_release
+release_label = args.spec_release
+selected_api = args.api
 
 major_version = release_label
 match = re.match("^(r\d+)(\.\d+)*$", major_version)
@@ -130,7 +144,7 @@ output = {
     }],
     "schemes": ["https"],
     "info": {
-        "title": "Matrix Client-Server API",
+        "title": available_apis[selected_api],
         "version": release_label,
     },
     "securityDefinitions": {},
@@ -138,15 +152,15 @@ output = {
     "swagger": "2.0",
 }
 
-cs_api_dir = os.path.join(api_dir, 'client-server')
-with open(os.path.join(cs_api_dir, 'definitions',
+selected_api_dir = os.path.join(api_dir, selected_api)
+with open(os.path.join(selected_api_dir, 'definitions',
                        'security.yaml')) as f:
     output['securityDefinitions'] = yaml.safe_load(f)
 
-for filename in os.listdir(cs_api_dir):
+for filename in os.listdir(selected_api_dir):
     if not filename.endswith(".yaml"):
         continue
-    filepath = os.path.join(cs_api_dir, filename)
+    filepath = os.path.join(selected_api_dir, filename)
 
     print("Reading swagger API: %s" % filepath)
     with open(filepath, "r") as f:

--- a/scripts/dump-swagger.py
+++ b/scripts/dump-swagger.py
@@ -37,11 +37,18 @@ def resolve_references(path, schema):
         # do $ref first
         if '$ref' in schema:
             value = schema['$ref']
+            previous_path = path
             path = os.path.join(os.path.dirname(path), value)
-            with open(path, encoding="utf-8") as f:
-                ref = yaml.safe_load(f)
-            result = resolve_references(path, ref)
-            del schema['$ref']
+            try:
+                with open(path, encoding="utf-8") as f:
+                    ref = yaml.safe_load(f)
+                result = resolve_references(path, ref)
+                del schema['$ref']
+                path = previous_path
+            except FileNotFoundError:
+                print("Resolving {}".format(schema))
+                print("File not found: {}".format(path))
+                result = {}
         else:
             result = {}
 


### PR DESCRIPTION
Currently, only the client-server is made available as an OpenAPI JSON file. This adds support for the rest of the API.

* `application-service` and `push-gateway` work.
* `server-server` does not work yet. It fails to resolve a specific reference, still investigating.
* `identity` does not work yet. I haven’t had time to look into it yet. YAML reading works fine, the problem occurs when writing the JSON output.

Work towards https://github.com/matrix-org/matrix-doc/issues/1458 ~ TravisR







<!-- Replace -->
Preview: https://pr3684--matrix-org-previews.netlify.app
<!-- Replace -->
