### PR TITLE
Fix knock->leave transition in auth rules

### DIFF
--- a/changelogs/room_versions/newsfragments/3694.clarification
+++ b/changelogs/room_versions/newsfragments/3694.clarification
@@ -1,0 +1,1 @@
+Fix auth rules to allow membership of `knock` -> `leave` in v7, v8, and v9.

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -91,7 +91,8 @@ The rules are as follows:
         5.  Otherwise, reject.
     5.  If `membership` is `leave`:
         1.  If the `sender` matches `state_key`, allow if and only if
-            that user's current membership state is `invite` or `join`.
+            that user's current membership state is `invite`, `join`,
+            or `knock`.
         2.  If the `sender`'s current membership state is not `join`,
             reject.
         3.  If the *target user*'s current membership state is `ban`,

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -114,7 +114,8 @@ The rules are as follows:
         5.  Otherwise, reject.
     4.  If `membership` is `leave`:
         1.  If the `sender` matches `state_key`, allow if and only if
-            that user's current membership state is `invite` or `join`.
+            that user's current membership state is `invite`, `join`,
+            or `knock`.
         2.  If the `sender`'s current membership state is not `join`,
             reject.
         3.  If the *target user*'s current membership state is `ban`,


### PR DESCRIPTION
This was an oversight from knocking being added.

For safety, this has been verified as at least intended by Synapse to work:
https://github.com/matrix-org/synapse/blob/f5e2cde3f50c7315d4d7a69e814deb9593943318/synapse/event_auth.py#L390-L391




<!-- Replace -->
Preview: https://pr3694--matrix-org-previews.netlify.app
<!-- Replace -->
