### PR TITLE
Update v1.2 changelog with missed PR

### DIFF
--- a/changelogs/server_server/3528.clarification
+++ b/changelogs/server_server/3528.clarification
@@ -1,1 +1,0 @@
-Fix various typos throughout the specification.

--- a/layouts/partials/changelogs/v1.2.md
+++ b/layouts/partials/changelogs/v1.2.md
@@ -80,7 +80,7 @@ Variables:
 <strong>Spec Clarifications</strong>
 
 
-- Fix various typos throughout the specification. ([#3527](https://github.com/matrix-org/matrix-doc/issues/3527))
+- Fix various typos throughout the specification. ([#3527](https://github.com/matrix-org/matrix-doc/issues/3527), [#3528](https://github.com/matrix-org/matrix-doc/issues/3528))
 - Clarify that `GET /_matrix/federation/v1/event_auth/{roomId}/{eventId}` does *not* return the auth chain for the full state of the room. ([#3583](https://github.com/matrix-org/matrix-doc/issues/3583))
 - Fix the rendering of the responses for various API endpoints. ([#3674](https://github.com/matrix-org/matrix-doc/issues/3674))
 


### PR DESCRIPTION
The v1.2 changelog missed a PR (because the newsfile was in the wrong directory). Add it retrospectively.

<!-- Replace -->
Preview: https://pr3705--matrix-org-previews.netlify.app
<!-- Replace -->
