### PR TITLE
Fix m.login.appservice -> m.login.application_service

### DIFF
--- a/changelogs/3711.clarification
+++ b/changelogs/3711.clarification
@@ -1,1 +1,1 @@
-Clarify that `m.login.application_service` should be used for appservice logins, rather than `m.login.appservice`.
+Fix incorrectly referenced `m.login.appservice` login identifier, instead using `m.login.application_service`.

--- a/changelogs/3711.clarification
+++ b/changelogs/3711.clarification
@@ -1,0 +1,1 @@
+Clarify that `m.login.application_service` should be used for appservice logins, rather than `m.login.appservice`

--- a/changelogs/3711.clarification
+++ b/changelogs/3711.clarification
@@ -1,1 +1,1 @@
-Clarify that `m.login.application_service` should be used for appservice logins, rather than `m.login.appservice`
+Clarify that `m.login.application_service` should be used for appservice logins, rather than `m.login.appservice`.

--- a/content/client-server-api/_index.md
+++ b/content/client-server-api/_index.md
@@ -1087,7 +1087,7 @@ To use this login type, clients should submit a `/login` request as follows:
 
 ```json
 {
-  "type": "m.login.appservice",
+  "type": "m.login.application_service",
   "identifier": {
     "type": "m.id.user",
     "user": "<user_id or user localpart>"


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-doc/issues/3709

Implementations seem to agree with the proposal, so I'd suggest we fix the typo in the spec. I don't *think* this needs a MSC as the original proposal was fine, and this was just a copy error.

I didn't update the changelog file for v1.2, but can do if requested.







<!-- Replace -->
Preview: https://pr3711--matrix-org-previews.netlify.app
<!-- Replace -->
