### PR TITLE
Use yaml.safe_load instead of yaml.load in `check-event-schema-examples.py`

### DIFF
--- a/scripts/check-event-schema-examples.py
+++ b/scripts/check-event-schema-examples.py
@@ -55,7 +55,7 @@ def load_file(path):
         else:
             # We have to assume it's YAML because some of the YAML examples
             # do not have file extensions.
-            return yaml.load(f)
+            return yaml.safe_load(f)
 
 
 def resolve_references(path, schema):
@@ -84,7 +84,7 @@ def check_example_file(examplepath, schemapath):
         example = resolve_references(examplepath, json.load(f))
 
     with open(schemapath) as f:
-        schema = yaml.load(f)
+        schema = yaml.safe_load(f)
 
     fileurl = "file://" + os.path.abspath(schemapath)
     schema["id"] = fileurl


### PR DESCRIPTION
PyYAML 6.0 [requires](https://github.com/yaml/pyyaml/pull/561) a Loader argument to be passed to yaml.load. We could pass `yaml.SafeLoader`, or simply use the `yaml.safe_load` method instead. This PR opts to do the latter for simplicity.

The previous default loader was `yaml.FullLoader`, and as such this PR changes the behaviour to `yaml.SafeLoader`. I don't think this has any actual repercussions on the data that we're loading in however. https://msg.pyyaml.org/load has more details, and even recommends that `FullLoader` no longer be used.

This PR is required for this script to work with PyYAML 6.0.

<!-- Replace -->
Preview: https://pr3716--matrix-org-previews.netlify.app
<!-- Replace -->
