### PR TITLE
Use `yaml.safe_load` in `check-swagger-sources.py`

### DIFF
--- a/scripts/check-swagger-sources.py
+++ b/scripts/check-swagger-sources.py
@@ -89,7 +89,7 @@ def check_response(filepath, request, code, response):
 
 def check_swagger_file(filepath):
     with open(filepath) as f:
-        swagger = yaml.load(f)
+        swagger = yaml.safe_load(f)
 
     for path, path_api in swagger.get('paths', {}).items():
 
@@ -162,7 +162,7 @@ def load_file(path):
         else:
             # We have to assume it's YAML because some of the YAML examples
             # do not have file extensions.
-            return yaml.load(f)
+            return yaml.safe_load(f)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The same as #3716, but for `check-swagger-sources.py`.

Note that this script is currently failing to validate our sources before this change (#3718). However, reverting to a known good commit (d4c74d37a9d5f2625c3b9b46b4b44f61edc2ab9d) and using `yaml.safe_load` produced no errors.