### PR TITLE
Clarify that the X-Matrix validation uses the parsed request body

### DIFF
--- a/changelogs/server_server/newsfragments/3727.clarification
+++ b/changelogs/server_server/newsfragments/3727.clarification
@@ -1,0 +1,1 @@
+Clarify that the `content` for `X-Matrix` signature validation is the parsed JSON body.

--- a/content/server-server-api.md
+++ b/content/server-server-api.md
@@ -237,7 +237,7 @@ Step 1 sign JSON:
     "uri": "/target",
     "origin": "origin.hs.example.com",
     "destination": "destination.hs.example.com",
-    "content": <request body>,
+    "content": <JSON-parsed request body>,
     "signatures": {
         "origin.hs.example.com": {
             "ed25519:key1": "ABCDEF..."
@@ -274,6 +274,7 @@ def authorization_headers(origin_name, origin_signing_key,
     }
 
     if content is not None:
+        # Assuming content is already parsed as JSON
         request_json["content"] = content
 
     signed_json = sign_json(request_json, origin_name, origin_signing_key)


### PR DESCRIPTION





<!-- Replace -->
Preview: https://pr3727--matrix-org-previews.netlify.app
<!-- Replace -->
