### PR TITLE
GHA: Skip building the docs site for MSCs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,12 @@ on:
       - main
     tags:
       - v*
+    # don't bother with this workflow if only proposals are changed
+    paths-ignore:
+      - proposals
   pull_request:
+    paths-ignore:
+      - proposals
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
If only the `proposals` directory has changed, there's no point building the
docs site and offering a preview.

<!-- Replace -->
Preview: https://pr3729--matrix-org-previews.netlify.app
<!-- Replace -->
