### PR TITLE
MSC3735: Add device information to m.room_key.withheld message

### DIFF
--- a/proposals/3735-add-device-to-withheld-message.md
+++ b/proposals/3735-add-device-to-withheld-message.md
@@ -1,4 +1,4 @@
-# MSCxxxx: Add device information to m.room_key.withheld message
+# MSC3735: Add device information to m.room_key.withheld message
 
 [MSC2399](https://github.com/matrix-org/matrix-doc/pull/2399) introduced a
 message that could be used to inform message recipients about the reason that a
@@ -40,7 +40,7 @@ None
 ## Unstable prefix
 
 Until this proposal is accepted, the field used should be called
-`org.matrix.mscxxxx.from_device`.
+`org.matrix.msc3735.from_device`.
 
 ## Dependencies
 


### PR DESCRIPTION
[Rendered](https://github.com/uhoreg/matrix-doc/blob/add_device_to_withheld/proposals/3735-add-device-to-withheld-message.md)




<!-- Replace -->
Preview: https://pr3735--matrix-org-previews.netlify.app
<!-- Replace -->
