### PR TITLE
Fix join membership auth rules when `join_rule` is knock

### DIFF
--- a/changelogs/room_versions/newsfragments/3737.clarification
+++ b/changelogs/room_versions/newsfragments/3737.clarification
@@ -1,0 +1,1 @@
+Fix join membership auth rules when `join_rule` is `knock`.

--- a/content/rooms/fragments/v8-auth-rules.md
+++ b/content/rooms/fragments/v8-auth-rules.md
@@ -53,8 +53,8 @@ The rules are as follows:
             `state_key` is the creator, allow.
         2.  If the `sender` does not match `state_key`, reject.
         3.  If the `sender` is banned, reject.
-        4.  If the `join_rule` is `invite` then allow if membership
-            state is `invite` or `join`.
+        4.  If the `join_rule` is `invite` or `knock` then allow if
+            membership state is `invite` or `join`.
         5.  If the `join_rule` is `restricted`:
             1.  If membership state is `join` or `invite`, allow.
             2.  If the `join_authorised_via_users_server` key in `content`

--- a/content/rooms/v7.md
+++ b/content/rooms/v7.md
@@ -82,8 +82,8 @@ The rules are as follows:
             `state_key` is the creator, allow.
         2.  If the `sender` does not match `state_key`, reject.
         3.  If the `sender` is banned, reject.
-        4.  If the `join_rule` is `invite` then allow if membership
-            state is `invite` or `join`.
+        4.  If the `join_rule` is `invite` or `knock` then allow if
+            membership state is `invite` or `join`.
         5.  If the `join_rule` is `public`, allow.
         6.  Otherwise, reject.
     3.  If `membership` is `invite`:


### PR DESCRIPTION
Fixes #3736




<!-- Replace -->
Preview: https://pr3737--matrix-org-previews.netlify.app
<!-- Replace -->
