### PR TITLE
MSC3871: Gappy timelines

### DIFF
--- a/proposals/0000-gappy-timelines.md
+++ b/proposals/0000-gappy-timelines.md
@@ -1,0 +1,125 @@
+# MSC0000: Gappy timeline
+
+`/messages` returns a linearized version of the event DAG. From any given
+homeservers perspective of the room, the DAG can have gaps where they're missing
+events. This could be because the homeserver hasn't fetched them yet or because
+it failed to fetch the events because those homeservers are unreachable and no
+one else knows about the event.
+
+Currently, there is an unwritten expectation(TODO: better word) between the
+server and client that the server will always return all contiguous events in
+that part of the timeline. But the server has to break this promise(TODO: match
+word above) sometimes when it doesn't have the event and is unable to get the
+event from anyone else and the client is unaware. This MSC aims to change the
+dynamic so the server can give the client feedback and an indication of where
+the gaps are.
+
+This way clients know where they are missing events and can even retry fetching
+by perhaps adding some UI to the timeline like "We failed to get some messages
+in this gap, try again."
+
+This can also make servers faster to respond to `/messages`. For example,
+currently, Synapse always tries to backfill and fill in the gap (even when it
+has enough messages locally to respond). In big rooms like `#matrix:matrix.org`
+(Matrix HQ), almost every place you ask for has gaps in it (thousands of
+backwards extremities) and lots are unreachable so we try the same thing over
+and over hoping the response will be different this time but instead, we just
+make the `/messages` response time slow. With this MSC, we can instead be more
+intelligent about backfilling in the background and just tell the client about
+the gap that they can retry fetching a little later.
+
+
+## Proposal
+
+Add a `m.timeline.gap` indicator, that can be used in the `chunk` list of events
+from a `GET /_matrix/client/v3/rooms/{roomId}/messages` response. There can be
+multiple gaps per response.
+
+
+### `m.timeline.gap`
+
+key | type | value | description | required
+--- | --- | --- | --- | ---
+`gap_start_event_id` | string | Event ID | The event ID that the homeserver is missing where the gap begins | yes
+`pagination_token` | string | Pagination token | A pagination token that represents the spot in the DAG after the missing `gap_start_event_id`. Useful when retrying to fetch the missing part of the timeline again via `/messages?dir=b&from=<pagination_token>` | yes
+
+Pagination tokens are positions between events. This already an established
+concept but to illustrate this better, see the following diagram:
+```
+                                                     pagination_token
+                                                     |
+<oldest-in-time> [0]<--[1] <gap> [gap_start_event_id]▼<--[4]<--[5]<--[6] <newest-in-time>
+```
+
+`m.timeline.gap` has a similar shape to a normal event so it's still easy to
+iterate over the `/messages` response and process but has no `event_id` itself
+so it should not be mistaken as a real event in the room.
+
+A full example of the `m.timeline.gap` indicator:
+
+```json5
+{
+  "type": "m.timeline.gap",
+  "content": {
+    "gap_start_event_id": "$12345",
+    "pagination_token": "t47409-4357353_219380_26003_2265",
+  }
+},
+```
+
+`/messages` response example with a gap:
+
+```json5
+{
+  "chunk": [
+    {
+      "type": "m.room.message",
+      "content": {
+        "body": "foo",
+      }
+    },
+    {
+      "type": "m.timeline.gap",
+      "content": {
+        "gap_start_event": "$12345",
+        "pagination_token": "t47409-4357353_219380_26003_2265",
+      }
+    },
+    {
+      "type": "m.room.message",
+      "content": {
+        "body": "baz",
+      }
+    },
+  ]
+}
+```
+
+
+## Potential issues
+
+Lots of gaps/extremities are generated when a spam attack occurs and federation
+falls behind. If clients start showing gaps with retry links, we might just be
+exposing the spam more.
+
+
+## Alternatives
+
+As an alternative, we can continue to do nothing as we do today and not worry
+about the occasional missing events. People seem not to notice any missing
+messages anyway but they do probably see our slow `/messages` pagination.
+
+
+
+## Security considerations
+
+Only your own homeserver controls whether a `m.timeline.gap` indicator is added to the
+message response and it isn't an event of the room so there shouldn't be any weird
+edge case where the gap is trying to get you to fetch spam or something.
+
+
+## Unstable prefix
+
+The `m.timeline.gap` indicator can be used in the `org.matrix.mscXXXX` room version.
+
+

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -38,7 +38,7 @@ timeline are as defined below.
 
 ### 200 response
 
-Thid describes the new `gaps` response field being added to the `200 response`
+This describes the new `gaps` response field being added to the `200 response`
 of `/messages`:
 
 Name | Type | Description | required

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -6,11 +6,10 @@ events. This could be because the homeserver hasn't fetched them yet or because
 it failed to fetch the events because those homeservers are unreachable and no
 one else knows about the event.
 
-Currently, there is an unwritten expectation(TODO: better word) between the
-server and client that the server will always return all contiguous events in
-that part of the timeline. But the server has to break this promise(TODO: match
-word above) sometimes when it doesn't have the event and is unable to get the
-event from anyone else. This MSC aims to change the
+Currently, there is an unwritten rule between the server and client that the
+server will always return all contiguous events in that part of the timeline.
+But the server has to break this rule sometimes when it doesn't have the event
+and is unable to get the event from anyone else. This MSC aims to change the
 dynamic so the server can give the client feedback and an indication of where
 the gaps are.
 

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -401,11 +401,29 @@ control whether you to fetch something.
 
 ## Unstable prefix
 
-Servers will indicate support for this MSC via a `true` value for feature
-flag `org.matrix.msc3871` in `unstable_features` in the response to `GET
-/_matrix/client/versions`.
-
 While this feature is in development, the `gaps` field can be used as
 `org.matrix.msc3871.gaps`
 
+### While the MSC is unstable
 
+During this period, to detect server support clients should check for the
+presence of the `org.matrix.msc3871` flag in `unstable_features` on `/versions`.
+Clients are also required to use the unstable prefixes (see [unstable
+prefix](#unstable-prefix)) during this time.
+
+### Once the MSC is merged but not in a spec version
+
+Once this MSC is merged, but is not yet part of the spec, clients should rely on
+the presence of the `org.matrix.msc3871.stable` flag in `unstable_features` to
+determine server support. If the flag is present, clients are required to use
+stable prefixes (see [unstable prefix](#unstable-prefix)).
+
+### Once the MSC is in a spec version
+
+Once this MSC becomes a part of a spec version, clients should rely on the
+presence of the spec version, that supports the MSC, in `versions` on
+`/versions`, to determine support. Servers are encouraged to keep the
+`org.matrix.msc3871.stable` flag around for a reasonable amount of time
+to help smooth over the transition for clients. "Reasonable" is intentionally
+left as an implementation detail, however the MSC process currently recommends
+*at most* 2 months from the date of spec release.

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -188,6 +188,27 @@ about the occasional missing events. People seem not to notice any missing
 messages anyway but they do probably see our slow `/messages` pagination.
 
 
+### Expose `prev_events` to the client
+
+One alternative is including the `prev_events` in the events that the client sees so
+they can figure out the DAG chain themselves and see if there is an missing event in the
+middle.
+
+There is an [unspecced `/messages?raw=true` query parameter in
+Synapse](https://github.com/matrix-org/synapse/blob/20c76cecb9eb84dadfa7b2d25b436d3ab9218a1a/synapse/rest/client/room.py#L653)
+that returns the full raw event as seen over federation which means it will include the
+`prev_events`.
+
+You can also specify `event_format: federation` directly in that JSON `filter` parameter
+of `/messages` ->
+`/_matrix/client/v3/rooms/{room_id}}/messages?dir=b&filter=%7B%22event_format%22%3A%20%22federation%22%7D`
+
+Related to:
+
+ - https://github.com/matrix-org/matrix-spec/issues/859
+ - https://github.com/matrix-org/matrix-spec/issues/1047
+
+
 ### Synthetic `m.timeline.gap` event alternative
 
 Another alternative is using synthetic events (thing that looks like an event

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -51,8 +51,8 @@ Name | Type | Description | required
 key | type | value | description | required
 --- | --- | --- | --- | ---
 `event_id` | string | Event ID | The event ID indicating the position in the `/messages` `chunk` response  | yes
-`prev_pagination_token` | string | Pagination token | A pagination token that represents the spot in the DAG before the given `event_id` in the `chunk` | yes
-`next_pagination_token` | string | Pagination token | A pagination token that represents the spot in the DAG after the given `event_id` in the `chunk` | yes
+`prev_pagination_token` | string | Pagination token | A pagination token that represents the spot in the DAG before the given `event_id` in the `chunk`. Omitting this field just means there is no gap on this side. | no
+`next_pagination_token` | string | Pagination token | A pagination token that represents the spot in the DAG after the given `event_id` in the `chunk`. Omitting this field just means there is no gap on this side. | no
 
 
 ### `/messages` response examples

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -30,9 +30,10 @@ the client about the gap that they can retry fetching a little later.
 
 ## Proposal
 
-Add a `m.timeline.gap` indicator, that can be used in the `chunk` list of events
-from a `GET /_matrix/client/v3/rooms/{roomId}/messages` response. There can be
-multiple gaps per response.
+Add a `?gaps_allowed=true` query parameter flag to `GET
+/_matrix/client/v3/rooms/{roomId}/messages` which allows usage of a
+`m.timeline.gap` indicator, that can be used in the `response` `chunk` list of
+events. There can be multiple gaps per response.
 
 
 ### `m.timeline.gap`
@@ -119,6 +120,7 @@ edge case where the gap is trying to get you to fetch spam or something.
 
 ## Unstable prefix
 
-The `m.timeline.gap` indicator can be used in the `org.matrix.msc3871` room version.
+While this feature is in development, it can be used as `GET
+/_matrix/client/unstable/org.matrix.msc3871/rooms/{roomId}/messages?gaps_allowed=true`
 
 

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -56,13 +56,18 @@ key | type | value | description | required
 Pagination tokens are positions between events. This already an established
 concept but to illustrate this better, see the following diagram:
 ```
-                                                     pagination_token
-                                                     |
-<oldest-in-time> [0]<--[1] <gap> [gap_start_event_id]▼<--[4]<--[5]<--[6] <newest-in-time>
+                                   pagination_token
+                                   |
+<oldest-in-time> [0]<--[1]<-- <gap>▼ <--[4 (next_to_event_id)]<--[5]<--[6] <newest-in-time>
 ```
+
+The idea is to be able to keep paginating from `pagination_token` in the same
+direction of the request to fill in the gap.
 
 
 ### `/messages` response examples
+
+#### `/messages?dir=f`
 
 `/messages?dir=f` response example with a gap (`chunk` has events in
 chronoligcal order):
@@ -95,6 +100,15 @@ chronoligcal order):
 }
 ```
 
+```
+                                             pagination_token
+                                             |
+<oldest-in-time> [foo (next_to_event_id)]<-- ▼<gap> <--[baz] <newest-in-time>
+```
+
+
+#### `/messages?dir=b`
+
 
 `/messages?dir=b` response example with a gap (`chunk` has events in
 reverse-chronoligcal order):
@@ -126,6 +140,13 @@ reverse-chronoligcal order):
   ]
 }
 ```
+
+```
+                               pagination_token
+                               |
+<oldest-in-time> [foo]<-- <gap>▼ <--[baz (next_to_event_id)] <newest-in-time>
+```
+
 
 
 ## Potential issues

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -10,11 +10,11 @@ Currently, there is an unwritten expectation(TODO: better word) between the
 server and client that the server will always return all contiguous events in
 that part of the timeline. But the server has to break this promise(TODO: match
 word above) sometimes when it doesn't have the event and is unable to get the
-event from anyone else and the client is unaware. This MSC aims to change the
+event from anyone else. This MSC aims to change the
 dynamic so the server can give the client feedback and an indication of where
 the gaps are.
 
-This way clients know where they are missing events and can even retry fetching
+This way, clients know where they are missing events and can even retry fetching
 by perhaps adding some UI to the timeline like "We failed to get some messages
 in this gap, try again."
 
@@ -22,11 +22,11 @@ This can also make servers faster to respond to `/messages`. For example,
 currently, Synapse always tries to backfill and fill in the gap (even when it
 has enough messages locally to respond). In big rooms like `#matrix:matrix.org`
 (Matrix HQ), almost every place you ask for has gaps in it (thousands of
-backwards extremities) and lots are unreachable so we try the same thing over
-and over hoping the response will be different this time but instead, we just
-make the `/messages` response time slow. With this MSC, we can instead be more
-intelligent about backfilling in the background and just tell the client about
-the gap that they can retry fetching a little later.
+backwards extremities) and lots of those events are unreachable so we try the
+same thing over and over hoping the response will be different this time but
+instead, we just make the `/messages` response time slow. With this MSC, we can
+instead be more intelligent about backfilling in the background and just tell
+the client about the gap that they can retry fetching a little later.
 
 
 ## Proposal
@@ -57,19 +57,19 @@ so it should not be mistaken as a real event in the room.
 
 A full example of the `m.timeline.gap` indicator:
 
-```json5
+```json
 {
   "type": "m.timeline.gap",
   "content": {
     "gap_start_event_id": "$12345",
     "pagination_token": "t47409-4357353_219380_26003_2265",
   }
-},
+}
 ```
 
 `/messages` response example with a gap:
 
-```json5
+```json
 {
   "chunk": [
     {

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -67,46 +67,6 @@ direction of the request to fill in the gap.
 
 ### `/messages` response examples
 
-#### `/messages?dir=f`
-
-`/messages?dir=f` response example with a gap (`chunk` has events in
-chronoligcal order):
-
-```json5
-{
-  "chunk": [
-    {
-      "event_id": "$foo",
-      "type": "m.room.message",
-      "content": {
-        "body": "foo",
-      }
-    },
-    // <the `GapEntry` indicates a gap here>
-    {
-      "event_id": "$baz",
-      "type": "m.room.message",
-      "content": {
-        "body": "baz",
-      }
-    },
-  ]
-  "gaps": [
-        {
-          "next_to_event_id": "$foo",
-          "pagination_token": "t47402-4357353_219380_26003_2265",
-        }
-  ]
-}
-```
-
-```
-                                             pagination_token
-                                             |
-<oldest-in-time> [foo (next_to_event_id)]<-- ▼<gap> <--[baz] <newest-in-time>
-```
-
-
 #### `/messages?dir=b`
 
 
@@ -145,6 +105,46 @@ reverse-chronoligcal order):
                                pagination_token
                                |
 <oldest-in-time> [foo]<-- <gap>▼ <--[baz (next_to_event_id)] <newest-in-time>
+```
+
+
+#### `/messages?dir=f`
+
+`/messages?dir=f` response example with a gap (`chunk` has events in
+chronoligcal order):
+
+```json5
+{
+  "chunk": [
+    {
+      "event_id": "$foo",
+      "type": "m.room.message",
+      "content": {
+        "body": "foo",
+      }
+    },
+    // <the `GapEntry` indicates a gap here>
+    {
+      "event_id": "$baz",
+      "type": "m.room.message",
+      "content": {
+        "body": "baz",
+      }
+    },
+  ]
+  "gaps": [
+        {
+          "next_to_event_id": "$foo",
+          "pagination_token": "t47402-4357353_219380_26003_2265",
+        }
+  ]
+}
+```
+
+```
+                                             pagination_token
+                                             |
+<oldest-in-time> [foo (next_to_event_id)]<-- ▼<gap> <--[baz] <newest-in-time>
 ```
 
 

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -391,6 +391,15 @@ chronoligcal order since we're paginating forwards):
 </details>
 
 
+## Future considerations
+
+In the future, we should consider adding the same `gaps` field to `/context` because
+it's another endpoint that returns a linearized version of the DAG.
+
+It could make sense to roll this into this MSC but it might make the proposal less clear
+if we have to bulk it up by specifying the same details for `/context`. Leaving it to be
+follow-up MSC for now.
+
 
 ## Security considerations
 

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -1,4 +1,4 @@
-# MSC0000: Gappy timeline
+# MSC3871: Gappy timeline
 
 `/messages` returns a linearized version of the event DAG. From any given
 homeservers perspective of the room, the DAG can have gaps where they're missing
@@ -120,6 +120,6 @@ edge case where the gap is trying to get you to fetch spam or something.
 
 ## Unstable prefix
 
-The `m.timeline.gap` indicator can be used in the `org.matrix.mscXXXX` room version.
+The `m.timeline.gap` indicator can be used in the `org.matrix.msc3871` room version.
 
 

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -81,7 +81,7 @@ A full example of the `m.timeline.gap` indicator:
     {
       "type": "m.timeline.gap",
       "content": {
-        "gap_start_event": "$12345",
+        "gap_start_event_id": "$12345",
         "pagination_token": "t47409-4357353_219380_26003_2265",
       }
     },

--- a/proposals/3871-gappy-timelines.md
+++ b/proposals/3871-gappy-timelines.md
@@ -120,6 +120,10 @@ edge case where the gap is trying to get you to fetch spam or something.
 
 ## Unstable prefix
 
+Servers will indicate support for the new endpoint via a true value for feature
+flag `org.matrix.msc3871` in `unstable_features` in the response to `GET
+/_matrix/client/versions`.
+
 While this feature is in development, it can be used as `GET
 /_matrix/client/unstable/org.matrix.msc3871/rooms/{roomId}/messages?gaps_allowed=true`
 


### PR DESCRIPTION
A proposal for letting homeservers give feedback to clients where there is a gap in the timeline from a `/messages` response.

*Spawned from a discussion with @erikjohnston about making `/messages` faster*

[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/madlittlemods/gappy-timelines/proposals/3871-gappy-timelines.md)

Matrix Live demo: https://www.youtube.com/watch?v=Bo7GaLRhtc0&t=409s
 
Implementations:

 - Synapse: https://github.com/element-hq/synapse/pull/18873
 