### PR TITLE
MSC3918: Matrix Message Transport (IETF/MIMI)

### DIFF
--- a/proposals/3918-ietf-mimi-transport.txt
+++ b/proposals/3918-ietf-mimi-transport.txt
@@ -198,10 +198,10 @@ Table of Contents
 
    Practically, this looks like:
 
-Room on server A sent message A1,       The same room on server B has received
-then sent A2, and received C1 from      A1 and A2, but not C1, e.g. due to
-server C which raced with A2 and so     network connectivity problems.
-follows A1.
+  Room on server A sent message A1,     The same room on server B has
+  then sent A2, and received C1 from    received A1 and A2, but not C1,
+  server C which raced with A2 and so   e.g. due to network connectivity
+  follows A1.                            problems.
      __________                                              __________
     '          '                                            '          '
     '    A1    '                                            '    A1    '
@@ -209,7 +209,7 @@ follows A1.
     '  A2  C1  '                                            '  A2      '
     '__________'                                            '__________'
 
-Server A sends another message, A3:
+  Server A sends another message, A3:
 
      __________                                              __________
     '          '                                            '          '
@@ -220,7 +220,7 @@ Server A sends another message, A3:
     '    A3    '  /_matrix/federation/v1/send/{txnId}       '    A3    '
     '__________'  A3                                        '__________'
 
-Server B sees that A3 refers to the missing event C1, and pulls it from A:
+  Server B sees that A3 refers to missing event C1, and pulls it from A:
 
      __________                                              __________
     '          '                                            '          '
@@ -231,8 +231,8 @@ Server B sees that A3 refers to the missing event C1, and pulls it from A:
     '    A3    '  /_matrix/federation/v1/get_missing_events '    A3    '
     '__________'  C1                                        '__________'
 
-Typically, get_missing_events isn't needed, given servers push all events
-to all participating servers by default.
+  Typically, get_missing_events isn't needed, given servers push all
+  events to all participating servers by default.
 
    Figure 1
 


### PR DESCRIPTION
[Rendered](https://turt2live.github.io/ietf-mimi-matrix-transport/draft-ralston-mimi-matrix-transport.html) (latest IETF draft)

**This MSC is slightly different to other proposals in the Matrix spec process.** Instead of proposing changes to Matrix, it is proposing adoption of Matrix at the [IETF](https://www.ietf.org/) level. Comments raised against this MSC will be taken into consideration in two places: under the [MIMI](https://github.com/coopdanger/ietf-wg-mimi/blob/main/charter.md) working group and within the Matrix spec process where appropriate.

This MSC serves to show what the Spec Core Team/Matrix.org Foundation is thinking about with respect to modern messenger interoperability in the context of IETF.