### PR TITLE
MSC3997: Add timestamp massaging to `/createRoom`

### DIFF
--- a/proposals/3997-createroom-timestamp-massaging.md
+++ b/proposals/3997-createroom-timestamp-massaging.md
@@ -39,6 +39,11 @@ could be future considerations to opening this up to any client as it's kinda ar
 to restrict it this way and just seems like friction to try to get only people with good
 intentions using it.
 
+---
+
+Also related: [MSC3998](https://github.com/matrix-org/matrix-spec-proposals/pull/3998)
+proposes adding a `ts` querystring parameter to the `/join` and `/knock` endpoints but
+for different reasons.
 
 ## Potential issues
 


### PR DESCRIPTION
MSC3997: Add timestamp massaging to `/createRoom?ts=123`

---

[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/madlittlemods/createroom-timestamp-massaging/proposals/3997-createroom-timestamp-massaging.md)

Server implementations:

 - *Implementations needed*
 
Other related references:

 - Original MSC where timestamp massaging was introduced: [MSC3316](https://github.com/matrix-org/matrix-spec-proposals/pull/3316)
    - https://github.com/matrix-org/synapse/pull/2754
    - https://github.com/matrix-org/synapse/pull/11866
 - Synapse issue tracking `/createRoom` timestamp massaging proposed in this MSC: https://github.com/matrix-org/synapse/issues/15346
 - Related [MSC3998](https://github.com/matrix-org/matrix-spec-proposals/pull/3998) to add timestamp massaging to `/join` and `/knock`