### PR TITLE
MSC4146: Shared Message Drafts

### DIFF
--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -40,6 +40,8 @@ This could be done something like this, with a field to indicate what room it re
 }
 ```
 
+The format of the event should be somewhat compatible with clients that do not implement the MSC, so that in those clients the draft gets displayed as a message that the user could still manually copy or edit to also edit the draft. Theoretically there could be an extra field, say `m.draft_full_event` that contains a full event with intentional mentions, media and more, but this is an idea that I am still exploring.
+
 When a user is in multiple `m.drafts` rooms, the client should take whatever draft is chronologically the newest for a given room from any `m.drafts` room, unless there is two or more drafts with the same timestamp. When there is two or more drafts with the same timestamp, the client should give the user the option of which draft to keep, redacting the other drafts in whatever room the drafts are in.
 
 The Client should also only import it's own events when checking `m.drafts` rooms, unless explicitly requested otherwise by the user.

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -92,7 +92,7 @@ Proposed unstable prefixes for `m.drafts` and `m.draft_in` would be:
 | prefix                        | description                       |
 |-------------------------------|-----------------------------------|
 | `org.matrix.msc4146.drafts`   | For the room type                 |
-| `org.matrix.msc4146.draft_in` | For the actual events in the room |
+| `org.matrix.msc4146.draft_in` | For the room ID information on the events |
 
 ## Dependencies
 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -42,9 +42,6 @@ This could be done something like this, with a field to indicate what room it re
 
 ## Potential issues
 
-*Not all proposals are perfect. Sometimes there's a known disadvantage to implementing the proposal,
-and they should be documented here. There should be some explanation for why the disadvantage is
-acceptable, however - just like in this example.*
 
 There are some issues with both approaches, notably I thought of:
 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -40,15 +40,17 @@ This could be done something like this, with a field to indicate what room it re
 }
 ```
 
+When a user is in multiple `m.drafts` rooms, the client should take whatever draft is chronologically the newest for a given room from any `m.drafts` room, unless there is two or more drafts with the same timestamp. When there is two or more drafts with the same timestamp, the client should give the user the option of which draft to keep, redacting the other drafts in whatever room the drafts are in.
+
+The Client should also only import it's own events when checking `m.drafts` rooms, unless explicitly requested otherwise by the user.
+
 ## Potential issues
 
-
-There are some issues with both approaches, notably I thought of:
+There are some issues with this approach, notably I thought of:
 
 - If the room is encrypted to allow privacy for these drafts, then the drafts would be unavailable to a client that has just authenticated but has not been verified yet, and as such cannot get the keys for the messages in the room and decrypt any of the drafts.
 - Clients that do not support this MSC might display the drafts room normally, allowing the user to send arbitrary messages into the room, which might become messy. 
-- If a client removes the `m.draft_in` as part of an edit the draft would no longer be associated with a room, causing confusion on the users' end as to where their draft went.
-
+- If a client removes the `m.draft_in` as part of an edit the draft would no longer be associated with a room, causing confusion on the users' end as to where their draft went. 
 
 ## Alternatives
 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -1,38 +1,25 @@
 # MSC4146: Shared Message Drafts
 
-In Matrix, most clients support saving drafts, either in LocalStorage or some 
-other platform-specific storage so that you can come back to writing a message 
-later if you have not finished it, however this information does not carry over 
-between clients, meaning you can only continue your draft or send it on the 
-device that you initially started writing it in.
-
-This proposal aims to address that problem by sharing ideas on a mechanism to 
-share message drafts between devices, and serves as a place of discussion for 
-such a feature.
-
-This being my first MSC, without having read the entire spec there will be 
-mistakes and oversights I've made as to how Matrix operates and how a feature 
-like this may be implemented, so I'd very much appreciate some pointers or help 
-if I got anything wrong :)
+In Matrix, most clients support saving drafts, yet there is no way to share this
+data. This proposal outlines how such data could be shared.
 
 ## Proposal
 
-In Matrix, especially when used in work environments, there is often the need to 
-draft out a message before sending it out, like wanting someone else to 
-proofread it first, writing a message about an ongoing event, or a plethora of 
-other scenarios where a message should just remain unsent until the time comes. 
-However the experience is frustrating because you are limited only to one 
-device, or even just one client on the same device. 
+There is often the need to draft out a message before sending it out, like
+wanting someone else to proofread it first, writing a message about an ongoing
+event, or a plethora of other scenarios where a message should just remain
+unsent until the time comes. However the experience is frustrating because you
+are limited only to one device, or even just one client on the same device.
 
-If you're ever in a situation where you want to send the message, edit it, or 
-maybe even delete the draft, you cannot do so without first going back to the 
-device you initially wrote it on. This means you cannot carry over a draft from 
-your Phone to your Computer to have a more comfortable typing experience, or to 
+If you're ever in a situation where you want to send the message, edit it, or
+maybe even delete the draft, you cannot do so without first going back to the
+device you initially wrote it on. This means you cannot carry over a draft from
+your Phone to your Computer to have a more comfortable typing experience, or to
 see the text on a bigger screen, and is generally just an inconvenience.
 
-My first idea would be to repurpose rooms, similar to how it's proposed for 
-Profiles-As-Rooms or how Spaces are implemented. A new room type, `m.drafts` or 
-`m.draft` would be added, allowing the client to differentiate this room from 
+My first idea would be to repurpose rooms, similar to how it's proposed for
+Profiles-As-Rooms or how Spaces are implemented. A new room type, `m.drafts` or
+`m.draft` would be added, allowing the client to differentiate this room from
 DMs, Spaces or Groups. A creation event could look something like this:
 
 ```json
@@ -46,15 +33,15 @@ DMs, Spaces or Groups. A creation event could look something like this:
 }
 ```
 
-In said room, the client would then send normal `m.text` events, optionally with 
-a formatted body, and would edit the message every ´n´ seconds or once the user 
-stops typing. <span style="color: grey">(This is more of a UI/UX implementation 
+In said room, the client would then send normal `m.text` events, optionally with
+a formatted body, and would edit the message every ´n´ seconds or once the user
+stops typing. <span style="color: grey">(This is more of a UI/UX implementation
 detail though)</span>
 
-Another thing that would be introduced would be a field that defines what room 
+Another thing that would be introduced would be a field that defines what room
 this is supposed to be for / In which room this draft was written
 
-This could be done something like this, with a field to indicate what room it 
+This could be done something like this, with a field to indicate what room it
 relates to:
 
 ```json
@@ -70,33 +57,45 @@ relates to:
 }
 ```
 
+The format of the event should be somewhat compatible with clients that do not
+implement the MSC, so that in those clients the draft gets displayed as a
+message that the user could still manually copy or edit to also edit the draft.
+Theoretically there could be an extra field, say `m.draft_full_event` that
+contains a full event with intentional mentions, media and more, but this is an
+idea that I am still exploring.
+
+When a user is in multiple `m.drafts` rooms, the client should take whatever
+draft is chronologically the newest for a given room from any `m.drafts` room,
+unless there is two or more drafts with the same timestamp. When there is two or
+more drafts with the same timestamp, the client should give the user the option
+of which draft to keep, redacting the other drafts in whatever room the drafts
+are in.
+
+The Client should also only import it's own events when checking `m.drafts`
+rooms, unless explicitly requested otherwise by the user.
+
 ## Potential issues
 
-*Not all proposals are perfect. Sometimes there's a known disadvantage to 
-implementing the proposal, and they should be documented here. There should be 
-some explanation for why the disadvantage is acceptable, however - just like in 
-this example.*
+There are some issues with this approach, notably I thought of:
 
-There are some issues with both approaches, notably I thought of:
-
-- If the room is encrypted to allow privacy for these drafts, then the drafts 
-would be unavailable to a client that has just authenticated but has not been 
-verified yet, and as such cannot get the keys for the messages in the room and 
-decrypt any of the drafts. 
-- Clients that do not support this MSC might display 
-the drafts room normally, allowing the user to send arbitrary messages into the 
-room, which might become messy. 
-- If a client removes the `m.draft_in` as part 
-of an edit the draft would no longer be associated with a room, causing 
+- If the room is encrypted to allow privacy for these drafts, then the drafts
+would be unavailable to a client that has just authenticated but has not been
+verified yet, and as such cannot get the keys for the messages in the room and
+decrypt any of the drafts.
+- Clients that do not support this MSC might display
+the drafts room normally, allowing the user to send arbitrary messages into the
+room, which might become messy.
+- If a client removes the `m.draft_in` as part
+of an edit the draft would no longer be associated with a room, causing
 confusion on the users' end as to where their draft went.
 
 ## Alternatives
 
-An alternative way to implement this would be to instead add this data to 
-account data, adding a field similar to what Element does with 
+An alternative way to implement this would be to instead add this data to
+account data, adding a field similar to what Element does with
 `io.element.recent_emoji`
 
-The field could be named something like `m.room_drafts` or `m.drafts` (just like 
+The field could be named something like `m.room_drafts` or `m.drafts` (just like
 the room type from idea #1) and could contain something like this:
 
 ```json
@@ -114,15 +113,15 @@ the room type from idea #1) and could contain something like this:
 
 This would cut the requirement for re-purposing a room (from what I understand).
 
-However, it would also mean that you cannot encrypt the drafts, and as such 
-these drafts would be leaked metadata that the server can read. This should be 
+However, it would also mean that you cannot encrypt the drafts, and as such
+these drafts would be leaked metadata that the server can read. This should be
 avoided as drafts can belong to an encrypted room, which you do not want leaked.
 
 ## Security considerations
 
-By implementing this by repurposing an **encrypted** room you can avoid the 
-drafts - and as such messages that might go into an encrypted room - being 
-leaked to the homeserver. Encryption for a feature like this is a goal that 
+By implementing this by repurposing an **encrypted** room you can avoid the
+drafts - and as such messages that might go into an encrypted room - being
+leaked to the homeserver. Encryption for a feature like this is a goal that
 should not be neglected.
 
 ## Unstable prefix
@@ -130,9 +129,9 @@ should not be neglected.
 Proposed unstable prefixes for `m.drafts` and `m.draft_in` would be:
 
 | prefix                        | description                       |
-| ----------------------------- | --------------------------------- |
+|-------------------------------|-----------------------------------|
 | `org.matrix.msc4146.drafts`   | For the room type                 |
-| `org.matrix.msc4146.draft_in` | For the actual events in the room |
+| `org.matrix.msc4146.draft_in` | For the room ID information on the events |
 
 ## Dependencies
 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -191,6 +191,7 @@ Proposed unstable prefixes for `m.drafts` and `m.draft_in` would be:
 |-------------------------------|-----------------------------------|
 | `org.matrix.msc4146.drafts`   | For the room type                 |
 | `org.matrix.msc4146.draft_in` | For the room ID information on the events |
+| `org.matrix.msc4146.draft_full_event` | For storing a full event alongside the normal message body or media |
 
 ## Dependencies
 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -1,4 +1,4 @@
-# MSCXXXX: Shared Message Drafts
+# MSC4146: Shared Message Drafts
 
 In Matrix, most clients support saving drafts, either in LocalStorage or some other platform-specific storage so that you can come back to writing a message later if you have not finished it, however this information does not carry over between clients, meaning you can only continue your draft or send it on the device that you initially started writing it in.
 
@@ -91,8 +91,8 @@ Proposed unstable prefixes for `m.drafts` and `m.draft_in` would be:
 
 | prefix                        | description                       |
 |-------------------------------|-----------------------------------|
-| `org.matrix.mscXXXX.drafts`   | For the room type                 |
-| `org.matrix.mscXXXX.draft_in` | For the actual events in the room |
+| `org.matrix.msc4146.drafts`   | For the room type                 |
+| `org.matrix.msc4146.draft_in` | For the actual events in the room |
 
 ## Dependencies
 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -2,11 +2,6 @@
 
 In Matrix, most clients support saving drafts, either in LocalStorage or some other platform-specific storage so that you can come back to writing a message later if you have not finished it, however this information does not carry over between clients, meaning you can only continue your draft or send it on the device that you initially started writing it in.
 
-This proposal aims to address that problem by sharing ideas on a mechanism to share message drafts between devices, and serves as a place of discussion for such a feature.
-
-This being my first MSC, without having read the entire spec there will be mistakes and oversights I've made as to how Matrix operates and how a feature like this may be implemented, so I'd very much appreciate some pointers or help if I got anything wrong :)
-
-
 ## Proposal
 
 In Matrix, especially when used in work environments, there is often the need to draft out a message before sending it out, like wanting someone else to proofread it first, writing a message about an ongoing event, or a plethora of other scenarios where a message should just remain unsent until the time comes. However the experience is frustrating because you are limited only to one device, or even just one client on the same device. 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -1,10 +1,10 @@
 # MSC4146: Shared Message Drafts
 
-In Matrix, most clients support saving drafts, either in LocalStorage or some other platform-specific storage so that you can come back to writing a message later if you have not finished it, however this information does not carry over between clients, meaning you can only continue your draft or send it on the device that you initially started writing it in.
+In Matrix, most clients support saving drafts, yet there is no way to share this data. This proposal outlines how such data could be shared.
 
 ## Proposal
 
-In Matrix, especially when used in work environments, there is often the need to draft out a message before sending it out, like wanting someone else to proofread it first, writing a message about an ongoing event, or a plethora of other scenarios where a message should just remain unsent until the time comes. However the experience is frustrating because you are limited only to one device, or even just one client on the same device. 
+There is often the need to draft out a message before sending it out, like wanting someone else to proofread it first, writing a message about an ongoing event, or a plethora of other scenarios where a message should just remain unsent until the time comes. However the experience is frustrating because you are limited only to one device, or even just one client on the same device. 
 
 If you're ever in a situation where you want to send the message, edit it, or maybe even delete the draft, you cannot do so without first going back to the device you initially wrote it on. This means you cannot carry over a draft from your Phone to your Computer to have a more comfortable typing experience, or to see the text on a bigger screen, and is generally just an inconvenience.
 

--- a/proposals/4146-Shared-Message-Drafts.md
+++ b/proposals/4146-Shared-Message-Drafts.md
@@ -1,4 +1,4 @@
-# MSCXXXX: Shared Message Drafts
+# MSC4146: Shared Message Drafts
 
 In Matrix, most clients support saving drafts, either in LocalStorage or some 
 other platform-specific storage so that you can come back to writing a message 
@@ -131,8 +131,8 @@ Proposed unstable prefixes for `m.drafts` and `m.draft_in` would be:
 
 | prefix                        | description                       |
 | ----------------------------- | --------------------------------- |
-| `org.matrix.mscXXXX.drafts`   | For the room type                 |
-| `org.matrix.mscXXXX.draft_in` | For the actual events in the room |
+| `org.matrix.msc4146.drafts`   | For the room type                 |
+| `org.matrix.msc4146.draft_in` | For the actual events in the room |
 
 ## Dependencies
 

--- a/proposals/MSCXXXX-Shared-Message-Drafts.md
+++ b/proposals/MSCXXXX-Shared-Message-Drafts.md
@@ -1,0 +1,99 @@
+# MSCXXXX: Shared Message Drafts
+
+In Matrix, most clients support saving drafts, either in LocalStorage or some other platform-specific storage so that you can come back to writing a message later if you have not finished it, however this information does not carry over between clients, meaning you can only continue your draft or send it on the device that you initially started writing it in.
+
+This proposal aims to address that problem by sharing ideas on a mechanism to share message drafts between devices, and serves as a place of discussion for such a feature.
+
+This being my first MSC, without having read the entire spec there will be mistakes and oversights I've made as to how Matrix operates and how a feature like this may be implemented, so I'd very much appreciate some pointers or help if I got anything wrong :)
+
+
+## Proposal
+
+In Matrix, especially when used in work environments, there is often the need to draft out a message before sending it out, like wanting someone else to proofread it first, writing a message about an ongoing event, or a plethora of other scenarios where a message should just remain unsent until the time comes. However the experience is frustrating because you are limited only to one device, or even just one client on the same device. 
+
+If you're ever in a situation where you want to send the message, edit it, or maybe even delete the draft, you cannot do so without first going back to the device you initially wrote it on. This means you cannot carry over a draft from your Phone to your Computer to have a more comfortable typing experience, or to see the text on a bigger screen, and is generally just an inconvenience.
+
+My first idea would be to repurpose rooms, similar to how it's proposed for Profiles-As-Rooms or how Spaces are implemented. A new room type, `m.drafts` or `m.draft` would be added, allowing the client to differentiate this room from DMs, Spaces or Groups. A creation event could look something like this:
+
+```json
+{
+  "content": {
+    "creator": "@example:example.com",
+    "room_version": "9",
+    "type": "m.drafts"
+  },
+  ...
+}
+```
+
+In said room, the client would then send normal `m.text` events, optionally with a formatted body, and would edit the message every ´n´ seconds or once the user stops typing. <span style="color: grey">(This is more of a UI/UX implementation detail though)</span>
+
+Another thing that would be introduced would be a field that defines what room this is supposed to be for / In which room this draft was written
+
+This could be done something like this, with a field to indicate what room it relates to:
+
+```json
+{
+  "type": "m.room.message",
+  "content": {
+    "msgtype": "m.text",
+    "body": "**test!!!**",
+    "format": "org.matrix.custom.html",
+    "formatted_body": "<strong>test!!!</strong>",
+    "m.draft_in": "!ROOMID:example.com"
+  }
+}
+```
+
+## Potential issues
+
+*Not all proposals are perfect. Sometimes there's a known disadvantage to implementing the proposal,
+and they should be documented here. There should be some explanation for why the disadvantage is
+acceptable, however - just like in this example.*
+
+There are some issues with both approaches, notably I thought of:
+
+- If the room is encrypted to allow privacy for these drafts, then the drafts would be unavailable to a client that has just authenticated but has not been verified yet, and as such cannot get the keys for the messages in the room and decrypt any of the drafts.
+- Clients that do not support this MSC might display the drafts room normally, allowing the user to send arbitrary messages into the room, which might become messy. 
+- If a client removes the `m.draft_in` as part of an edit the draft would no longer be associated with a room, causing confusion on the users' end as to where their draft went.
+
+
+## Alternatives
+
+An alternative way to implement this would be to instead add this data to account data, adding a field similar to what Element does with `io.element.recent_emoji`
+
+The field could be named something like `m.room_drafts` or `m.drafts` (just like the room type from idea #1) and could contain something like this:
+
+```json
+{
+  "type": "m.room_drafts",
+  "content": {
+    "!ROOMID:example.com": {
+      "body": "**test!**",
+      "format": "org.matrix.custom.html",
+      "formatted_body": "<strong>test!!!</strong>"
+    }
+  }
+}
+```
+
+This would cut the requirement for re-purposing a room (from what I understand).
+
+However, it would also mean that you cannot encrypt the drafts, and as such these drafts would be leaked metadata that the server can read. This should be avoided as drafts can belong to an encrypted room, which you do not want leaked.
+
+## Security considerations
+
+By implementing this by repurposing an **encrypted** room you can avoid the drafts - and as such messages that might go into an encrypted room - being leaked to the homeserver. Encryption for a feature like this is a goal that should not be neglected.
+
+## Unstable prefix
+
+Proposed unstable prefixes for `m.drafts` and `m.draft_in` would be:
+
+| prefix                        | description                       |
+|-------------------------------|-----------------------------------|
+| `org.matrix.mscXXXX.drafts`   | For the room type                 |
+| `org.matrix.mscXXXX.draft_in` | For the actual events in the room |
+
+## Dependencies
+
+Not Applicable


### PR DESCRIPTION
[Rendered](https://github.com/cyrneko/matrix-spec-proposals/blob/shared-message-drafts/proposals/4146-Shared-Message-Drafts.md)

This MSC proposes a way to share message drafts between clients, to edit and/or send them on clients they weren't initially written in.

Signed off by: Simon Müller (simeonlps@proton.me)