### PR TITLE
MSC4164: Leave all rooms on deactivation

### DIFF
--- a/proposals/4164-leave-all-rooms-on-deactivation.md
+++ b/proposals/4164-leave-all-rooms-on-deactivation.md
@@ -1,9 +1,5 @@
 # MSC4164: Leave all rooms on deactivation
 
-There can never be enough templates in the world, and MSCs shouldn't be any different. The level
-of detail expected of proposals can be unclear - this is what this example proposal (which doubles
-as a template itself) aims to resolve.
-
 When an account is
 [deactivated](https://spec.matrix.org/v1.11/client-server-api/#post_matrixclientv3accountdeactivate),
 it removes all ability for the user to login again. However, as the account is not removed from rooms


### PR DESCRIPTION
While most servers already do this, I think it would be good to actually recommend this in the spec directly, so that future servers know to implement this as well.

[Rendered](https://github.com/Kladki/matrix-spec-proposals/blob/leave-all-rooms-on-deactivation/proposals/4164-leave-all-rooms-on-deactivation.md)

Implementations:
- Synapse: https://github.com/matrix-org/synapse/pull/3201
- Dendrite: https://github.com/matrix-org/dendrite/pull/2545
- Conduit: https://gitlab.com/famedly/conduit/-/commit/b81939841b272206991041ce7643a1c572590db3