### PR TITLE
MSC4268: Sharing room keys for past messages

### DIFF
--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -135,7 +135,7 @@ The plaintext content of such a message should be:
 The properties within the `content` are defined as:
 
  * `room_id`: the room to which the keys in the key bundle relate. (This is
-   required so that Bob can download the key bundle at the right time.)
+   required so that Bob can defer downloading the bundle until he joins the room.)
 
  * `file`: `EncryptedFile` from the [encrypted attachment
    format](https://spec.matrix.org/v1.13/client-server-api/#extensions-to-mroommessage-msgtypes).

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -27,6 +27,9 @@ future members of the room should have access to. Specifically, those are the
 megolm sessions associated with that room which were marked with
 `shared_history`: see [below](#shared_history-property-in-mroom_key-events).
 
+It is RECOMMENDED that Alice first makes sure she has downloaded any keys for
+the relevant room from the server-side key storage.
+
 The keys are assembled into a JSON object with the following structure:
 
 ```json5

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -337,7 +337,7 @@ this problem:
   practical questions. For example:
 
   * should the store be populated by all users, or just admins? If the former,
-    what if a mischeivous user uploads incorrect keys? If the latter, what if
+    what if a mischievous user uploads incorrect keys? If the latter, what if
     no admins are online?
 
   * What happens if there are users on multiple servers: do we need to

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -93,7 +93,6 @@ The details of this key bundle are then shared with Bob, as below.
 Having uploaded the encrypted key bundle, Alice must share the details with each of Bob's devices.
 
 She first ensures she has an up-to-date list of his devices (performing a
-
 [`/keys/query`](https://spec.matrix.org/v1.17/client-server-api/#post_matrixclientv3keysquery)
 request if necessary). She then sends a to-device message to each of his devices
 **which are correctly signed by his cross-signing keys**.
@@ -161,7 +160,7 @@ messages with Charlie. However, it is dangerous for Bob to take the server's
 word for the history visibility setting: a malicious server admin collaborating
 with Charlie could tell Bob that the history visibility was open when in fact
 it was restricted. In addition, the history visibility in a given room may have
-been changed over time and it can be difficult for clients to estalish which
+been changed over time and it can be difficult for clients to establish which
 setting was in force for a particular Megolm session.
 
 To counter this, we add a `shared_history` property to
@@ -365,7 +364,7 @@ These alternatives are also discussed in a presentation made at Matrix Conferenc
   the user does not have a copy of the session decryption key and it is safe to
   continue using the same session.
 
-  This latter is no longer a valid assumption.
+  The latter is no longer a valid assumption.
 
   TODO: how to solve this? https://github.com/element-hq/element-meta/issues/3078.
 

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -238,6 +238,9 @@ have the `shared_history` flag set (which means that the creator of that
 session believed that the room history visibility did not allow new members to
 access history).
 
+The `m.history_not_shared` withheld code SHOULD NOT be used in
+`m.room_key.withheld` messages, since they would not be meaningful there.
+
 * Aside: the spec currently contains a definition for a `withheld` code
   `m.unauthorised`. However, its semantics are unclear: the spec defines it as
   meaning "the user/device is not allowed to have the key", but is unclear
@@ -259,7 +262,7 @@ access history).
   used in non-Element clients.
 
   In short, a new code is likely to cause less confusion than repurposing
-  `m.unauthorised`,
+  `m.unauthorised`.
 
 ### Actions as a receiving client
 

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -72,7 +72,7 @@ The properties in the object are defined as:
 
  * `withheld`: an array of objects with the same format as the content of an
    [`m.room_key.withheld`](https://spec.matrix.org/v1.14/client-server-api/#mroom_keywithheld)
-   messsage, usually with code `m.unauthorised` to indicate that the recipient
+   message, usually with code `m.unauthorised` to indicate that the recipient
    isn't allowed to receive the key.
 
 A single session MUST NOT appear in both the `room_keys` and `withheld` sections.
@@ -219,7 +219,7 @@ For example:
 In all cases, an absent or non-boolean `shared_history` property is treated the same as
 `shared_history: false`.
 
-### Actions as a receving client
+### Actions as a receiving client
 
 When Bob's client receives an `m.room_key_bundle` event from Alice, there are two possibilities:
 

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -1,0 +1,117 @@
+# MSC0000: Template for new MSCs
+
+*Note: Text written in italics represents notes about the section or proposal process. This document
+serves as an example of what a proposal could look like (in this case, a proposal to have a template)
+and should be used where possible.*
+
+*In this first section, be sure to cover your problem and a broad overview of the solution. Covering
+related details, such as the expected impact, can also be a good idea. The example in this document
+says that we're missing a template and that things are confusing and goes on to say the solution is
+a template. There's no major expected impact in this proposal, so it doesn't list one. If your proposal
+was more invasive (such as proposing a change to how servers discover each other) then that would be
+a good thing to list here.*
+
+*If you're having troubles coming up with a description, a good question to ask is "how
+does this proposal improve Matrix?" - the answer could reveal a small impact, and that is okay.*
+
+There can never be enough templates in the world, and MSCs shouldn't be any different. The level
+of detail expected of proposals can be unclear - this is what this example proposal (which doubles
+as a template itself) aims to resolve.
+
+
+## Proposal
+
+*Here is where you'll reinforce your position from the introduction in more detail, as well as cover
+the technical points of your proposal. Including rationale for your proposed solution and detailing
+why parts are important helps reviewers understand the problem at hand. Not including enough detail
+can result in people guessing, leading to confusing arguments in the comments section. The example
+here covers why templates are important again, giving a stronger argument as to why we should have
+a template. Afterwards, it goes on to cover the specifics of what the template could look like.*
+
+Having a default template that everyone can use is important. Without a template, proposals would be
+all over the place and the minimum amount of detail may be left out. Introducing a template to the
+proposal process helps ensure that some amount of consistency is present across multiple proposals,
+even if each author decides to abandon the template.
+
+The default template should be a markdown document because the MSC process requires authors to write
+a proposal in markdown. Using other formats wouldn't make much sense because that would prevent authors
+from copy/pasting the template.
+
+The template should have the following sections:
+
+* **Introduction** - This should cover the primary problem and broad description of the solution.
+* **Proposal** - The gory details of the proposal.
+* **Potential issues** - This is where problems with the proposal would be listed, such as changes
+  that are not backwards compatible.
+* **Alternatives** - This section lists alternative solutions to the same
+  problem which have been considered and dismsissed.
+* **Security considerations** - Discussion of what steps were taken to avoid security issues in the
+  future and any potential risks in the proposal.
+
+Furthermore, the template should not be required to be followed. However it is strongly recommended to
+maintain some sense of consistency between proposals.
+
+
+## Potential issues
+
+*Not all proposals are perfect. Sometimes there's a known disadvantage to implementing the proposal,
+and they should be documented here. There should be some explanation for why the disadvantage is
+acceptable, however - just like in this example.*
+
+Someone is going to have to spend the time to figure out what the template should actually have in it.
+It could be a document with just a few headers or a supplementary document to the process explanation,
+however more detail should be included. A template that actually proposes something should be considered
+because it not only gives an opportunity to show what a basic proposal looks like, it also means that
+explanations for each section can be described. Spending the time to work out the content of the template
+is beneficial and not considered a significant problem because it will lead to a document that everyone
+can follow.
+
+
+## Alternatives
+
+*This is where alternative solutions could be listed. There's almost always another way to do things
+and this section gives you the opportunity to highlight why those ways are not as desirable. The
+argument made in this example is that all of the text provided by the template could be integrated
+into the proposals introduction, although with some risk of losing clarity.*
+
+Instead of adding a template to the repository, the assistance it provides could be integrated into
+the proposal process itself. There is an argument to be had that the proposal process should be as
+descriptive as possible, although having even more detail in the proposals introduction could lead to
+some confusion or lack of understanding. Not to mention if the document is too large then potential
+authors could be scared off as the process suddenly looks a lot more complicated than it is. For those
+reasons, this proposal does not consider integrating the template in the proposals introduction a good
+idea.
+
+
+## Security considerations
+
+**All proposals must now have this section, even if it is to say there are no security issues.**
+
+*Think about how to attack your proposal, using lists from sources like
+[OWASP Top Ten](https://owasp.org/www-project-top-ten/) for inspiration.*
+
+*Some proposals may have some security aspect to them that was addressed in the proposed solution. This
+section is a great place to outline some of the security-sensitive components of your proposal, such as
+why a particular approach was (or wasn't) taken. The example here is a bit of a stretch and unlikely to
+actually be worthwhile of including in a proposal, but it is generally a good idea to list these kinds
+of concerns where possible.*
+
+MSCs can drastically affect the protocol. The authors of MSCs may not have a security background. If they
+do not consider vulnerabilities with their design, we rely on reviewers to consider vulnerabilities. This
+is easy to forget, so having a mandatory 'Security Considerations' section serves to nudge reviewers
+into thinking like an attacker.
+
+## Unstable prefix
+
+*If a proposal is implemented before it is included in the spec, then implementers must ensure that the
+implementation is compatible with the final version that lands in the spec. This generally means that
+experimental implementations should use `/unstable` endpoints, and use vendor prefixes where necessary.
+For more information, see [MSC2324](https://github.com/matrix-org/matrix-doc/pull/2324). This section
+should be used to document things such as what endpoints and names are being used while the feature is
+in development, the name of the unstable feature flag to use to detect support for the feature, or what
+migration steps are needed to switch to newer versions of the proposal.*
+
+## Dependencies
+
+This MSC builds on MSCxxxx, MSCyyyy and MSCzzzz (which at the time of writing have not yet been accepted
+into the spec).

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -293,7 +293,7 @@ be when importing a key export; however:
 
   * Only keys for the relevant room should be imported.
 
-  * Bob's client should remember who sent the keys (Alice, in this case), and
+  * Bob's client should remember who he received the keys from (Alice, in this case), and
     MUST show that information to the user, since he has only that user's word
     for the authenticity of those sessions.
 
@@ -391,7 +391,7 @@ These alternatives are also discussed in a presentation made at Matrix Conferenc
 
   The latter is no longer a valid assumption. Instead, clients MUST observe
   changes in state in the room, and whenever they see a user leaving the room,
-  assume that the departed user may have access to any existing Megol session,
+  assume that the departed user may have access to any existing Megolm session,
   and create a new session before sending further encrypted messages.
 
   Note that, in a `limited` sync, clients must treat any membership event with a

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -79,7 +79,9 @@ The properties in the object are defined as:
    [below](#new-withheld-code)) to indicate that the recipient isn't allowed to
    receive the key.
 
-A single session MUST NOT appear in both the `room_keys` and `withheld` sections.
+A single session MUST NOT appear in both the `room_keys` and `withheld`
+sections. Handling such malformed bundles as a receiving client is
+implementation-defined.
 
 The JSON object is then encrypted using the same algorithm as [encrypted
 attachments](https://spec.matrix.org/v1.17/client-server-api/#sending-encrypted-attachments)
@@ -273,7 +275,11 @@ When Bob's client receives an `m.room_key_bundle` event from Alice, there are tw
    however, that this process must be resilient to Bob's client being restarted
    before the download/import completes.
 
-   TODO: what does "recently" mean?
+   The definition of "recently" is left up to clients. (They should consider
+   balancing the needs of (a) a user that closes their client just after
+   joining a room but before the bundle is imported, against (b) the
+   overhead of attempting to download a key bundle on every
+   startup. Element-Web and `matrix-rust-sdk` use a value of 24 hours.)
 
  * Otherwise, Bob's client should store the details of the key bundle but not
    download it immediately.  If he later accepts an invite to the room from
@@ -294,8 +300,9 @@ be when importing a key export; however:
 ### Out-of-scope (for now, at least)
 
 * Ideally, the bundle would be deleted once the recipient has successfully
-  downloaded it. An implementation is left for a future MSC. This is tracked at
-  https://github.com/matrix-org/matrix-rust-sdk/issues/5113.
+  downloaded it. An implementation is left for a future MSC, such as
+  [MSC4425](https://github.com/matrix-org/matrix-spec-proposals/pull/4425). This
+  is tracked at https://github.com/matrix-org/matrix-rust-sdk/issues/5113.
 
 * In future, we will need to extend the
   [`BackedUpSessionData`](https://spec.matrix.org/v1.17/client-server-api/#definition-backedupsessiondata)
@@ -311,6 +318,21 @@ be when importing a key export; however:
 * As noted in the "Security considerations" section below, current
   implementations make assumptions about when it is necessary to rotate
   outgoing megolm sessions that are no longer sufficient.
+
+* It might be relatively easy to be tricked by a malicious user into downloading
+  a (potentially very large) key bundle. It's possible that we will need to add
+  a mechanism for warning the user about this in the future. In the meantime,
+  the risk is mitigated by the fact that the key bundle size is limited by the
+  homeserver's media size limit.
+
+* Users may experience unexpected failures when sending invites because they
+  have reached a limit in their media quota, or may be surprised to discover
+  that they have used their entire media quota by inviting people to encrypted
+  rooms.
+
+  [MSC4425](https://github.com/matrix-org/matrix-spec-proposals/pull/4425)
+  may help with this in the future, for example by force-expiring ephemeral
+  media.
 
 ## Alternatives
 
@@ -385,6 +407,15 @@ These alternatives are also discussed in a presentation made at Matrix Conferenc
   records of cross-signing keys seen for each user, and if a change is
   observed, consider this a red flag suggesting that the account may be
   compromised and confirm with the user.
+
+* Similarly, users need to be particularly careful when sending room invites
+  that the recipient of an invite is in fact the intended user: leaking
+  encryption keys to a typo-squatter could be catastrophic, for example.
+
+  Clients might consider warning users before they send an invite to a user
+  that they haven't previously interacted with. (This is tracked for the
+  Element clients at
+  [element-meta#3163](https://github.com/element-hq/element-meta/issues/3163).)
 
 * Recipients must be mindful that there is no authoritative evidence of the
   sender of messages decrypted using a room key bundle: a malicious (or buggy)

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -389,9 +389,14 @@ These alternatives are also discussed in a presentation made at Matrix Conferenc
   the user does not have a copy of the session decryption key and it is safe to
   continue using the same session.
 
-  The latter is no longer a valid assumption.
+  The latter is no longer a valid assumption. Instead, clients MUST observe
+  changes in state in the room, and whenever they see a user leaving the room,
+  assume that the departed user may have access to any existing Megol session,
+  and create a new session before sending further encrypted messages.
 
-  TODO: how to solve this? https://github.com/element-hq/element-meta/issues/3078.
+  Note that, in a `limited` sync, clients must treat any membership event with a
+  membership other than `join` as an indication that the affected user may have
+  joined and left the room.
 
 * The proposed mechanism allows clients to share the decryption keys for
   significant amounts of encrypted content. Sharing historical keys in this way

--- a/proposals/4268-encrypted-history-sharing.md
+++ b/proposals/4268-encrypted-history-sharing.md
@@ -297,6 +297,12 @@ be when importing a key export; however:
     MUST show that information to the user, since he has only that user's word
     for the authenticity of those sessions.
 
+Client implementations should note that server implementations may delete or
+expire old media that appears unused. They must therefore gracefully handle
+download failures due to the key bundle having expired (typically by just giving up
+on the attempt to download the bundle, though they could also warn the
+user.)
+
 ### Out-of-scope (for now, at least)
 
 * Ideally, the bundle would be deleted once the recipient has successfully
@@ -333,6 +339,10 @@ be when importing a key export; however:
   [MSC4425](https://github.com/matrix-org/matrix-spec-proposals/pull/4425)
   may help with this in the future, for example by force-expiring ephemeral
   media.
+
+* In theory, the key bundle could exceed the maximum size of media item that is
+  permitted by either the inviting user's homeserver, or the joining user's
+  homeserver.
 
 ## Alternatives
 


### PR DESCRIPTION
A proposal for sharing the keys to existing room messages when inviting someone to a room.

This reintroduces the functionality previously proposed in MSC3061.

Conflict of Interest declaration: I am employed by Element. This MSC was written as part of my work on the Element Cryptography team.

The functionality discussed here is implemented in current versions of Element Web and Element X.

[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposal/encrypted_history_sharing/proposals/4268-encrypted-history-sharing.md)


[MSC checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/4268#issuecomment-4040658330)
[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4268#issuecomment-4040661140)
