### PR TITLE
MSC4308: Thread Subscriptions extension to Sliding Sync

### DIFF
--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -128,7 +128,9 @@ URL parameters:
   If this token is not provided, then backpagination starts from the 'end'.
 
 - `to` (string, optional): a token used to limit the backpagination \
-  The token can be acquired from a Sliding Sync response.
+  The token, originally acquired from `pos` in a Sliding Sync response,
+  would be the same one used as the `pos` **request** parameter in the
+  Sliding Sync request that returned the `prev_batch`.
 
 - `limit` (int, optional; default `100`): a maximum number of thread subscriptions to fetch
   in one response. \

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -196,6 +196,8 @@ above they do not have any special meaning.
 Notably, `bump_stamp`s MUST NOT be compared between different threads, because servers MAY
 treat `bump_stamp`s as per-thread.
 
+`bump_stamp` MUST be an ECMAScript-compatible (Canonical JSON-compatible) integer.
+
 `bump_stamp`s are independent of the sliding sync session and remain valid for comparison
 even if the sliding sync connection is reset, or if the device is changed.
 Servers do not need to make `bump_stamp`s consistent across different users.

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -30,6 +30,8 @@ The Sliding Sync request format is extended to include the `thread_subscriptions
 
     // Used to opt-in to receiving changes to thread subscriptions.
     "thread_subscriptions": {
+      // Must be specified and true to enable the extension.
+      "enabled": true,
       // Maximum number of thread subscription changes to receive
       // in the response.
       // Defaults to 100.

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -196,6 +196,10 @@ above they do not have any special meaning.
 Notably, `bump_stamp`s MUST NOT be compared between different threads, because servers MAY
 treat `bump_stamp`s as per-thread.
 
+`bump_stamp`s are independent of the sliding sync session and remain valid for comparison
+even if the sliding sync connection is reset, or if the device is changed.
+Servers do not need to make `bump_stamp`s consistent across different users.
+
 ## Potential issues
 
 

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -142,7 +142,7 @@ Response body:
   },
   // If there are still more thread subscriptions to fetch,
   // a new `from` token the client can use to walk further
-  // backwards.
+  // backwards. (The `to` token, if used, should be reused.)
   "end": "OPAQUE_TOKEN"
 }
 ```

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -109,7 +109,7 @@ URL parameters:
 
 Response body:
 
-```
+```jsonc
 {
   // Required
   "chunk": {

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -72,16 +72,18 @@ The response format is then extended to compensate:
         // ...
       },
 
-      // A pair of tokens that can be used to backpaginate other thread subscription
+      // A token that can be used to backpaginate other thread subscription
       // changes that occurred since the last sync, but that were not
       // included in this response.
       //
-      // The tokens are to be used with the `/thread_subscriptions` endpoint
-      // as `from` and `to` parameters with `dir=b`.
+      // The token is to be used with the `/thread_subscriptions` endpoint
+      // as `from`, with `dir`=`b`.
+      // The `pos` parameter in the **request** would be used for the `to`
+      // parameter.
       //
       // Only present when some thread subscriptions have been missed out
       // from the response because there are too many of them.
-      "prev": {"from": "OPAQUE_TOKEN", "to": "OPAQUE_TOKEN"}
+      "prev_batch": "OPAQUE_TOKEN"
     }
   }
 }
@@ -105,7 +107,7 @@ URL parameters:
 
 - `from` (string, optional): a token used to continue backpaginating \
   The token is either acquired from a previous `/thread_subscriptions` response,
-  or a Sliding Sync response. \
+  or the `prev_batch` in a Sliding Sync response. \
   The token is opaque and has no client-discernible meaning. \
   If this token is not provided, then backpagination starts from the 'end'.
 
@@ -149,11 +151,12 @@ Response body:
 
 If two changes occur to the same subscription, only the latter change ever needs
 to be sent to the client. \
-Servers do not need to store intermediate subscription states.
+Servers MUST not send intermediate subscription states to clients.
 
 The pagination structure of this endpoint matches that of the `/messages` endpoint, but fixed
 to the backward direction (`dir=b`).
 For simplicity, the `start` response field is removed as it is entirely redundant.
+
 
 ## Potential issues
 

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -159,7 +159,7 @@ Servers do not need to store intermediate subscription states.
 
 Whilst this proposal is unstable, a few unstable prefixes must be observed by experimental implementations:
 
-- the Sliding Sync extension is called `io.element.msc4306.thread_subscriptions` instead of `thread_subscriptions`
+- the Sliding Sync extension is called `io.element.msc4308.thread_subscriptions` instead of `thread_subscriptions`
 - the companion endpoint is called `/_matrix/client/unstable/io.element.msc4308/thread_subscriptions` instead of `/_matrix/v1/thread_subscriptions`
 
 

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -95,7 +95,7 @@ Servers do not need to store intermediate subscription states.
 ### Companion endpoint for backpaginating thread subscription changes
 
 ```
-GET /_matrix/v1/thread_subscriptions
+GET /_matrix/client/v1/thread_subscriptions
 ```
 
 URL parameters:
@@ -173,7 +173,7 @@ For simplicity, the `start` response field is removed as it is entirely redundan
 Whilst this proposal is unstable, a few unstable prefixes must be observed by experimental implementations:
 
 - the Sliding Sync extension is called `io.element.msc4308.thread_subscriptions` instead of `thread_subscriptions`
-- the companion endpoint is called `/_matrix/client/unstable/io.element.msc4308/thread_subscriptions` instead of `/_matrix/v1/thread_subscriptions`
+- the companion endpoint is called `/_matrix/client/unstable/io.element.msc4308/thread_subscriptions` instead of `/_matrix/client/v1/thread_subscriptions`
 
 
 ## Dependencies

--- a/proposals/4308-sliding-sync-ext-thread-subscriptions.md
+++ b/proposals/4308-sliding-sync-ext-thread-subscriptions.md
@@ -1,0 +1,94 @@
+MSC4308: Thread Subscriptions extension to Sliding Sync
+===
+
+## Background and Summary
+
+Threads were introduced in [version 1.4 of the Matrix Specification](https://spec.matrix.org/v1.13/changelog/v1.4/) as a way to isolate conversations in a room, making it easier for users to track specific conversations that they care about (and ignore those that they do not).
+
+Threads Subscriptions are proposed in [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md) as a way for users to efficiently indicate which threads they care about, for the purposes of receiving updates.
+
+Sliding Sync is proposed in [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/blob/erikj/sss/proposals/4186-simplified-sliding-sync.md) as a paginated replacement to `/_matrix/client/v3/sync` with smaller response bodies and lower latency.
+The `/_matrix/client/v3/sync` endpoint is notorious in real-world applications of Matrix for producing large response bodies (to the amplified detriment of mobile clients) and the high latency caused by waiting for the server to calculate that full payload.
+
+This MSC proposes an 'extension' to Sliding Sync that allows clients to opt-in to receiving updates to the user's thread subscriptions.
+
+## Proposal
+
+The Sliding Sync request format is extended to include the `thread_subscriptions` extension as follows:
+
+```jsonc
+{
+  // ...
+  
+  "extensions": {
+    // ...
+    
+    // Used to opt-in to receiving updates to thread subscriptions.
+    "thread_subscriptions": {
+      // Maximum number of thread subscription changes to receive.
+      // Defaults to 100.
+      "limit": 100,
+    }
+  }
+}
+```
+
+The response format is then extended to compensate:
+
+```jsonc
+{
+  // ...
+  
+  "extensions": {
+    // ...
+    
+    // Returns a limited window of updates to thread subscriptions
+    "thread_subscriptions": {
+      "changed": [
+        {
+          "room_id": "!roomid:example.org",
+          "root_event_id": "$abc123",
+          
+          "subscribed": true,
+          
+          // must be present when subscribed is true,
+          // but must be absent when subscribed is false
+          "automatic": true
+        },
+        {
+          "room_id": "!roomid:example.org",
+          "root_event_id": "$def456",
+          
+          "subscribed": false
+        },
+        ...
+      ]
+    }
+  }
+}
+```
+
+## Potential issues
+
+When clients start a fresh sync with no initial state, it may be the case that there is a backlog of many thread_subscriptions to send down to the client.
+
+Servers MAY choose to return Thread Subscription Settings in an order that is more heuristically-useful to the client, such as 'most recently updated' or 'threads with most recent activity first', instead of 'oldest first'. This could be either for all Thread Subscriptions, or only the backlogged ones.
+
+## Alternatives
+
+
+## Limitations
+
+
+## Security considerations
+
+- No particular security issues anticipated.
+
+## Unstable prefix
+
+TODO
+
+## Dependencies
+
+- [MSC4186 Sliding Sync](https://github.com/matrix-org/matrix-spec-proposals/blob/erikj/sss/proposals/4186-simplified-sliding-sync.md)
+- [MSC4306 Threads Subscriptions](https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md)


### PR DESCRIPTION
Depends-on: #4186, #4306

[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_ssext_threadsubs/proposals/4308-sliding-sync-ext-thread-subscriptions.md)