### PR TITLE
MSC4312: Resetting cross-signing keys in the OAuth world

### DIFF
--- a/proposals/4312-x-signing-reset-with-nextgen-auth.md
+++ b/proposals/4312-x-signing-reset-with-nextgen-auth.md
@@ -20,8 +20,8 @@ documents these workarounds as a low-effort interim workaround until better solu
 
 Clients that have authenticated via the new [OAuth APIs] continue to use
 [`/_matrix/client/v3/keys/device_signing/upload`] to replace cross-signing keys. Homeservers
-continue to enforce UIA on the endpoint but MUST only use a single stage `m.oauth`[^1] together with
-a URL that points to the authorization server's account management UI.
+continue to enforce UIA on the endpoint with a flow containing a single stage `m.oauth`[^1] together
+with a URL that points to the authorization server's account management UI.
 
 ``` json5
 {


### PR DESCRIPTION
[Rendered](https://github.com/gematik/matrix-spec-proposals/blob/johannes/x-signing-reset-with-nextgen-auth/proposals/4312-x-signing-reset-with-nextgen-auth.md)

Implementations:

- Server
  - [x] Synapse: https://github.com/element-hq/synapse/pull/17509 (July 2024)
  - [x] MAS:
    - https://github.com/matrix-org/matrix-authentication-service/pull/2142
    - https://github.com/matrix-org/matrix-authentication-service/pull/2364
    - https://github.com/matrix-org/matrix-authentication-service/pull/3102
- Client:
  - [x] Element Web (supporting the new UIA stage): https://github.com/element-hq/matrix-react-sdk/pull/34
  - [x] Example of client that doesn't support the UIA stage working using the fallback:

https://github.com/user-attachments/assets/b7b42b9b-9963-46c1-9b7d-6fef4b7218c1


----

SCT Stuff:

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4312#issuecomment-3330366883)

[MSC checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/4312#issuecomment-3330352715)