### PR TITLE
Clarify capability behaviour with respect to avatar_url and displayname in MSC4133

### DIFF
--- a/proposals/4133-extended-profiles.md
+++ b/proposals/4133-extended-profiles.md
@@ -148,8 +148,7 @@ Clients MAY check for this capability before attempting to create or modify a pr
   (or all) changes, it SHOULD use the capability to advertise this, improving the client experience.
 
 - **When `enabled` is `false`**: Clients SHOULD expect to display profiles but NOT create or update
-  fields. Any attempt to do so SHOULD result in a `403 Forbidden` error. This does not affect
-  `avatar_url` and `displayname` fields, which are allowed for compatibility purposes.
+  fields. Any attempt to do so SHOULD result in a `403 Forbidden` error.
 
 - **When `enabled` is `true`**: Clients SHOULD allow users to create or update fields, except those
   keys listed in the `disallowed` array. Servers MAY specify an `allowed` array to allowlist fields


### PR DESCRIPTION
Discovered while writing the spec PR. See https://github.com/matrix-org/matrix-spec-proposals/pull/4133#discussion_r2254938551 for further details.

Process note: MSCs can receive clarification changes post-FCP, but anything materially different requires a new MSC. I believe this qualifies as clarification because it isn't core to the MSC and the implementation used for FCP does the behaviour described. SCT members are able to disagree and require a new MSC instead.
