### PR TITLE
MSC4335: M_USER_LIMIT_EXCEEDED error code

### DIFF
--- a/proposals/4335-user-limit-exceeded.md
+++ b/proposals/4335-user-limit-exceeded.md
@@ -21,7 +21,7 @@ This proposal adds a new [common error code]
 `M_USER_LIMIT_EXCEEDED` to the Matrix specification. This error code should be returned when a user has exceeded
 limits that are specifically associated with their account, such as:
 
-* **Storage quotas**: When a user has exceeded their allocated storage space for smedia uploads,
+* **Storage quotas**: When a user has exceeded their allocated storage space for media uploads,
   message history, or other persistent data.
 * **Resource limits**: When a user has reached their maximum number of allowed rooms, devices,
   or other account-scoped resources.
@@ -270,7 +270,7 @@ take start the action of upgrading.
 However, this led to [uncertainty](https://github.com/matrix-org/matrix-spec-proposals/pull/4335#discussion_r2582153412)
 about what exactly would happen when the button is pressed.
 
-To remove this uncertainty `increase_uri` was removed and the homserver gets to provide a single `info_uri` and it is
+To remove this uncertainty `increase_uri` was removed and the homeserver gets to provide a single `info_uri` and it is
 the responsibility of the homeserver to provide a UX that makes sense and is clear about what is happening.
 
 ## Dependencies


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/hughns/user-limit-exceeded/proposals/4335-user-limit-exceeded.md)

---
I am employed by Element to write this MSC on behalf of the Matrix Foundation for use on the [matrix.org homeserver](https://matrix.org/homeserver/about/). Hence the use of the `org.matrix` namespace on the unstable values.

## Implementations

- Server:
  - [x] Synapse: https://github.com/element-hq/synapse/pull/18876
- Client:
  - [x] Element Web: https://github.com/element-hq/element-web/pull/30738

In the prototype Element Web implementation when this error code is encountered for a file upload, it is rendered as follows for a soft limit:

<img width="809" height="297" alt="image" src="https://github.com/user-attachments/assets/72bab978-b800-4ae5-994a-66757b38168d" />

And like this for a hard limit:

<img width="810" height="282" alt="image" src="https://github.com/user-attachments/assets/35636ad3-0360-4ac6-812b-410531e1782b" />

## Customisation of clients for matrix.org homeserver

The Matrix.org Foundation has discussed with [Element Creations Limited](https://element.io) the possibility of having Element clients show a custom message when the `M_USER_LIMIT_EXCEEDED` error is received from the matrix.org homeserver. Element have agreed to this in principle.

If this MSC is accepted then the Foundation intends to request that other client developers consider implementing a similar customisation for the matrix.org homeserver. The purpose of this is to support the [funding of the matrix.org homeserver](https://matrix.org/blog/2025/06/funding-homeserver-premium/).

Whilst the exact design/form of this in Element is to be decided, the following illustrates the level of customisation that is anticipated. (For example, it might appear as feedback within the timeline instead of a modal)

In the case of a Free user encountering a limit that can be increased by upgrading to Premium:

<img width="812" height="301" alt="image" src="https://github.com/user-attachments/assets/f774a962-94a9-475d-8a1e-e6660b9dfb44" />

For a hard limit:

<img width="811" height="277" alt="image" src="https://github.com/user-attachments/assets/c703025c-7ae0-4db1-b489-d97bf0f95d84" />

---

SCT Stuff:

[MSC checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/4335#issuecomment-3391828661)

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4335#issuecomment-3391550751)