### PR TITLE
MSC4373: Server opt-out of specific EDU types

### DIFF
--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -34,7 +34,7 @@ If the EDU type is listed, and is set to `false`, any EDUs of that type
 SHOULD NOT be sent to the target homeserver. The target server MUST ignore
 EDUs of these types.
 
-If the EDU type is set to `true` or absent, the EDU SHOULD be sent to the target 
+If the EDU type is set to `true` or absent, the EDU MAY be sent to the target 
 homeserver, unless other factors disallow it (such as room ACLs, where that is
 relevant).
 

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -1,4 +1,4 @@
-# MSCXXXX: Server opt-out of specific EDU types
+# MSC4373: Server opt-out of specific EDU types
 
 Some servers may wish to not receive specific types of EDUs, such as presence, to
 cut down on the amount of bandwidth used (as an example).

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -36,6 +36,8 @@ SHOULD NOT be sent to the target homeserver.
 If the EDU type is set to `true`, the EDU MAY be sent to the target homeserver,
 unless other factors disallow it (such as room ACLs, where that is relevant).
 
+The endpoint response SHOULD be cached, for a week at maximum.
+
 ## Potential issues
 
 Older homeservers (or simply non-compliant ones) will still send unwanted EDUs,

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -14,15 +14,15 @@ The response for this endpoint is shaped like the following:
 ```json
 {
     "m.presence": false,
-    "m.typing": true,
-    "m.read": true
+    "m.receipt": true,
+    "m.typing": true
 }
 ```
 
 The allowed types are:
 * `m.presence`
+* `m.receipt`
 * `m.typing`
-* `m.read`
 
 Other types of EDUs (signing key updates, device lists, to-device messaging, etc)
 are likely unsafe to opt-out of.

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -27,7 +27,7 @@ The allowed types are:
 Other types of EDUs (signing key updates, device lists, to-device messaging, etc)
 are likely unsafe to opt-out of.
 
-This endpoint MUST NOT require authentication, but if provided, follow the normal
+This endpoint SHOULD NOT require authentication, but if provided, follow the normal
 verification process.
 
 If the EDU type is listed, and is set to `false`, any EDUs of that type

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -31,7 +31,8 @@ This endpoint SHOULD NOT require authentication, but if provided, follow the nor
 verification process.
 
 If the EDU type is listed, and is set to `false`, any EDUs of that type
-SHOULD NOT be sent to the target homeserver.
+SHOULD NOT be sent to the target homeserver. The target server MUST ignore
+EDUs of these types.
 
 If the EDU type is set to `true`, the EDU MAY be sent to the target homeserver,
 unless other factors disallow it (such as room ACLs, where that is relevant).

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -9,21 +9,32 @@ cut down on the amount of bandwidth used (as an example).
 
 This endpoint dictates what types of EDUs the server wishes to receive.
 
-The server should reply with a list of EDU types:
+The response for this endpoint is shaped like the following:
 
 ```json
 {
-    "read_receipts": true,
-    "presence": true,
-    "typing": true
+    "m.presence": false,
+    "m.typing": true,
+    "m.read": true
 }
 ```
 
-Other types of EDUs (signing key updates, device lists, to-device messaging)
-are likely unsafe to opt-out of and thus must not be included.
+The allowed types are:
+* `m.presence`
+* `m.typing`
+* `m.read`
 
-This endpoint should not require authentication as nothing too sensitive is
-revealed by having it as such.
+Other types of EDUs (signing key updates, device lists, to-device messaging, etc)
+are likely unsafe to opt-out of.
+
+This endpoint MUST NOT require authentication, but if provided, follow the normal
+verification process.
+
+If the EDU type is listed, and is set to `false`, any EDUs of that type
+SHOULD NOT be sent to the target homeserver.
+
+If the EDU type is set to `true`, the EDU MAY be sent to the target homeserver,
+unless other factors disallow it (such as room ACLs, where that is relevant).
 
 ## Potential issues
 

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -1,11 +1,11 @@
 # MSC4373: Server opt-out of specific EDU types
 
-Some servers may wish to not receive specific types of EDUs, such as presence, to
-cut down on the amount of bandwidth used (as an example).
+Some servers may wish to not receive specific types of EDUs, e.g. presence, to cut down
+on bandwidth usage.
 
 ## Proposal
 
-### `GET /_matrix/federation/v1/edutypes`
+### `GET /_matrix/federation/v1/query/edutypes`
 
 This endpoint dictates what types of EDUs the server wishes to receive.
 

--- a/proposals/4373-edu-types.md
+++ b/proposals/4373-edu-types.md
@@ -34,19 +34,28 @@ If the EDU type is listed, and is set to `false`, any EDUs of that type
 SHOULD NOT be sent to the target homeserver. The target server MUST ignore
 EDUs of these types.
 
-If the EDU type is set to `true`, the EDU MAY be sent to the target homeserver,
-unless other factors disallow it (such as room ACLs, where that is relevant).
+If the EDU type is set to `true` or absent, the EDU SHOULD be sent to the target 
+homeserver, unless other factors disallow it (such as room ACLs, where that is
+relevant).
 
-The endpoint response SHOULD be cached, for a week at maximum.
+The endpoint response SHOULD be cached. Servers SHOULD read the `Cache-Control`
+HTTP header, and max it out at a week, using a week if the header is absent
+or malformed.
 
 ## Potential issues
 
 Older homeservers (or simply non-compliant ones) will still send unwanted EDUs,
-although these can just be discarded.
+although these can just be ignored.
 
 ## Alternatives
 
-None.
+An explicit allowlist is recommended over allowing everything with a list of keys
+that SHOULD NOT be put in the list, to ensure important information in new EDU types
+is not ignored or not sent to homeservers.
+
+While the alternative design is more flexible, it introduces unnecessary risk by
+defaulting to allowing filtering of all EDU types, which is bad for the reasons
+described above.
 
 ## Security considerations
 

--- a/proposals/XXXX-edu-types.md
+++ b/proposals/XXXX-edu-types.md
@@ -1,0 +1,47 @@
+# MSCXXXX: Server opt-out of specific EDU types
+
+Some servers may wish to not receive specific types of EDUs, such as presence, to
+cut down on the amount of bandwidth used (as an example).
+
+## Proposal
+
+### `GET /_matrix/federation/v1/edutypes`
+
+This endpoint dictates what types of EDUs the server wishes to receive.
+
+The server should reply with a list of EDU types:
+
+```json
+{
+    "read_receipts": true,
+    "presence": true,
+    "typing": true
+}
+```
+
+Other types of EDUs (signing key updates, device lists, to-device messaging)
+are likely unsafe to opt-out of and thus must not be included.
+
+This endpoint should not require authentication as nothing too sensitive is
+revealed by having it as such.
+
+## Potential issues
+
+Older homeservers (or simply non-compliant ones) will still send unwanted EDUs,
+although these can just be discarded.
+
+## Alternatives
+
+None.
+
+## Security considerations
+
+None.
+
+## Unstable prefix
+
+`/_matrix/federation/unstable/io.fsky.vel/edutypes`
+
+## Dependencies
+
+None.


### PR DESCRIPTION
[Rendered](https://github.com/velikopter/matrix-spec-proposals/blob/edutypes/proposals/4373-edu-types.md)

Implementations:
- Server (setting value):
  - Continuwuity: https://forgejo.ellis.link/continuwuation/continuwuity/pulls/1137
  - Calyx: https://foundry.fsky.io/vel/calyx/src/commit/5ef3ca34986202931b4b73a53d026f524008947e/synapse/federation/transport/server/federation.py#L879
- Server (reading value):

Signed-off-by: Helix K <vel@riseup.net>