### PR TITLE
MSC4377: Clarify Image Pack Ordering

### DIFF
--- a/proposals/4377-clarify-image-pack-ordering.md
+++ b/proposals/4377-clarify-image-pack-ordering.md
@@ -13,6 +13,29 @@ Instead of an **empty object**, this MSC defines this object like so:
 
 - `order` **Optional, String**. Lexicographic ordering key.
 
+So for example, before:
+```
+{
+  "rooms": {
+    "!NasysSDfxKxZBzJJoE:matrix.org": {
+      "Nonexistent-Stickers": {}
+    },
+  }
+}
+```
+After:
+```
+{
+  "rooms": {
+    "!NasysSDfxKxZBzJJoE:matrix.org": {
+      "Nonexistent-Stickers": {
+        "order": "abcd"
+      }
+    },
+  }
+}
+```
+
 ### Sorting
 
 Clients can continue to use the image pack source priority defined in MSC2545, but within the sources that utilize `m.image_pack.rooms`, clients should sort the packs lexicographically by the `order` field.


### PR DESCRIPTION
[Rendered](https://github.com/Enovale/matrix-spec-proposals/blob/pack-order/proposals/4377-clarify-image-pack-ordering.md)

Author: @Enovale 

# Current Implementations

## Implements reordering UX
- None at the time of this edit

## Respects `order` field:
- This Cinny fork by @Enovale: https://github.com/cinnyapp/cinny/compare/dev...Enovale:cinny:dev