### PR TITLE
Proposal template: explicitly mention RFC 3552 in security section

### DIFF
--- a/proposals/0000-proposal-template.md
+++ b/proposals/0000-proposal-template.md
@@ -87,7 +87,7 @@ idea.
 
 **All proposals must now have this section, even if it is to say there are no security issues.**
 
-*Think about how to attack your proposal. See [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552)
+*Think about how to attack your proposal. See [RFC 3552](https://datatracker.ietf.org/doc/html/rfc3552)
 for things to think about, but in particular pay attention to lists from sources like
 [OWASP Top Ten](https://owasp.org/www-project-top-ten/) for inspiration.*
 


### PR DESCRIPTION
Just a small addition to https://github.com/matrix-org/matrix-spec-proposals/pull/4199: Let's not only mention [RFC3552](https://datatracker.ietf.org/doc/html/rfc3552) in `MSC_CHECKLIST.md` but also in `proposals/0000-proposal-template.md`