### PR TITLE
MSC4380: Invite blocking

### DIFF
--- a/proposals/4380-invite-blocking.md
+++ b/proposals/4380-invite-blocking.md
@@ -39,6 +39,13 @@ is invited:
 Any rejected requests should result in an HTTP 403 status code, with the Matrix
 error code `M_INVITE_BLOCKED`. This is a new error code.
 
+Note: in the case of `POST /createRoom`, it is possible for one of the invited users
+to be rejected whilst the room creation as a whole succeeds. This is an
+[existing problem](https://github.com/matrix-org/matrix-spec/issues/1951) in
+Matrix which we do not attempt to resolve here; we specify only that
+implementations should handle such rejections similarly to other failed
+invites.
+
 In addition, existing events already in the database MUST NOT be served over client synchronisation endpoints such as
 [`GET
 /_matrix/client/v3/sync`](https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3sync)


### PR DESCRIPTION
An alternative to MSC4155.

Written wearing my Spec Core Team hat, in an attempt to unblock the situation that `matrix.org` and Element-Web have implemented an unspecced MSC which we can't turn off.

[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposal/invite_blocking/proposals/4380-invite-blocking.md)

Server implementation: https://github.com/element-hq/synapse/pull/19203
Client implementation: https://github.com/element-hq/element-web/pull/31268

---- 

SCT Stuff:

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4380#issuecomment-3603050579)

[MSC checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/4380#issuecomment-3549308609)
