### PR TITLE
MSC4383: Client-Server Discovery of Server Version

### DIFF
--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -4,8 +4,10 @@
 
 Client applications utilizing the Matrix SDK[^6], a Client-Server[^7] library, have been observed
 making requests to `GET /_matrix/federation/v1/version`[^2]. It is the only known example of a
-cross-interface request to have any possible[^5] use to any implementation[^3], motivating this
-proposal to reestablish a properly clean partition between client and federation interfaces.
+cross-interface request made by an implementation[^3]. The purpose is valid: informing logs
+used for crash reports of the server specifics; often essential for efficient triage and robust
+patching of client software. This proposal reestablises the proper partition between client and
+federation interfaces while retaining the value added by the de facto misuse.
 
 Such cross-interface requests are problematic: the partition in the `/_matrix` URL hierarchy is
 understood by site-administrators to allow for distinct middleware configurations. Sites commonly
@@ -83,9 +85,6 @@ proxy) will have to note their implementation's new exposure of it when upgradin
 [^3]: https://github.com/matrix-org/matrix-rust-sdk/blob/d228bde8ef51a98da10a6b7d4b9f3e5b8f49ad3c/crates/matrix-sdk/src/client/mod.rs#L581-L616
 
 [^4]: https://github.com/matrix-org/matrix-spec-proposals/pull/2301
-
-[^5]: Server version information can provide useful context in logs and may be essential for
-effective crash reports.
 
 [^6]: https://github.com/matrix-org/matrix-rust-sdk
 

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -1,0 +1,92 @@
+# MSC4383: Client-Server Discovery of Server Version
+
+### Motivation
+
+Client applications utilizing the Matrix SDK[^6], a Client-Server[^7] library, have been observed
+making requests to `GET /_matrix/federation/v1/version`[^2]. It is the only known example of a
+cross-interface request to have any possible[^5] use to any implementation[^3], motivating this
+proposal to reestablish a properly clean partition between client and federation interfaces.
+
+Such cross-interface requests are problematic: the partition in the `/_matrix` URL hierarchy is
+understood by site-administrators to allow for distinct middleware configurations. Sites commonly
+employ WAF rules covering the client and federation hierarchies with source and destination
+assumptions. Some sites disable the entire federation portion, rendering the status quo as unreliable.
+
+This proposal reestablishes the partition between client-server and server-server by simply offering
+the same version data over both. With the adoption of this proposal, no need for cross-interface
+requests will be known to remain.
+
+### Proposal
+
+An object is added to the top-level of `GET /_matrix/client/versions`[^1] named `server` with
+parity to the eponymous object returned by `GET /_matrix/federation/v1/version`[^2].
+
+Example of the `server` object:
+
+```
+  "server": {
+    "name": "My_Homeserver_Implementation",
+    "version": "ArbitraryVersionNumber"
+  }
+```
+
+Example of a full response:
+```
+{
+  "server": {
+    "name": "My_Homeserver_Implementation",
+    "version": "ArbitraryVersionNumber"
+  },
+  "unstable_features": {
+    "org.example.my_feature": true
+  },
+  "versions": [
+    "r0.0.1",
+    "v1.1"
+  ]
+}
+```
+
+##### Unstable prefix
+
+| Stable identifier | Purpose | Unstable identifier |
+| --- | --- | ---|
+| `server` | Server information | `net.zemos.msc4383.server` |
+
+### Alternatives
+
+MSC2301[^4] enriches the discovery information, including some identifying information about the
+server, though specific formal vendor and semantic version information appears avoided
+(see: potential issues).
+
+### Potential Issues
+
+Server vendor and version information has been considered counter-productive to the motivations
+of Matrix as a unifying communication standard. Matrix believes any use of implementation
+knowledge as a condition in its applications always represents an accidental failure of its
+implementations or the standard binding them; the solution to such problems is thus found in
+cooperation, community and conformity, precluding the need for bug-for-bug conditions and
+workarounds. This MSC has the option of including a normative statement which inhibits the use
+of vendor information to determine functionality.
+
+### Security Concerns
+
+The federation endpoint is the only location which presently reveals this information.
+Site-administrators which have taken some measure to hide, or obscure, or modify it (i.e. with a
+proxy) will have to note their implementation's new exposure of it when upgrading.
+
+
+[^1]: https://spec.matrix.org/v1.16/client-server-api/#api-versions
+
+[^2]: https://spec.matrix.org/v1.16/server-server-api/#server-implementation
+
+[^3]: https://github.com/matrix-org/matrix-rust-sdk/blob/d228bde8ef51a98da10a6b7d4b9f3e5b8f49ad3c/crates/matrix-sdk/src/client/mod.rs#L581-L616
+
+[^4]: https://github.com/matrix-org/matrix-spec-proposals/pull/2301
+
+[^5]: Server version information can provide useful context in logs and may be essential for
+effective crash reports.
+
+[^6]: https://github.com/matrix-org/matrix-rust-sdk
+
+[^7]: https://spec.matrix.org/v1.16/client-server-api/

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -63,6 +63,20 @@ Example of a full response:
 }
 ```
 
+A server that advertises `net.zemos.msc4383` in `unstable_features` (or,
+after acceptance, supports the stable identifier) MUST include the
+`server` object in responses to `GET /_matrix/client/versions`, and MUST
+populate at least the `name` and `version` fields. The two fields
+SHOULD carry the same values the server reports from
+`GET /_matrix/federation/v1/version`; an implementation that does not
+operate a federation endpoint MAY emit its own values.
+
+Clients MUST NOT use the contents of the `server` object to gate
+application logic. The object is intended for inclusion in diagnostic
+submissions and similar logging contexts; routing user-visible behaviour
+on server identity is contrary to Matrix's interoperability goal (see
+Potential Issues).
+
 The endpoint specification is otherwise unchanged.
 `GET /_matrix/client/versions`[^1] remains unauthenticated, is not
 rate-limited, and guest-access restrictions are not applicable. No new

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -49,6 +49,12 @@ Example of a full response:
 }
 ```
 
+The endpoint specification is otherwise unchanged.
+`GET /_matrix/client/versions`[^1] remains unauthenticated, is not
+rate-limited, and guest-access restrictions are not applicable. No new
+error responses are introduced; the field is purely additive on the
+existing response body.
+
 ##### Unstable prefix
 
 | Stable identifier | Purpose | Unstable identifier |

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -85,9 +85,11 @@ existing response body.
 
 ##### Unstable prefix
 
-| Stable identifier | Purpose | Unstable identifier |
-| --- | --- | ---|
-| `server` | Server information | `net.zemos.msc4383.server` |
+| Name | Stable identifier | Unstable identifier |
+| --- | --- | --- |
+| Server information field | `server` | `net.zemos.msc4383.server` |
+| Support advertisement (in `unstable_features`) | (none) | `net.zemos.msc4383` |
+| Stable-companion advertisement (in `unstable_features`) | (none) | `net.zemos.msc4383.stable` |
 
 ### Backwards Compatibility
 

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -21,8 +21,12 @@ understood by site administrators to permit distinct middleware configurations, 
 apply WAF rules to the client and federation hierarchies under differing source and destination
 assumptions. Some sites disable the federation portion entirely, rendering the status quo
 unreliable. Client applications utilising the Matrix SDK[^6], a client-server library, have been
-observed[^3] making this cross-interface request; it is the only known example of an implementation
-doing so.
+observed[^3] making this cross-interface request. element-web exhibits a related workaround in its
+rageshake collector[^11]: a primary call to the Synapse-specific administrative endpoint
+`GET /_synapse/admin/v1/server_version`, falling back to the same federation `/version` call when
+the administrative endpoint is unavailable. The administrative-endpoint path substitutes a
+vendor-specific dependency for the partition violation; neither workaround functions under
+deployments that restrict the corresponding interface.
 
 This proposal reestablishes the partition between the client-server and server-server interfaces
 by exposing the same version data over both. With its adoption, no need for cross-interface
@@ -151,3 +155,5 @@ proxy) will have to note their implementation's new exposure of it when upgradin
 [^9]: https://github.com/ruma/ruma/pull/2495
 
 [^10]: https://github.com/matrix-org/matrix-rust-sdk/pull/6622
+
+[^11]: https://github.com/element-hq/element-web/blob/220f68935e1700f3bd6e0786aac049bf6803badb/apps/web/src/rageshake/submit-rageshake.ts#L153-L189

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -61,6 +61,31 @@ existing response body.
 | --- | --- | ---|
 | `server` | Server information | `net.zemos.msc4383.server` |
 
+### Backwards Compatibility
+
+The `server` object is additive. Clients that do not recognise it
+ignore it per the existing client-server forward-compatibility rules.
+No existing field is renamed or removed, and the response shape on
+`GET /_matrix/client/versions`[^1] is otherwise unchanged.
+
+Implementations populating the field advertise `net.zemos.msc4383: true`
+in `unstable_features`, so clients can detect support without inspecting
+the object. Clients that have existing fallback paths to
+`GET /_matrix/federation/v1/version`[^2] may keep those paths conditional
+on the flag's absence; once servers in the deployment universe advertise
+the flag, the fallback may be retired.
+
+SDKs that already expose a method fetching this data from the federation
+endpoint can transparently prefer the client-server source under this
+proposal and retain the federation call as a fallback, so application
+consumers receive the partition correction without code change. The
+matrix-rust-sdk implementation (see Implementations) demonstrates this
+pattern: the existing `Client::server_vendor_info` API preserves its
+return-type contract while switching its primary source to
+`GET /_matrix/client/versions`, and applications consuming the FFI
+binding inherit the new behaviour on rebuild without an application-side
+opt-in.
+
 ### Alternatives
 
 MSC2301[^4] enriches the discovery information, including some identifying information about the

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -1,22 +1,32 @@
 # MSC4383: Client-Server Discovery of Server Version
 
-### Motivation
+### Introduction
 
-Client applications utilizing the Matrix SDK[^6], a Client-Server[^7] library, have been observed
-making requests to `GET /_matrix/federation/v1/version`[^2]. It is the only known example of a
-cross-interface request made by an implementation[^3]. The purpose is valid: informing logs
-used for crash reports of the server specifics; often essential for efficient triage and robust
-patching of client software. This proposal reestablises the proper partition between client and
-federation interfaces while retaining the value added by the de facto misuse.
+The Matrix client-server API does not advertise which homeserver implementation a client is
+connected to. In its absence, client applications have settled on querying the server-server
+endpoint `GET /_matrix/federation/v1/version`[^2] from the client side, where the homeserver
+identifies itself by name and version. The result is embedded in crash reports and diagnostic
+submissions so that defect triage can route a report to the appropriate implementation team. This
+proposal offers the same information over the client-server interface, allowing the cross-interface
+workaround to be retired.
 
-Such cross-interface requests are problematic: the partition in the `/_matrix` URL hierarchy is
-understood by site-administrators to allow for distinct middleware configurations. Sites commonly
-employ WAF rules covering the client and federation hierarchies with source and destination
-assumptions. Some sites disable the entire federation portion, rendering the status quo as unreliable.
+The observed use is logging only. The identification is included in rageshakes and similar
+diagnostic submissions so that recipients can recognise the server vendor and version; the field
+is not consulted to determine application behaviour. The query is to the user's own homeserver
+only; remote-server identification is out of scope, and a client has no general means to resolve
+a remote server name in any case.
 
-This proposal reestablishes the partition between client-server and server-server by simply offering
-the same version data over both. With the adoption of this proposal, no need for cross-interface
-requests will be known to remain.
+Cross-interface requests are problematic. The partition in the `/_matrix` URL hierarchy is
+understood by site administrators to permit distinct middleware configurations, and sites commonly
+apply WAF rules to the client and federation hierarchies under differing source and destination
+assumptions. Some sites disable the federation portion entirely, rendering the status quo
+unreliable. Client applications utilising the Matrix SDK[^6], a client-server library, have been
+observed[^3] making this cross-interface request; it is the only known example of an implementation
+doing so.
+
+This proposal reestablishes the partition between the client-server and server-server interfaces
+by exposing the same version data over both. With its adoption, no need for cross-interface
+requests is known to remain.
 
 ### Proposal
 

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -20,9 +20,9 @@ Cross-interface requests are problematic. The partition in the `/_matrix` URL hi
 understood by site administrators to permit distinct middleware configurations, and sites commonly
 apply WAF rules to the client and federation hierarchies under differing source and destination
 assumptions. Some sites disable the federation portion entirely, rendering the status quo
-unreliable. Client applications utilising the Matrix SDK[^6], a client-server library, have been
+unreliable. Client applications utilising the Matrix SDK[^5], a client-server library, have been
 observed[^3] making this cross-interface request. element-web exhibits a related workaround in its
-rageshake collector[^11]: a primary call to the Synapse-specific administrative endpoint
+rageshake collector[^9]: a primary call to the Synapse-specific administrative endpoint
 `GET /_synapse/admin/v1/server_version`, falling back to the same federation `/version` call when
 the administrative endpoint is unavailable. The administrative-endpoint path substitutes a
 vendor-specific dependency for the partition violation; neither workaround functions under
@@ -125,27 +125,25 @@ server, though specific formal vendor and semantic version information appears a
 ### Potential Issues
 
 Server vendor and version information has been considered counter-productive to the motivations
-of Matrix as a unifying communication standard. Matrix believes any use of implementation
+of Matrix as a unifying communication standard. Matrix considers that any use of implementation
 knowledge as a condition in its applications always represents an accidental failure of its
 implementations or the standard binding them; the solution to such problems is thus found in
-cooperation, community and conformity, precluding the need for bug-for-bug conditions and
-workarounds. This MSC has the option of including a normative statement which inhibits the use
-of vendor information to determine functionality.
+cooperation, community and conformity, precluding the need for bug-for-bug conditions and workarounds.
 
 ### Security Considerations
 
 The federation endpoint is the only location which presently reveals this information.
-Site-administrators which have taken some measure to hide, or obscure, or modify it (i.e. with a
+Site administrators which have taken some measure to hide, or obscure, or modify it (i.e. with a
 proxy) will have to note their implementation's new exposure of it when upgrading.
 
 ### Implementations
 
-- Server: Tuwunel[^8] (shipped in v1.6.2), populating the `server` object on
+- Server: Tuwunel[^6] (shipped in v1.6.2), populating the `server` object on
   `GET /_matrix/client/versions` and advertising `net.zemos.msc4383` in
   `unstable_features`.
-- Protocol types: a Ruma[^9] pull request adds the `Server` struct and the
+- Protocol types: a Ruma[^7] pull request adds the `Server` struct and the
   `Response.server` field behind the `unstable-msc4383` Cargo feature.
-- Client SDK: a matrix-rust-sdk[^10] pull request rewrites
+- Client SDK: a matrix-rust-sdk[^8] pull request rewrites
   `Client::server_vendor_info` to prefer the client-server source, falling
   back to `GET /_matrix/federation/v1/version` only when the object is
   absent. The feature is enabled by default in `matrix-sdk-ffi`, so
@@ -162,14 +160,13 @@ proxy) will have to note their implementation's new exposure of it when upgradin
 
 [^4]: https://github.com/matrix-org/matrix-spec-proposals/pull/2301
 
-[^6]: https://github.com/matrix-org/matrix-rust-sdk
+[^5]: https://github.com/matrix-org/matrix-rust-sdk
 
-[^7]: https://spec.matrix.org/v1.16/client-server-api/
+[^6]: https://github.com/matrix-construct/tuwunel
 
-[^8]: https://github.com/matrix-construct/tuwunel
+[^7]: https://github.com/ruma/ruma/pull/2495
 
-[^9]: https://github.com/ruma/ruma/pull/2495
+[^8]: https://github.com/matrix-org/matrix-rust-sdk/pull/6622
 
-[^10]: https://github.com/matrix-org/matrix-rust-sdk/pull/6622
-
-[^11]: https://github.com/element-hq/element-web/blob/220f68935e1700f3bd6e0786aac049bf6803badb/apps/web/src/rageshake/submit-rageshake.ts#L153-L189
+[^9]:
+    https://github.com/element-hq/element-web/blob/220f68935e1700f3bd6e0786aac049bf6803badb/apps/web/src/rageshake/submit-rageshake.ts#L153-L189

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -25,7 +25,7 @@ parity to the eponymous object returned by `GET /_matrix/federation/v1/version`[
 
 Example of the `server` object:
 
-```
+```json
   "server": {
     "name": "My_Homeserver_Implementation",
     "version": "ArbitraryVersionNumber"
@@ -33,7 +33,7 @@ Example of the `server` object:
 ```
 
 Example of a full response:
-```
+```json
 {
   "server": {
     "name": "My_Homeserver_Implementation",
@@ -71,7 +71,7 @@ cooperation, community and conformity, precluding the need for bug-for-bug condi
 workarounds. This MSC has the option of including a normative statement which inhibits the use
 of vendor information to determine functionality.
 
-### Security Concerns
+### Security Considerations
 
 The federation endpoint is the only location which presently reveals this information.
 Site-administrators which have taken some measure to hide, or obscure, or modify it (i.e. with a
@@ -82,7 +82,8 @@ proxy) will have to note their implementation's new exposure of it when upgradin
 
 [^2]: https://spec.matrix.org/v1.16/server-server-api/#server-implementation
 
-[^3]: https://github.com/matrix-org/matrix-rust-sdk/blob/d228bde8ef51a98da10a6b7d4b9f3e5b8f49ad3c/crates/matrix-sdk/src/client/mod.rs#L581-L616
+[^3]:
+    https://github.com/matrix-org/matrix-rust-sdk/blob/d228bde8ef51a98da10a6b7d4b9f3e5b8f49ad3c/crates/matrix-sdk/src/client/mod.rs#L581-L616
 
 [^4]: https://github.com/matrix-org/matrix-spec-proposals/pull/2301
 

--- a/proposals/4383-client-server-info.md
+++ b/proposals/4383-client-server-info.md
@@ -77,6 +77,20 @@ The federation endpoint is the only location which presently reveals this inform
 Site-administrators which have taken some measure to hide, or obscure, or modify it (i.e. with a
 proxy) will have to note their implementation's new exposure of it when upgrading.
 
+### Implementations
+
+- Server: Tuwunel[^8] (shipped in v1.6.2), populating the `server` object on
+  `GET /_matrix/client/versions` and advertising `net.zemos.msc4383` in
+  `unstable_features`.
+- Protocol types: a Ruma[^9] pull request adds the `Server` struct and the
+  `Response.server` field behind the `unstable-msc4383` Cargo feature.
+- Client SDK: a matrix-rust-sdk[^10] pull request rewrites
+  `Client::server_vendor_info` to prefer the client-server source, falling
+  back to `GET /_matrix/federation/v1/version` only when the object is
+  absent. The feature is enabled by default in `matrix-sdk-ffi`, so
+  applications consuming the FFI binding acquire the client-server path
+  on rebuild without an app-side flag.
+
 
 [^1]: https://spec.matrix.org/v1.16/client-server-api/#api-versions
 
@@ -90,3 +104,9 @@ proxy) will have to note their implementation's new exposure of it when upgradin
 [^6]: https://github.com/matrix-org/matrix-rust-sdk
 
 [^7]: https://spec.matrix.org/v1.16/client-server-api/
+
+[^8]: https://github.com/matrix-construct/tuwunel
+
+[^9]: https://github.com/ruma/ruma/pull/2495
+
+[^10]: https://github.com/matrix-org/matrix-rust-sdk/pull/6622


### PR DESCRIPTION
[rendered](https://github.com/matrix-construct/matrix-refreshed/blob/jevolk/client-server-info/proposals/4383-client-server-info.md)

## Implementations

- **Server**: [Tuwunel](https://github.com/matrix-construct/tuwunel) (shipped in v1.6.2), populating the `server` object on `GET /_matrix/client/versions` and advertising `net.zemos.msc4383` in `unstable_features`.
- **Protocol types**: [ruma/ruma#2495](https://github.com/ruma/ruma/pull/2495) adds the `Server` struct and the `Response.server` field behind the `unstable-msc4383` Cargo feature.
- **Client SDK**: [matrix-org/matrix-rust-sdk#6622](https://github.com/matrix-org/matrix-rust-sdk/pull/6622) rewrites `Client::server_vendor_info` to prefer the client-server source, falling back to `GET /_matrix/federation/v1/version` only when the object is absent. The feature is enabled by default in `matrix-sdk-ffi`, so applications consuming the FFI binding acquire the client-server path on rebuild without an app-side flag.

## Pre-acceptance checklist

- [x] Are appropriate implementation(s) specified in the MSC's PR description? (See above.)
- [x] Are all MSCs that this MSC depends on already accepted? (No dependencies.)
- [x] For each endpoint that is introduced or modified:
  - [x] Have authentication requirements been specified? (`GET /_matrix/client/versions` remains unauthenticated.)
  - [x] Have rate-limiting requirements been specified? (Not rate-limited.)
  - [x] Have guest access requirements been specified? (Guest-access restrictions are not applicable.)
  - [x] Are error responses specified? (No new error responses; the field is purely additive on the existing response body.)
    - [x] Does each error case have a specified `errcode` and HTTP status code? (N/A.)
      - [x] If a new `errcode` is introduced, is it clear that it is new? (N/A.)
- [x] Will the MSC require a new room version, and if so, has that been made clear? (No new room version.)
  - [x] Is the reason for a new room version clearly stated? (N/A.)
- [x] Are backwards-compatibility concerns appropriately addressed? (See §Backwards Compatibility: additive wire shape, `unstable_features` advertise gate, and SDK migration path preserving the existing `Client::server_vendor_info` contract.)
- [x] Are the endpoint conventions honoured?
  - [x] Do HTTP endpoints `use_underscores_like_this`? (Existing endpoint; convention preserved.)
  - [x] Will the endpoint return unbounded data? If so, has pagination been considered? (Fixed-shape object; pagination not applicable.)
  - [x] If the endpoint utilises pagination, is it consistent with the appendices? (N/A.)
- [x] An introduction exists and clearly outlines the problem being solved. (§Introduction.)
- [ ] All outstanding threads are resolved.
  - [x] All feedback is incorporated into the proposal text itself, either as a fix or noted as an alternative.
- [x] While the exact sections do not need to be present, the details implied by the proposal template are covered:
  - [x] Introduction
  - [x] Proposal text
  - [x] Potential issues
  - [x] Alternatives
  - [x] Dependencies (none; omitted)
- [x] Stable identifiers are used throughout the proposal, except for the unstable prefix section.
  - [x] Unstable prefixes consider the awkward accepted-but-not-merged state (`net.zemos.msc4383.stable` companion flag listed in §Unstable prefix).
  - [x] Chosen unstable prefixes do not pollute any global namespace (vendor prefix is the controlled reverse-DNS `net.zemos.*`).
- [x] Changes have applicable Sign Off from all authors/editors/contributors. Per-commit Signed-off-by on every new commit.
- [x] There is a dedicated "Security Considerations" section.
