### PR TITLE
MSC4409: Clarify thumbnailing behavior in E2EE

### DIFF
--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -1,0 +1,46 @@
+# MSC4409: Clarify thumbnailing behavior
+
+The purpose of this spec change is to clarify how clients should behave in regards to thumbnails in an E2EE world.
+
+Matrix clients capable of rendering media can choose to render the original source or a thumbnail representing it. For 
+example one would not want to render a full video player within a scrollable timeline view but would a thumbnail image,
+for performance reasons. The clients are still able to choose the original source if the situation warrants it e.g. animating
+GIFs.
+
+Historically homeservers would come to the clients' help by providing an [endpoint to do so](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid). 
+The [Thumbnails](https://spec.matrix.org/latest/client-server-api/#thumbnails) section of the Spec's client behavior 
+states that homeserver provided thumbnails are available for certain media formats, in a fixed number of resolutions and
+following rules like no upscaling and returning the original if the thumbnail is smaller than the original (for supported
+formats).
+
+With the advent of E2EE aware clients server support is no longer possible. Clients are instead expected to 
+upload their own thumbnail resources and attach them to newly introduced (at the time) `thumbnail_url`/`thumbnail_info` 
+fields on various events.
+
+The spec does not however clarify how the 2 should be handled in mixed encrypted and non-encrypted environments.
+
+## Proposal
+
+The proposal is to introduce new language in the [Thumbnails](https://spec.matrix.org/latest/client-server-api/#thumbnails)
+section that does address this as follows:
+
+E2EE aware clients are expected to provide thumbnail resources next to the original media they're uploading as close 
+in resolution to what the maximum backend endpoints would provide (800x600 at the time of writing).
+
+For image media smaller than that no thumbnail should be provided. Uploading clients can provide thumbnails larger than 
+800x600 for non-image media.
+
+Providing thumbnails should happen for both encrypted and non-encrypted rooms in order to provide maximum flexibility in 
+thumbnail choice, reduce backend strain and improve format compatibility.
+
+Rendering clients are expected to choose the thumbnail resources (if available) when rendering media previews.
+Calling the thumbnailing homeserver endpoint on a thumbnail resource is allowed, similar to any other resource, but will 
+return the original resource in encrypted rooms, where backend support isn't available.
+
+Client SDKs are encouraged to apply post network request processing to original thumbnails to have them fit 
+the final client's request size if necessary but that's an optimization left to the implementer.
+
+## Security concerns
+
+Malicious clients can of course upload thumbnails that do not represent the original content but that does not fall 
+under the umbrella of this MSC.

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -34,11 +34,13 @@ The sending client should provide thumbnails for both encrypted and non-encrypte
 flexibility in thumbnail choice, reduce backend strain and improve format compatibility.
 
 Rendering clients are expected to choose the thumbnail resources (if available) when rendering media previews.
-Calling the thumbnailing homeserver endpoint on a thumbnail resource is allowed, similar to any other resource, but will 
-return the original resource for encrypted media, where backend support isn't available.
+Calling the thumbnailing homeserver endpoint on an availlable encrypted thumbnail resource is allowed, similar to any 
+other resource, and will result in the original media, with backend support not being available to generate other 
+thumbnail variants.
 
-Client SDKs are encouraged to apply post network request processing to original thumbnails to have them fit 
-the final client's request size if necessary but that's an optimization left to the implementer.
+Client SDKs are encouraged to apply post download checks and processing to the thumbnails received from the homeserver as
+resolution limits cannot be enforced on encrypted media. The result should fit the caller requested size but that's 
+an optimization left to the implementer.
 
 ## Security concerns
 

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -7,8 +7,8 @@ example one would not want to render a full video player within a scrollable tim
 for performance reasons. The clients are still able to choose the original source if the situation warrants it e.g. animating
 GIFs.
 
-Historically homeservers would come to the clients' help by providing an [endpoint to do so](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid). 
-The [Thumbnails](https://spec.matrix.org/latest/client-server-api/#thumbnails) section of the Spec's client behavior 
+Historically homeservers would come to the clients' help by providing an [endpoint to do so](https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid). 
+The [Thumbnails](https://spec.matrix.org/v1.18/client-server-api/#thumbnails) section of the Spec's client behavior 
 states that homeserver provided thumbnails are available for certain media formats, in a fixed number of resolutions and
 following rules like no upscaling and returning the original if the thumbnail is smaller than the original (for supported
 formats).
@@ -21,7 +21,7 @@ The spec does not however clarify how the 2 should be handled in mixed encrypted
 
 ## Proposal
 
-The proposal is to introduce new language in the [Thumbnails](https://spec.matrix.org/latest/client-server-api/#thumbnails)
+The proposal is to introduce new language in the [Thumbnails](https://spec.matrix.org/v1.18/client-server-api/#thumbnails)
 section that does address this as follows:
 
 E2EE aware clients are expected to provide thumbnail resources next to the original media they're uploading as close 

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -34,7 +34,7 @@ The sending client should provide thumbnails for both encrypted and non-encrypte
 flexibility in thumbnail choice, reduce backend strain and improve format compatibility.
 
 Rendering clients are expected to choose the thumbnail resources (if available) when rendering media previews.
-Calling the thumbnailing homeserver endpoint on an availlable encrypted thumbnail resource is allowed, similar to any 
+Calling the thumbnailing homeserver endpoint on an available encrypted thumbnail resource is allowed, similar to any 
 other resource, and will result in the original media, with backend support not being available to generate other 
 thumbnail variants.
 

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -30,12 +30,12 @@ in resolution to what the maximum backend endpoints would provide (800x600 at th
 For image media smaller than that no thumbnail should be provided. Uploading clients can provide thumbnails larger than 
 800x600 for non-image media.
 
-The sending client should provide thumbnails for both encrypted and non-encrypted rooms in order to provide maximum 
+The sending client should provide thumbnails for both encrypted and non-encrypted media in order to provide maximum 
 flexibility in thumbnail choice, reduce backend strain and improve format compatibility.
 
 Rendering clients are expected to choose the thumbnail resources (if available) when rendering media previews.
 Calling the thumbnailing homeserver endpoint on a thumbnail resource is allowed, similar to any other resource, but will 
-return the original resource in encrypted rooms, where backend support isn't available.
+return the original resource for encrypted media, where backend support isn't available.
 
 Client SDKs are encouraged to apply post network request processing to original thumbnails to have them fit 
 the final client's request size if necessary but that's an optimization left to the implementer.

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -35,12 +35,10 @@ flexibility in thumbnail choice, reduce backend strain and improve format compat
 
 Rendering clients are expected to choose the thumbnail resources (if available) when rendering media previews.
 Calling the thumbnailing homeserver endpoint on an available encrypted thumbnail resource is allowed, similar to any 
-other resource, and will result in the original media, with backend support not being available to generate other 
-thumbnail variants.
+other resource, but will result in bad requests (400) as encrypted files cannot be thumbnailed.
 
-Client SDKs are encouraged to apply post download checks and processing to the thumbnails received from the homeserver as
-resolution limits cannot be enforced on encrypted media. The result should fit the caller requested size but that's 
-an optimization left to the implementer.
+Clients should not assume that images from thumbnail endpoints are the exact size requested, potentially downscaling on 
+the client if appropriate.
 
 ## Security concerns
 

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -17,7 +17,7 @@ With the advent of E2EE aware clients server support is no longer possible. Clie
 upload their own thumbnail resources and attach them to newly introduced (at the time) `thumbnail_url`/`thumbnail_info` 
 fields on various events.
 
-The spec does not however clarify how the 2 should be handled in mixed encrypted and non-encrypted environments.
+The spec does not however clarify how the two should be handled in mixed encrypted and non-encrypted environments.
 
 ## Proposal
 
@@ -30,8 +30,8 @@ in resolution to what the maximum backend endpoints would provide (800x600 at th
 For image media smaller than that no thumbnail should be provided. Uploading clients can provide thumbnails larger than 
 800x600 for non-image media.
 
-Providing thumbnails should happen for both encrypted and non-encrypted rooms in order to provide maximum flexibility in 
-thumbnail choice, reduce backend strain and improve format compatibility.
+The sending client should provide thumbnails for both encrypted and non-encrypted rooms in order to provide maximum 
+flexibility in thumbnail choice, reduce backend strain and improve format compatibility.
 
 Rendering clients are expected to choose the thumbnail resources (if available) when rendering media previews.
 Calling the thumbnailing homeserver endpoint on a thumbnail resource is allowed, similar to any other resource, but will 

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -24,7 +24,7 @@ The spec does not however clarify how the two should be handled in mixed encrypt
 The proposal is to introduce new language in the [Thumbnails](https://spec.matrix.org/v1.18/client-server-api/#thumbnails)
 section that does address this as follows:
 
-E2EE aware clients are expected to provide thumbnail resources next to the original media they're uploading as close 
+Clients are expected to provide thumbnail resources next to the original media they're uploading as close 
 in resolution to what the maximum backend endpoints would provide (800x600 at the time of writing).
 
 For image media smaller than that no thumbnail should be provided. Uploading clients can provide thumbnails larger than 

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -24,10 +24,10 @@ The spec does not however clarify how the two should be handled in mixed encrypt
 The proposal is to introduce new language in the [Thumbnails](https://spec.matrix.org/v1.18/client-server-api/#thumbnails)
 section that does address this as follows:
 
-Clients are expected to provide, next to the original media they're uploading, thumbnail images
-as close as possible in resolution to the maximum resolution the 
-[/thumbnail](https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid) endpoint 
-would provide (800x600 at the time of writing).
+Clients are expected provide, next to the original media they're uploading, a thumbnail image.
+Clients should use the maximum resolution among those 
+[recommended for server-side thumbnails](https://spec.matrix.org/v1.18/client-server-api/#thumbnails)
+(i.e. 800x600 at the time of writing) as the target thumbnail resolution).
 
 For image media smaller than that no thumbnail should be provided. Uploading clients can provide thumbnails larger than 
 800x600 for non-image media.

--- a/proposals/4409-carify-thumbnailing.md
+++ b/proposals/4409-carify-thumbnailing.md
@@ -24,8 +24,10 @@ The spec does not however clarify how the two should be handled in mixed encrypt
 The proposal is to introduce new language in the [Thumbnails](https://spec.matrix.org/v1.18/client-server-api/#thumbnails)
 section that does address this as follows:
 
-Clients are expected to provide thumbnail resources next to the original media they're uploading as close 
-in resolution to what the maximum backend endpoints would provide (800x600 at the time of writing).
+Clients are expected to provide, next to the original media they're uploading, thumbnail images
+as close as possible in resolution to the maximum resolution the 
+[/thumbnail](https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid) endpoint 
+would provide (800x600 at the time of writing).
 
 For image media smaller than that no thumbnail should be provided. Uploading clients can provide thumbnails larger than 
 800x600 for non-image media.


### PR DESCRIPTION
This spec change proposal aims to clarify how clients should behave in regards to thumbnails in an E2EE world, or at least start a conversation around it that will eventually lead to clarifications.

This stemmed from recent internal discussions around expected behaviors for thumbnails of thumbnails and how that should be applied for local echoes.

[Rendered](https://github.com/stefanceriu/matrix-spec-proposals/blob/main/proposals/4409-carify-thumbnailing.md)

Implementation

EX iOS:
- Video thumbnail generation - https://github.com/element-hq/element-x-ios/blob/cf79cb9b013311f37911b9ed195ae75ab381f67d/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift#L398
- Image thumbnail generation - https://github.com/element-hq/element-x-ios/blob/cf79cb9b013311f37911b9ed195ae75ab381f67d/ElementX/Sources/Services/Media/MediaUploadingPreprocessor.swift#L342C18-L342C43
- Timeline view handling - https://github.com/element-hq/element-x-ios/blob/cf79cb9b013311f37911b9ed195ae75ab381f67d/ElementX/Sources/Screens/Timeline/View/TimelineItemViews/ImageRoomTimelineView.swift#L45-L65
- Actual loading - https://github.com/element-hq/element-x-ios/blob/cf79cb9b013311f37911b9ed195ae75ab381f67d/ElementX/Sources/Services/Media/Provider/MediaProvider.swift#L50-L54

RustSDK 
- Local echos - https://github.com/matrix-org/matrix-rust-sdk/blob/3be8726afb4a8cfd41899c7569f579e2509ca673/crates/matrix-sdk/src/send_queue/upload.rs#L607

---

SCT Stuff:

[MSC checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/4409#issuecomment-4500596132)

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4409#issuecomment-4500599232)

No designated reviewers assigned due to MSC size and scope.