### PR TITLE
MSC4415: Make `/_matrix/client/v3/admin/whois/{userId}` only available to admins

### DIFF
--- a/proposals/4415-whois-admin-only.md
+++ b/proposals/4415-whois-admin-only.md
@@ -1,4 +1,4 @@
-# MSC1337: Make `/_matrix/client/v3/admin/whois/{userId}` only available to admins
+# MSC4415: Make `/_matrix/client/v3/admin/whois/{userId}` only available to admins
 
 Currently, the `/_matrix/client/v3/admin/whois/{userId}` is available to non-admins
 if the requesting user is also the target user. This makes it nonfunctional as an


### PR DESCRIPTION
[Rendered](https://github.com/velikopter/matrix-spec-proposals/blob/whois-admin-only/proposals/4415-whois-admin-only.md)

Signed-off-by: Kierre Sametti <vel@riseup.net>