### PR TITLE
MSC4418: Make `destination` a required server authentication field

### DIFF
--- a/proposals/4418-require-destination.md
+++ b/proposals/4418-require-destination.md
@@ -1,0 +1,31 @@
+# MSC4418: Make `destination` a required server authentication field
+
+Currently the server to server authentication scheme allows `destination` to be optional for
+backwards-compatibility, however most homeserver implementations today no longer permit this.
+It additionally makes vHosting more difficult to implement and utilize.
+
+## Proposal
+
+Require `destination` for authenticated federation requests.
+
+## Potential issues
+
+Older homeservers may be unable to federate with servers that implement this MSC,
+however all major implementations have caught up by now, and any older Synapse
+versions that don't send the field are likely riddled with security holes.
+
+## Alternatives
+
+None?
+
+## Security considerations
+
+None.
+
+## Unstable prefix
+
+None.
+
+## Dependencies
+
+None.

--- a/proposals/4418-require-destination.md
+++ b/proposals/4418-require-destination.md
@@ -6,7 +6,8 @@ It additionally makes vHosting more difficult to implement and utilize.
 
 ## Proposal
 
-Require `destination` for authenticated federation requests.
+Require `destination` for
+[authenticated federation requests](https://spec.matrix.org/v1.17/server-server-api/#request-authentication).
 
 ## Potential issues
 

--- a/proposals/4418-require-destination.md
+++ b/proposals/4418-require-destination.md
@@ -11,8 +11,9 @@ Require `destination` for
 
 ## Potential issues
 
-Older homeservers may be unable to federate with servers that implement this MSC,
-however all major implementations have caught up by now:
+Older homeservers which do not send the field may be unable to federate
+with servers that implement this MSC, however all major implementations
+have caught up by now:
 
 - Continuwuity:
   [read](https://forgejo.ellis.link/continuwuation/continuwuity/src/commit/8d66500c991202f464785d34f3cfa31a1c831997/src/api/router/auth.rs#L327-L329),

--- a/proposals/4418-require-destination.md
+++ b/proposals/4418-require-destination.md
@@ -25,7 +25,7 @@ however all major implementations have caught up by now:
   [write](https://github.com/matrix-construct/tuwunel/blob/da3e7539f4753e8c681c8f0ade447dfab201f408/src/service/federation/execute.rs#L280)
 - Conduit:
   [read](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/ruma_wrapper/axum.rs#L198),
-  [write](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/server_server.rs#L125)
+  [write](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/server_server.rs#L282)
 - gomatrixserverlib (Dendrite):
   [read](https://github.com/matrix-org/gomatrixserverlib/blob/6c4c6f7d0d301cef23e84d237b27d9e9ff4562d7/fclient/request.go#L216),
   [write](https://github.com/matrix-org/gomatrixserverlib/blob/6c4c6f7d0d301cef23e84d237b27d9e9ff4562d7/fclient/request.go#L158)

--- a/proposals/4418-require-destination.md
+++ b/proposals/4418-require-destination.md
@@ -26,9 +26,6 @@ however all major implementations have caught up by now:
 - Conduit:
   [read](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/ruma_wrapper/axum.rs#L198),
   [write](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/server_server.rs#L125)
-- Conduit:
-  [read](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/ruma_wrapper/axum.rs#L198),
-  [write](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/server_server.rs#L125)
 - gomatrixserverlib (Dendrite):
   [read](https://github.com/matrix-org/gomatrixserverlib/blob/6c4c6f7d0d301cef23e84d237b27d9e9ff4562d7/fclient/request.go#L216),
   [write](https://github.com/matrix-org/gomatrixserverlib/blob/6c4c6f7d0d301cef23e84d237b27d9e9ff4562d7/fclient/request.go#L158)

--- a/proposals/4418-require-destination.md
+++ b/proposals/4418-require-destination.md
@@ -12,8 +12,26 @@ Require `destination` for
 ## Potential issues
 
 Older homeservers may be unable to federate with servers that implement this MSC,
-however all major implementations have caught up by now, and any older Synapse
-versions that don't send the field are likely riddled with security holes.
+however all major implementations have caught up by now:
+
+- Continuwuity:
+  [read](https://forgejo.ellis.link/continuwuation/continuwuity/src/commit/8d66500c991202f464785d34f3cfa31a1c831997/src/api/router/auth.rs#L327-L329),
+  [write](https://forgejo.ellis.link/continuwuation/continuwuity/src/commit/754959e80d4865cfcfd9c0de10ab9391b11bac39/src/service/federation/execute.rs#L251)
+- Synapse:
+  [read](https://github.com/element-hq/synapse/blob/7e4588ac4f2d18bab150a2c1a123ecb22e535534/synapse/federation/transport/server/_base.py#L111-L118),
+  [write](https://github.com/element-hq/synapse/blob/df24e0f30244b1c423f4130d64c6008be341d0b7/synapse/http/matrixfederationclient.py#L956)
+- Tuwunel:
+  [read](https://github.com/matrix-construct/tuwunel/blob/da3e7539f4753e8c681c8f0ade447dfab201f408/src/api/router/auth/server.rs#L99-L101),
+  [write](https://github.com/matrix-construct/tuwunel/blob/da3e7539f4753e8c681c8f0ade447dfab201f408/src/service/federation/execute.rs#L280)
+- Conduit:
+  [read](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/ruma_wrapper/axum.rs#L198),
+  [write](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/server_server.rs#L125)
+- Conduit:
+  [read](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/ruma_wrapper/axum.rs#L198),
+  [write](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/server_server.rs#L125)
+- gomatrixserverlib (Dendrite):
+  [read](https://github.com/matrix-org/gomatrixserverlib/blob/6c4c6f7d0d301cef23e84d237b27d9e9ff4562d7/fclient/request.go#L216),
+  [write](https://github.com/matrix-org/gomatrixserverlib/blob/6c4c6f7d0d301cef23e84d237b27d9e9ff4562d7/fclient/request.go#L158)
 
 ## Alternatives
 


### PR DESCRIPTION
[Rendered](https://github.com/velikopter/matrix-spec-proposals/blob/require-destination/proposals/4418-require-destination.md)

Implementations requiring value:
 - [Continuwuity](https://forgejo.ellis.link/continuwuation/continuwuity/src/commit/8d66500c991202f464785d34f3cfa31a1c831997/src/api/router/auth.rs#L327-L329)
 - [Tuwunel](https://github.com/matrix-construct/tuwunel/blob/6c91aa1ddcfc2c25202dc9a1700ee7d11305fd6a/src/api/router/auth/server.rs#L99-L101)

Implementations permitting optional value:
 - [Conduit](https://gitlab.com/famedly/conduit/-/blob/8def22bfb8b9b23bbd47e17772f2bd80500eacf6/src/api/ruma_wrapper/axum.rs#L198)
 - [gomatrixserverlib](https://github.com/matrix-org/gomatrixserverlib/blob/20c9de33969e2df883eaa69c283d6a38efce9284/fclient/request.go#L309)
 - [Synapse](https://github.com/element-hq/synapse/blob/7e4588ac4f2d18bab150a2c1a123ecb22e535534/synapse/federation/transport/server/_base.py#L111-L118)
 - [Vona](https://foundry.fsky.io/vel/matrix-vona/src/commit/b413e4b05ba3260c0fc5426d3cac8a4cab1f2f5c/vona/__main__.py#L94)

Signed-off-by: Helix K <vel@riseup.net>


----

SCT Stuff

[MSC checklist](https://github.com/matrix-org/matrix-spec-proposals/pull/4418#issuecomment-4114144588)

[FCP tickyboxes](https://github.com/matrix-org/matrix-spec-proposals/pull/4418#issuecomment-4367206614)