### PR TITLE
Fix `height` definition on MSC2545: Image Packs

### DIFF
--- a/proposals/2545-emotes.md
+++ b/proposals/2545-emotes.md
@@ -136,10 +136,10 @@ An example of a pack object:
 An image object consists of the following keys:
 
 - `url`: **Required, String**. The MXC URL for this image.
-- `body`: **Optional, String**. A textual representation or associated 
+- `body`: **Optional, String**. A textual representation or associated
     description of the image.
 - `info`: **Optional, ImageInfo**. The already specified
-    [`ImageInfo`](https://spec.matrix.org/v1.18/client-server-api/#msticker_imageinfo) 
+    [`ImageInfo`](https://spec.matrix.org/v1.18/client-server-api/#msticker_imageinfo)
     object (from `m.sticker`).
 
 An example of an image object:
@@ -393,7 +393,7 @@ their own messages.
 The `height` attribute MUST be present. This maintains backwards-compatibility
 with clients that do not support custom emotes.
 
-Clents SHOULD set `height` to "32px". This is a default intended to look good on
+Clents SHOULD set `height` to "32" (pixels). This is a default intended to look good on
 most devices, and is for the benefit of legacy clients that do not treat custom
 emotes differently from other inline images.
 
@@ -567,7 +567,7 @@ tangentially touch custom emotes. Each warrant an MSC for themselves.
 - For stickers: Recommend rendering sizes / resolutions
 - Loading placeholders for emotes and stickers (i.e. via blurhashes
     [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448) or
-    vector paths) 
+    vector paths)
 
 ## Dependencies
 


### PR DESCRIPTION
Also remove stray whitespace my editor didn't like.

The [`img` height](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/height) is an *integer*, not a CSS-style string, so must be a value like `32`. This matches the examples throughout the proposal. 

Some implementations do send `height="32px"` as the MSC recommended, however this is incorrect behaviour and may lead to clients/browsers ignoring the `height` attribute entirely. Clients which are sending this invalid value SHOULD NOT continue doing so, and instead SHOULD use `"32"` instead. 

**Process note**: I've added a warning to https://github.com/matrix-org/matrix-spec-proposals/pull/2545 to highlight that this PR changes it a bit.