### PR TITLE
Stop linking to MSC2324 in the proposal template

### DIFF
--- a/proposals/0000-proposal-template.md
+++ b/proposals/0000-proposal-template.md
@@ -102,15 +102,17 @@ do not consider vulnerabilities with their design, we rely on reviewers to consi
 is easy to forget, so having a mandatory 'Security Considerations' section serves to nudge reviewers
 into thinking like an attacker.
 
+
 ## Unstable prefix
 
 *If a proposal is implemented before it is included in the spec, then implementers must ensure that the
 implementation is compatible with the final version that lands in the spec. This generally means that
 experimental implementations should use `/unstable` endpoints, and use vendor prefixes where necessary.
-For more information, see [MSC2324](https://github.com/matrix-org/matrix-doc/pull/2324). This section
+For more information, see https://spec.matrix.org/proposals/#early-release-of-an-mscidea. This section
 should be used to document things such as what endpoints and names are being used while the feature is
 in development, the name of the unstable feature flag to use to detect support for the feature, or what
 migration steps are needed to switch to newer versions of the proposal.*
+
 
 ## Dependencies
 


### PR DESCRIPTION
#2324 was merged into the spec with https://github.com/matrix-org/matrix-spec-proposals/pull/2433. I think we should link to the official spec text rather than the MSC now.

Blank lines added in the diff are for parity with the double blank lines used between sections in the rest of the template.