### PR TITLE
MSC4505: Push Rules for Live Location Sharing

### DIFF
--- a/proposals/4505-lls-push-rules.md
+++ b/proposals/4505-lls-push-rules.md
@@ -86,7 +86,7 @@ de-duplicate notifications for a beacon they already know about.
 As with [MSC3930](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3930-polls-notifications.md),
 these rules are a stop-gap of the current push rules system rather than a step
 towards a general solution for extensible events, and future work on notifications for extensible
-events would supercede them.
+events would supersede them.
 
 ## Alternatives
 

--- a/proposals/4505-lls-push-rules.md
+++ b/proposals/4505-lls-push-rules.md
@@ -1,4 +1,4 @@
-# MSCXXXX: Push rules for live location sharing
+# MSC4505: Push rules for live location sharing
 
 [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489) and
 [MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672) describe live location
@@ -108,9 +108,9 @@ matching the unstable event types from the
 
 | Stable | Unstable |
 |---|---|
-| `.m.rule.beacon_info_one_to_one` | `.io.element.rule.beacon_info_one_to_one` |
-| `.m.rule.beacon_info` | `.io.element.rule.beacon_info` |
-| `.m.rule.beacon` | `.io.element.rule.beacon` |
+| `.m.rule.beacon_info_one_to_one` | `.org.matrix.msc4505.rule.beacon_info_one_to_one` |
+| `.m.rule.beacon_info` | `.org.matrix.msc4505.rule.beacon_info` |
+| `.m.rule.beacon` | `.org.matrix.msc4505.rule.beacon` |
 | `m.beacon_info` (in conditions) | `org.matrix.msc3672.beacon_info` |
 | `m.beacon` (in conditions) | `org.matrix.msc3672.beacon` |
 

--- a/proposals/xxxx-beacon-push-rules.md
+++ b/proposals/xxxx-beacon-push-rules.md
@@ -2,33 +2,24 @@
 
 [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489) and
 [MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672) describe live location
-sharing: a user starts a share by sending an `m.beacon_info` state event (`state_key` = their user
-ID, `content.live: true`), streams location updates as `m.beacon` timeline events referencing it,
-and stops the share by re-sending the `m.beacon_info` state event with `content.live: false`.
+sharing (LLS).  A user starts a share by sending an `m.beacon_info` state event (with their user id as the
+`state_key`, setting `content.live: true`), streams location updates as `m.beacon` timeline events
+referencing it, and stops the share by updating the state event to `content.live: false`.
 
-Neither proposal defines how push notifications work for these events. Because starting a share is
-a state event, no default push rule matches it (the `.m.rule.message` and `.m.rule.encrypted`
-underrides match only `m.room.message` and `m.room.encrypted` respectively, and there is no
-catch-all), so today a homeserver sends **no push at all** when someone starts sharing their live
-location — recipients whose clients are backgrounded or offline never learn about a share that may
-be safety-relevant ("I'm on my way, follow along"). This proposal fills that gap, exactly as
+Neither proposal defines how push notifications work for these events: as starting a share is
+a state event, no default push rule matches it, meaning users have no way of being told when
+someone is trying to share their location with them.
+
+This proposal fills that gap, much as
 [MSC3930](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3930-polls-notifications.md)
 did for polls.
 
-Note that this works identically in encrypted rooms: state events are not encrypted, so
-`m.beacon_info` is visible to server-side push rule evaluation even when the room is end-to-end
-encrypted.
-
 ## Proposal
 
-Starting a live location share should notify like a message. We define the following underride
-push rules, mirroring their `m.room.message` partners. As with
-[MSC3930](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3930-polls-notifications.md),
-they are to be inserted immediately after the `.m.rule.poll_end` underride rule, in the order
-presented.
-
-The `content.live` condition restricts the rules to share **starts**: stopping a share re-sends
-the same state event with `live: false` and must not notify.
+We define the following underride push rules, following the same pattern as 
+[MSC3930](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3930-polls-notifications.md).
+The rules are to be inserted immediately after the `.m.rule.poll_end` underride rule, in the order
+presented.  We only push for LLS beginning (`content.live: true`), not stopping (`content.live: false`).
 
 ```jsonc
 {
@@ -54,7 +45,6 @@ the same state event with `live: false` and must not notify.
   "default": true,
   "enabled": true,
   "conditions": [
-    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
     {"kind": "event_property_is", "key": "type", "value": "m\\.beacon_info"},
     {"kind": "event_property_is", "key": "content.live", "value": true}
   ],
@@ -64,9 +54,9 @@ the same state event with `live: false` and must not notify.
 }
 ```
 
-Additionally, a new override rule is defined to explicitly suppress the `m.beacon` location update
-events, inserted immediately after the `.m.rule.poll_response` override rule. A share streams many
-updates (typically one every few seconds); notifying for each would be unusable.
+Additionally, for unencrypted rooms, a new override rule is defined to explicitly suppress the `m.beacon`
+location update events, inserted immediately after the `.m.rule.poll_response` override rule. 
+This stops sending needless push for every LLS beacon update.
 
 ```jsonc
 {
@@ -74,19 +64,11 @@ updates (typically one every few seconds); notifying for each would be unusable.
   "default": true,
   "enabled": true,
   "conditions": [
-    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
     {"kind": "event_property_is", "key": "type", "value": "m\\.beacon"}
   ],
   "actions": []
 }
 ```
-
-*Note*: lack of `actions` means "don't do anything with matching events" / "don't notify".
-
-For the purposes of
-[MSC3932](https://github.com/matrix-org/matrix-spec-proposals/pull/3932), the push rules defined
-in this proposal are not affected by room version limitations, for the same reasons as MSC3930's
-rules: live location sharing is not inherently room version-specific.
 
 ## Potential issues
 
@@ -101,9 +83,10 @@ Re-sending `m.beacon_info` with `live: true` (e.g. extending a share's timeout) 
 This is arguably correct ("X is (still) sharing their live location"); clients may wish to
 de-duplicate notifications for a beacon they already know about.
 
-As with MSC3930, these rules are a stop-gap of the current push rules system rather than a step
+As with [MSC3930](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3930-polls-notifications.md),
+these rules are a stop-gap of the current push rules system rather than a step
 towards a general solution for extensible events, and future work on notifications for extensible
-events would supersede them.
+events would supercede them.
 
 ## Alternatives
 
@@ -134,7 +117,4 @@ matching the unstable event types from the
 ## Dependencies
 
 This MSC builds on [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489) and
-[MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672) (which at the time of
-writing have not yet been accepted into the spec) and uses the `event_property_is` push rule
-condition from [MSC3758](https://github.com/matrix-org/matrix-spec-proposals/pull/3758) (accepted;
-Matrix v1.7).
+[MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672)

--- a/proposals/xxxx-beacon-push-rules.md
+++ b/proposals/xxxx-beacon-push-rules.md
@@ -1,0 +1,140 @@
+# MSCXXXX: Push rules for live location sharing
+
+[MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489) and
+[MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672) describe live location
+sharing: a user starts a share by sending an `m.beacon_info` state event (`state_key` = their user
+ID, `content.live: true`), streams location updates as `m.beacon` timeline events referencing it,
+and stops the share by re-sending the `m.beacon_info` state event with `content.live: false`.
+
+Neither proposal defines how push notifications work for these events. Because starting a share is
+a state event, no default push rule matches it (the `.m.rule.message` and `.m.rule.encrypted`
+underrides match only `m.room.message` and `m.room.encrypted` respectively, and there is no
+catch-all), so today a homeserver sends **no push at all** when someone starts sharing their live
+location — recipients whose clients are backgrounded or offline never learn about a share that may
+be safety-relevant ("I'm on my way, follow along"). This proposal fills that gap, exactly as
+[MSC3930](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3930-polls-notifications.md)
+did for polls.
+
+Note that this works identically in encrypted rooms: state events are not encrypted, so
+`m.beacon_info` is visible to server-side push rule evaluation even when the room is end-to-end
+encrypted.
+
+## Proposal
+
+Starting a live location share should notify like a message. We define the following underride
+push rules, mirroring their `m.room.message` partners. As with
+[MSC3930](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3930-polls-notifications.md),
+they are to be inserted immediately after the `.m.rule.poll_end` underride rule, in the order
+presented.
+
+The `content.live` condition restricts the rules to share **starts**: stopping a share re-sends
+the same state event with `live: false` and must not notify.
+
+```jsonc
+{
+  "rule_id": ".m.rule.beacon_info_one_to_one",
+  "default": true,
+  "enabled": true,
+  "conditions": [
+    {"kind": "room_member_count", "is": "2"},
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "value": "m\\.beacon_info"},
+    {"kind": "event_property_is", "key": "content.live", "value": true}
+  ],
+  "actions": [
+    "notify",
+    {"set_tweak": "sound", "value": "default"}
+  ]
+}
+```
+
+```jsonc
+{
+  "rule_id": ".m.rule.beacon_info",
+  "default": true,
+  "enabled": true,
+  "conditions": [
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "value": "m\\.beacon_info"},
+    {"kind": "event_property_is", "key": "content.live", "value": true}
+  ],
+  "actions": [
+    "notify"
+  ]
+}
+```
+
+Additionally, a new override rule is defined to explicitly suppress the `m.beacon` location update
+events, inserted immediately after the `.m.rule.poll_response` override rule. A share streams many
+updates (typically one every few seconds); notifying for each would be unusable.
+
+```jsonc
+{
+  "rule_id": ".m.rule.beacon",
+  "default": true,
+  "enabled": true,
+  "conditions": [
+    // Note: `.` is escaped once, but for valid JSON we need to escape the escape.
+    {"kind": "event_property_is", "key": "type", "value": "m\\.beacon"}
+  ],
+  "actions": []
+}
+```
+
+*Note*: lack of `actions` means "don't do anything with matching events" / "don't notify".
+
+For the purposes of
+[MSC3932](https://github.com/matrix-org/matrix-spec-proposals/pull/3932), the push rules defined
+in this proposal are not affected by room version limitations, for the same reasons as MSC3930's
+rules: live location sharing is not inherently room version-specific.
+
+## Potential issues
+
+The `.m.rule.beacon` suppression cannot take effect in encrypted rooms, where location updates are
+sent as `m.room.encrypted` events and therefore match the `.m.rule.encrypted` underride on the
+server. Clients which re-evaluate push rules against the decrypted event (as the major
+implementations do) will suppress the notification via `.m.rule.beacon` at that point; the cost of
+the spurious push wakeups themselves is a pre-existing problem for all encrypted event types that
+are uninteresting once decrypted, and is out of scope here.
+
+Re-sending `m.beacon_info` with `live: true` (e.g. extending a share's timeout) will notify again.
+This is arguably correct ("X is (still) sharing their live location"); clients may wish to
+de-duplicate notifications for a beacon they already know about.
+
+As with MSC3930, these rules are a stop-gap of the current push rules system rather than a step
+towards a general solution for extensible events, and future work on notifications for extensible
+events would supersede them.
+
+## Alternatives
+
+A client-managed custom push rule (any client of the recipient inserts an equivalent user-scoped
+rule via the push rules API) would work without server changes, but requires every client
+implementation to manage the rule's lifecycle and leaves users of clients which haven't done so
+without notifications. Default server-side rules match how every other notifying event type works.
+
+## Security considerations
+
+None beyond those of MSC3489/MSC3672 themselves. The rules do not expose event content; they only
+cause pushes for an event type that room members receive anyway.
+
+## Unstable prefix
+
+While this MSC is not considered stable, implementations should use the following identifiers,
+matching the unstable event types from the
+[unstable prefix section of MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672):
+
+| Stable | Unstable |
+|---|---|
+| `.m.rule.beacon_info_one_to_one` | `.io.element.rule.beacon_info_one_to_one` |
+| `.m.rule.beacon_info` | `.io.element.rule.beacon_info` |
+| `.m.rule.beacon` | `.io.element.rule.beacon` |
+| `m.beacon_info` (in conditions) | `org.matrix.msc3672.beacon_info` |
+| `m.beacon` (in conditions) | `org.matrix.msc3672.beacon` |
+
+## Dependencies
+
+This MSC builds on [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489) and
+[MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672) (which at the time of
+writing have not yet been accepted into the spec) and uses the `event_property_is` push rule
+condition from [MSC3758](https://github.com/matrix-org/matrix-spec-proposals/pull/3758) (accepted;
+Matrix v1.7).


### PR DESCRIPTION
[Rendered](https://github.com/matrix-org/matrix-spec-proposals/blob/matthew/beacon-push-rules/proposals/4505-lls-push-rules.md)

Written with Matrix SCT lead hat on.

(implementations moved to thread: https://github.com/matrix-org/matrix-spec-proposals/pull/4505/changes#r3580285710 )